### PR TITLE
the equals method from TECPublicKeyParameters was not called because …

### DIFF
--- a/CryptoLib/src/Crypto/ClpAsymmetricKeyParameter.pas
+++ b/CryptoLib/src/Crypto/ClpAsymmetricKeyParameter.pas
@@ -42,7 +42,7 @@ type
   public
     property IsPrivate: Boolean read GetIsPrivate;
     property privateKey: Boolean read GetPrivateKey;
-    function Equals(const other: IAsymmetricKeyParameter): Boolean; reintroduce;
+    function Equals(const other: IAsymmetricKeyParameter): Boolean; reintroduce; virtual;
     function GetHashCode(): {$IFDEF DELPHI}Int32; {$ELSE}PtrInt;
 {$ENDIF DELPHI}override;
 

--- a/CryptoLib/src/Interfaces/ClpIECPublicKeyParameters.pas
+++ b/CryptoLib/src/Interfaces/ClpIECPublicKeyParameters.pas
@@ -33,6 +33,8 @@ type
     function GetQ: IECPoint;
 
     property Q: IECPoint read GetQ;
+
+    function Equals(const other: IECPublicKeyParameters): Boolean; reintroduce; overload;
   end;
 
 implementation


### PR DESCRIPTION
…it was not declared in the interface