### PR TITLE
feat: Customizable digests for Edwards curves (Ed25519/Ed448) via subclassing

### DIFF
--- a/CryptoLib.Tests/src/Math/EC/Rfc8032/Ed25519Tests.pas
+++ b/CryptoLib.Tests/src/Math/EC/Rfc8032/Ed25519Tests.pas
@@ -32,6 +32,7 @@ uses
   TestFramework,
 {$ENDIF FPC}
   ClpIDigest,
+  ClpDigestUtilities,
   ClpEd25519,
   ClpSecureRandom,
   ClpISecureRandom,
@@ -45,8 +46,11 @@ type
   var
     FRandom: ISecureRandom;
     FEd25519: TEd25519;
+    FEd25519Blake2b: TEd25519;
 
+    procedure ImplCheckEd25519Vector(AEd25519: TEd25519; const ASK, APK, AM, ASig, AText: String);
     procedure CheckEd25519Vector(const ASK, APK, AM, ASig, AText: String);
+    procedure CheckEd25519VectorBlake2b(const ASK, APK, AM, ASig, AText: String);
     procedure CheckEd25519ctxVector(const ASK, APK, AM, ACTX, ASig, AText: String);
     procedure CheckEd25519phVector(const ASK, APK, AM, ACTX, ASig, AText: String);
     procedure ImplTamingVector(ANumber: Int32; AExpected: Boolean; const AMsgHex, APubHex, ASigHex: String); overload;
@@ -56,6 +60,7 @@ type
     procedure TearDown; override;
   published
     procedure TestEd25519Consistency();
+    procedure TestEd25519ConsistencyDefaultMatchesSHA512Digest();
     procedure TestEd25519ctxConsistency();
     procedure TestEd25519phConsistency();
     procedure TestEd25519Vector1();
@@ -69,6 +74,17 @@ type
     procedure TestEd25519ctxVector3();
     procedure TestEd25519ctxVector4();
     procedure TestEd25519phVector1();
+
+    procedure TestEd25519WithCustomDigestSHA512Vector1();
+    procedure TestEd25519WithCustomDigestSHA512Vector2();
+    procedure TestEd25519WithCustomDigestSHA512Vector3();
+    procedure TestEd25519WithCustomDigestSHA512Vector4();
+    procedure TestEd25519WithCustomDigestSHA512Vector5();
+    procedure TestEd25519WithCustomDigestBlake2bVector1();
+    procedure TestEd25519WithCustomDigestBlake2bVector2();
+    procedure TestEd25519WithCustomDigestBlake2bVector3();
+    procedure TestEd25519WithCustomDigestBlake2bVector4();
+    procedure TestEd25519WithCustomDigestBlake2bVector5();
 
     procedure TestPublicKeyValidationFull();
     procedure TestPublicKeyValidationPartial();
@@ -89,9 +105,34 @@ type
 
 implementation
 
+type
+  TEd25519Blake2b = class(TEd25519)
+  strict protected
+    function CreateDigest(): IDigest; override;
+  end;
+
+  TEd25519Sha512 = class(TEd25519)
+  strict protected
+    function CreateDigest(): IDigest; override;
+  end;
+
+{ TEd25519Blake2b }
+
+function TEd25519Blake2b.CreateDigest(): IDigest;
+begin
+  Result := TDigestUtilities.GetDigest('BLAKE2B-512');
+end;
+
+{ TEd25519Sha512 }
+
+function TEd25519Sha512.CreateDigest: IDigest;
+begin
+  Result := TDigestUtilities.GetDigest('SHA-512');
+end;
+
 { TTestEd25519 }
 
-procedure TTestEd25519.CheckEd25519Vector(const ASK, APK, AM, ASig, AText: String);
+procedure TTestEd25519.ImplCheckEd25519Vector(AEd25519: TEd25519; const ASK, APK, AM, ASig, AText: String);
 var
   LSk, LPk, LM, LSig, LPkGen, LBadSig, LSigGen: TBytes;
   LShouldVerify, LShouldNotVerify: Boolean;
@@ -100,7 +141,7 @@ begin
   LPk := DecodeHex(APK);
 
   System.SetLength(LPkGen, TEd25519.PublicKeySize);
-  FEd25519.GeneratePublicKey(LSk, 0, LPkGen, 0);
+  AEd25519.GeneratePublicKey(LSk, 0, LPkGen, 0);
   CheckTrue(AreEqual(LPk, LPkGen), AText);
 
   LM := DecodeHex(AM);
@@ -111,17 +152,27 @@ begin
     xor $80);
 
   System.SetLength(LSigGen, TEd25519.SignatureSize);
-  FEd25519.Sign(LSk, 0, LM, 0, System.Length(LM), LSigGen, 0);
+  AEd25519.Sign(LSk, 0, LM, 0, System.Length(LM), LSigGen, 0);
   CheckTrue(AreEqual(LSig, LSigGen), AText);
 
-  FEd25519.Sign(LSk, 0, LPk, 0, LM, 0, System.Length(LM), LSigGen, 0);
+  AEd25519.Sign(LSk, 0, LPk, 0, LM, 0, System.Length(LM), LSigGen, 0);
   CheckTrue(AreEqual(LSig, LSigGen), AText);
 
-  LShouldVerify := FEd25519.Verify(LSig, 0, LPk, 0, LM, 0, System.Length(LM));
+  LShouldVerify := AEd25519.Verify(LSig, 0, LPk, 0, LM, 0, System.Length(LM));
   CheckTrue(LShouldVerify, AText);
 
-  LShouldNotVerify := FEd25519.Verify(LBadSig, 0, LPk, 0, LM, 0, System.Length(LM));
+  LShouldNotVerify := AEd25519.Verify(LBadSig, 0, LPk, 0, LM, 0, System.Length(LM));
   CheckFalse(LShouldNotVerify, AText);
+end;
+
+procedure TTestEd25519.CheckEd25519Vector(const ASK, APK, AM, ASig, AText: String);
+begin
+  ImplCheckEd25519Vector(FEd25519, ASK, APK, AM, ASig, AText);
+end;
+
+procedure TTestEd25519.CheckEd25519VectorBlake2b(const ASK, APK, AM, ASig, AText: String);
+begin
+  ImplCheckEd25519Vector(FEd25519Blake2b, ASK, APK, AM, ASig, AText);
 end;
 
 procedure TTestEd25519.CheckEd25519ctxVector(const ASK, APK, AM, ACTX, ASig,
@@ -184,7 +235,7 @@ begin
 
   System.SetLength(LSigGen, TEd25519.SignatureSize);
 
-  LPrehash := TEd25519.CreatePreHash();
+  LPrehash := FEd25519.CreatePreHash();
   LPrehash.BlockUpdate(LM, 0, System.Length(LM));
   System.SetLength(LPh, TEd25519.PrehashSize);
   LPrehash.DoFinal(LPh, 0);
@@ -201,22 +252,22 @@ begin
   LShouldNotVerify := FEd25519.VerifyPreHash(LBadSig, 0, LPk, 0, LCtx, LPh, 0);
   CheckFalse(LShouldNotVerify, AText);
 
-  LPrehash := TEd25519.CreatePreHash();
+  LPrehash := FEd25519.CreatePreHash();
   LPrehash.BlockUpdate(LM, 0, System.Length(LM));
   FEd25519.SignPreHash(LSk, 0, LCtx, LPrehash, LSigGen, 0);
   CheckTrue(AreEqual(LSig, LSigGen), AText);
 
-  LPrehash := TEd25519.CreatePreHash();
+  LPrehash := FEd25519.CreatePreHash();
   LPrehash.BlockUpdate(LM, 0, System.Length(LM));
   FEd25519.SignPreHash(LSk, 0, LPk, 0, LCtx, LPrehash, LSigGen, 0);
   CheckTrue(AreEqual(LSig, LSigGen), AText);
 
-  LPrehash := TEd25519.CreatePreHash();
+  LPrehash := FEd25519.CreatePreHash();
   LPrehash.BlockUpdate(LM, 0, System.Length(LM));
   LShouldVerify := FEd25519.VerifyPreHash(LSig, 0, LPk, 0, LCtx, LPrehash);
   CheckTrue(LShouldVerify, AText);
 
-  LPrehash := TEd25519.CreatePreHash();
+  LPrehash := FEd25519.CreatePreHash();
   LPrehash.BlockUpdate(LM, 0, System.Length(LM));
   LShouldNotVerify := FEd25519.VerifyPreHash(LBadSig, 0, LPk, 0, LCtx, LPrehash);
   CheckFalse(LShouldNotVerify, AText);
@@ -259,12 +310,15 @@ begin
   TEd25519.Precompute();
   FRandom := TSecureRandom.Create();
   FEd25519 := TEd25519.Create();
+  FEd25519Blake2b := TEd25519Blake2b.Create();
 end;
 
 procedure TTestEd25519.TearDown;
 begin
   FEd25519.Free;
   FEd25519 := nil;
+  FEd25519Blake2b.Free;
+  FEd25519Blake2b := nil;
   inherited;
 end;
 
@@ -287,7 +341,7 @@ begin
   for I := 0 to 9 do
   begin
     FEd25519.GeneratePrivateKey(FRandom, LSk);
-    LPublicPoint := TEd25519.GeneratePublicKey(LSk, 0);
+    LPublicPoint := FEd25519.GeneratePublicKey(LSk, 0);
     TEd25519.EncodePublicPoint(LPublicPoint, LPk, 0);
 
     FEd25519.GeneratePublicKey(LSk, 0, LPk2, 0);
@@ -340,7 +394,7 @@ begin
   for I := 0 to 9 do
   begin
     FEd25519.GeneratePrivateKey(FRandom, LSk);
-    LPublicPoint := TEd25519.GeneratePublicKey(LSk, 0);
+    LPublicPoint := FEd25519.GeneratePublicKey(LSk, 0);
     TEd25519.EncodePublicPoint(LPublicPoint, LPk, 0);
 
     FEd25519.GeneratePublicKey(LSk, 0, LPk2, 0);
@@ -396,7 +450,7 @@ begin
   for I := 0 to 9 do
   begin
     FEd25519.GeneratePrivateKey(FRandom, LSk);
-    LPublicPoint := TEd25519.GeneratePublicKey(LSk, 0);
+    LPublicPoint := FEd25519.GeneratePublicKey(LSk, 0);
     TEd25519.EncodePublicPoint(LPublicPoint, LPk, 0);
 
     FEd25519.GeneratePublicKey(LSk, 0, LPk2, 0);
@@ -404,7 +458,7 @@ begin
 
     LMLen := FRandom.NextInt32() and 255;
 
-    LPrehash := TEd25519.CreatePreHash();
+    LPrehash := FEd25519.CreatePreHash();
     LPrehash.BlockUpdate(LM, 0, LMLen);
     LPrehash.DoFinal(LPh, 0);
 
@@ -430,6 +484,82 @@ begin
     LShouldNotVerify := FEd25519.VerifyPreHash(LSig1, 0, LPublicPoint, LCtx, LPh, 0);
     CheckFalse(LShouldNotVerify,
       Format('Ed25519ph consistent verification failure #%d', [I]));
+  end;
+end;
+
+procedure TTestEd25519.TestEd25519ConsistencyDefaultMatchesSHA512Digest;
+var
+  LEdDefault, LEdSha512: TEd25519;
+  LSk, LPkDefault, LPkSha512, LM, LCtx, LPh, LSigDefault, LSigSha512: TBytes;
+  LPublicPoint: TEd25519.IPublicPoint;
+  I, LMLen: Int32;
+  LPrehash: IDigest;
+begin
+  LEdDefault := TEd25519.Create();
+  LEdSha512 := TEd25519Sha512.Create();
+  try
+    System.SetLength(LSk, TEd25519.SecretKeySize);
+    System.SetLength(LPkDefault, TEd25519.PublicKeySize);
+    System.SetLength(LPkSha512, TEd25519.PublicKeySize);
+    System.SetLength(LM, 255);
+    System.SetLength(LCtx, FRandom.NextInt32() and 7);
+    System.SetLength(LPh, TEd25519.PrehashSize);
+    System.SetLength(LSigDefault, TEd25519.SignatureSize);
+    System.SetLength(LSigSha512, TEd25519.SignatureSize);
+    FRandom.NextBytes(LM);
+    FRandom.NextBytes(LCtx);
+
+    for I := 0 to 9 do
+    begin
+      FEd25519.GeneratePrivateKey(FRandom, LSk);
+      LEdDefault.GeneratePublicKey(LSk, 0, LPkDefault, 0);
+      LEdSha512.GeneratePublicKey(LSk, 0, LPkSha512, 0);
+      CheckTrue(AreEqual(LPkDefault, LPkSha512), Format('Default SHA-512 key gen consistent #%d', [I]));
+      LPublicPoint := LEdDefault.GeneratePublicKey(LSk, 0);
+
+      LMLen := FRandom.NextInt32() and 255;
+      LEdDefault.Sign(LSk, 0, LM, 0, LMLen, LSigDefault, 0);
+      LEdSha512.Sign(LSk, 0, LM, 0, LMLen, LSigSha512, 0);
+      CheckTrue(AreEqual(LSigDefault, LSigSha512), Format('Default SHA-512 sign consistent #%d', [I]));
+
+      LEdDefault.Sign(LSk, 0, LPkDefault, 0, LM, 0, LMLen, LSigDefault, 0);
+      LEdSha512.Sign(LSk, 0, LPkSha512, 0, LM, 0, LMLen, LSigSha512, 0);
+      CheckTrue(AreEqual(LSigDefault, LSigSha512), Format('Default SHA-512 sign with Pk consistent #%d', [I]));
+
+      CheckTrue(LEdDefault.Verify(LSigDefault, 0, LPkDefault, 0, LM, 0, LMLen), Format('Default verify own sig #%d', [I]));
+      CheckTrue(LEdSha512.Verify(LSigSha512, 0, LPkSha512, 0, LM, 0, LMLen), Format('SHA-512 verify own sig #%d', [I]));
+      CheckTrue(LEdDefault.Verify(LSigDefault, 0, LPkSha512, 0, LM, 0, LMLen), Format('Default sig with SHA-512 pubkey #%d', [I]));
+      CheckTrue(LEdSha512.Verify(LSigSha512, 0, LPkDefault, 0, LM, 0, LMLen), Format('SHA-512 sig with default pubkey #%d', [I]));
+
+      CheckTrue(LEdDefault.Verify(LSigDefault, 0, LPublicPoint, LM, 0, LMLen), Format('Default verify PublicPoint own sig #%d', [I]));
+      CheckTrue(LEdSha512.Verify(LSigSha512, 0, LPublicPoint, LM, 0, LMLen), Format('SHA-512 verify PublicPoint own sig #%d', [I]));
+      CheckTrue(LEdSha512.Verify(LSigDefault, 0, LPublicPoint, LM, 0, LMLen), Format('Default sig with SHA-512 pubkey Verify PublicPoint #%d', [I]));
+      CheckTrue(LEdDefault.Verify(LSigSha512, 0, LPublicPoint, LM, 0, LMLen), Format('SHA-512 sig with default pubkey Verify PublicPoint #%d', [I]));
+
+      LPrehash := LEdDefault.CreatePreHash();
+      LPrehash.BlockUpdate(LM, 0, LMLen);
+      LPrehash.DoFinal(LPh, 0);
+      LEdDefault.SignPreHash(LSk, 0, LCtx, LPh, 0, LSigDefault, 0);
+      LEdSha512.SignPreHash(LSk, 0, LCtx, LPh, 0, LSigSha512, 0);
+      CheckTrue(AreEqual(LSigDefault, LSigSha512), Format('Default SHA-512 SignPrehash consistent #%d', [I]));
+
+      LEdDefault.SignPreHash(LSk, 0, LPkDefault, 0, LCtx, LPh, 0, LSigDefault, 0);
+      LEdSha512.SignPreHash(LSk, 0, LPkSha512, 0, LCtx, LPh, 0, LSigSha512, 0);
+      CheckTrue(AreEqual(LSigDefault, LSigSha512), Format('Default SHA-512 SignPrehash with Pk consistent #%d', [I]));
+
+      CheckTrue(LEdDefault.VerifyPreHash(LSigDefault, 0, LPkDefault, 0, LCtx, LPh, 0), Format('Default VerifyPreHash own sig #%d', [I]));
+      CheckTrue(LEdSha512.VerifyPreHash(LSigSha512, 0, LPkSha512, 0, LCtx, LPh, 0), Format('SHA-512 VerifyPreHash own sig #%d', [I]));
+      CheckTrue(LEdDefault.VerifyPreHash(LSigDefault, 0, LPkSha512, 0, LCtx, LPh, 0), Format('Default sig with SHA-512 pubkey VerifyPreHash #%d', [I]));
+      CheckTrue(LEdSha512.VerifyPreHash(LSigSha512, 0, LPkDefault, 0, LCtx, LPh, 0), Format('SHA-512 sig with default pubkey VerifyPreHash #%d', [I]));
+
+      CheckTrue(LEdDefault.VerifyPreHash(LSigDefault, 0, LPublicPoint, LCtx, LPh, 0), Format('Default VerifyPreHash PublicPoint own sig #%d', [I]));
+      CheckTrue(LEdSha512.VerifyPreHash(LSigSha512, 0, LPublicPoint, LCtx, LPh, 0), Format('SHA-512 VerifyPreHash PublicPoint own sig #%d', [I]));
+      CheckTrue(LEdSha512.VerifyPreHash(LSigDefault, 0, LPublicPoint, LCtx, LPh, 0), Format('Default sig with SHA-512 pubkey VerifyPreHash PublicPoint #%d', [I]));
+      CheckTrue(LEdDefault.VerifyPreHash(LSigSha512, 0, LPublicPoint, LCtx, LPh, 0), Format('SHA-512 sig with default pubkey VerifyPreHash PublicPoint #%d', [I]));
+    end;
+  finally
+    LEdDefault.Free;
+    LEdSha512.Free;
   end;
 end;
 
@@ -560,6 +690,106 @@ begin
     '',
     '98a70222f0b8121aa9d30f813d683f809e462b469c7ff87639499bb94e6dae4131f85042463c2a355a2003d062adf5aaa10b8c61e636062aaad11c2a26083406',
     'Ed25519ph Vector #1');
+end;
+
+procedure TTestEd25519.TestEd25519WithCustomDigestSHA512Vector1;
+begin
+  CheckEd25519Vector(
+    '9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60',
+    'd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a',
+    '',
+    'e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b',
+    'Ed25519 with custom digest SHA-512 Vector #1');
+end;
+
+procedure TTestEd25519.TestEd25519WithCustomDigestSHA512Vector2;
+begin
+  CheckEd25519Vector(
+    '4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb',
+    '3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c',
+    '72',
+    '92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00',
+    'Ed25519 with custom digest SHA-512 Vector #2');
+end;
+
+procedure TTestEd25519.TestEd25519WithCustomDigestSHA512Vector3;
+begin
+  CheckEd25519Vector(
+    'c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7',
+    'fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025',
+    'af82',
+    '6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a',
+    'Ed25519 with custom digest SHA-512 Vector #3');
+end;
+
+procedure TTestEd25519.TestEd25519WithCustomDigestSHA512Vector4;
+begin
+  CheckEd25519Vector(
+    '0d4a05b07352a5436e180356da0ae6efa0345ff7fb1572575772e8005ed978e9',
+    'e61a185bcef2613a6c7cb79763ce945d3b245d76114dd440bcf5f2dc1aa57057',
+    'cbc77b',
+    'd9868d52c2bebce5f3fa5a79891970f309cb6591e3e1702a70276fa97c24b3a8e58606c38c9758529da50ee31b8219cba45271c689afa60b0ea26c99db19b00c',
+    'Ed25519 with custom digest SHA-512 Vector #4');
+end;
+
+procedure TTestEd25519.TestEd25519WithCustomDigestSHA512Vector5;
+begin
+  CheckEd25519Vector(
+    '6df9340c138cc188b5fe4464ebaa3f7fc206a2d55c3434707e74c9fc04e20ebb',
+    'c0dac102c4533186e25dc43128472353eaabdb878b152aeb8e001f92d90233a7',
+    '5f4c8989',
+    '124f6fc6b0d100842769e71bd530664d888df8507df6c56dedfdb509aeb93416e26b918d38aa06305df3095697c18b2aa832eaa52edc0ae49fbae5a85e150c07',
+    'Ed25519 with custom digest SHA-512 Vector #5');
+end;
+
+procedure TTestEd25519.TestEd25519WithCustomDigestBlake2bVector1;
+begin
+  CheckEd25519VectorBlake2b(
+    '9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60',
+    '78e65bf30f893d32fc57ef051c341bdede242544fc2a2112f0fa2c7afdebc02f',
+    '',
+    '99a523bd4616c8161144d6a99d3c32400cb4a326f4d79e307340f6afa11750a0085d7d84626bc9e4b153fc0e396d15ce44c39bae4533804db1fe5b52f2b1b805',
+    'Ed25519-Blake2b Vector #1');
+end;
+
+procedure TTestEd25519.TestEd25519WithCustomDigestBlake2bVector2;
+begin
+  CheckEd25519VectorBlake2b(
+    '4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb',
+    '5e71392d91e6a58fedeb0850364f56cd158a60447557d7890389c9b3d4576d4d',
+    '72',
+    '6da75e15b5707f4de5a153c48a5d839fb85074c38aeb6285977f03a13977597f976069fdb903f183474aaa5ed0cfe878ba8ef868c5e47ca3f96ccfb3a89b2a06',
+    'Ed25519-Blake2b Vector #2');
+end;
+
+procedure TTestEd25519.TestEd25519WithCustomDigestBlake2bVector3;
+begin
+  CheckEd25519VectorBlake2b(
+    'c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7',
+    '8d53ca70f0eab23b9178345785fcdb69ed6723f8148f7e339e88653700b718da',
+    'af82',
+    '7cc3c13852bd12abf3ce4ca8ca2836cbf86da96c4634c50df3fb80dc809e29db0e109c361353407c1236a904f636868aa33977a99d3f844598db1538b4295203',
+    'Ed25519-Blake2b Vector #3');
+end;
+
+procedure TTestEd25519.TestEd25519WithCustomDigestBlake2bVector4;
+begin
+  CheckEd25519VectorBlake2b(
+    '0d4a05b07352a5436e180356da0ae6efa0345ff7fb1572575772e8005ed978e9',
+    '0c6989f1abebe219db9d1e2cb8b0c602b191828ef7238f8e6dbff8a506802c09',
+    'cbc77b',
+    '7fb2c11db736d16ebd07a653463dc8739d3315f89f61a66715e41528cb32b7689393f5af8a66c9c7336e209e6b187259fe266f7941a435fecb8cd7a7fc759400',
+    'Ed25519-Blake2b Vector #4');
+end;
+
+procedure TTestEd25519.TestEd25519WithCustomDigestBlake2bVector5;
+begin
+  CheckEd25519VectorBlake2b(
+    '6df9340c138cc188b5fe4464ebaa3f7fc206a2d55c3434707e74c9fc04e20ebb',
+    'ce99a0d41b2c1bdf593cfe41b0bf38f40ab77a804a71138188cc879b59869d90',
+    '5f4c8989',
+    'e09625735d184975409020659f3c0b07f036a19a7e7aa2100964cef577806e26125d1437577d2d3286c29df871797cac3fc0cdecbbeca616030cfcc6711db606',
+    'Ed25519-Blake2b Vector #5');
 end;
 
 procedure TTestEd25519.TestPublicKeyValidationFull;

--- a/CryptoLib.Tests/src/Math/EC/Rfc8032/Ed448Tests.pas
+++ b/CryptoLib.Tests/src/Math/EC/Rfc8032/Ed448Tests.pas
@@ -32,6 +32,7 @@ uses
   TestFramework,
 {$ENDIF FPC}
   ClpIXof,
+  ClpDigestUtilities,
   ClpEd448,
   ClpSecureRandom,
   ClpISecureRandom,
@@ -43,6 +44,8 @@ type
   private
   var
     FRandom: ISecureRandom;
+    FEd448: TEd448;
+    FEd448Xof: TEd448;
 
     procedure CheckEd448Vector(const ASK, APK, AM, ACTX, ASig, AText: String);
     procedure CheckEd448phVector(const ASK, APK, AM, ACTX, ASig, AText: String);
@@ -51,6 +54,7 @@ type
     procedure TearDown; override;
   published
     procedure TestEd448Consistency();
+    procedure TestEd448ConsistencyDefaultMatchesXof();
     procedure TestEd448phConsistency();
     procedure TestEd448Vector1();
     procedure TestEd448Vector2();
@@ -69,6 +73,17 @@ type
 
 implementation
 
+type
+  TEd448Shake256 = class(TEd448)
+  strict protected
+    function CreateXof(): IXof; override;
+  end;
+
+function TEd448Shake256.CreateXof(): IXof;
+begin
+  Result := TDigestUtilities.GetDigest('SHAKE256-512') as IXof;
+end;
+
 { TTestEd448 }
 
 procedure TTestEd448.CheckEd448Vector(const ASK, APK, AM, ACTX, ASig, AText: String);
@@ -80,7 +95,7 @@ begin
   LPk := DecodeHex(APK);
 
   System.SetLength(LPkGen, TEd448.PublicKeySize);
-  TEd448.GeneratePublicKey(LSk, 0, LPkGen, 0);
+  FEd448.GeneratePublicKey(LSk, 0, LPkGen, 0);
   CheckTrue(AreEqual(LPk, LPkGen), AText);
 
   LM := DecodeHex(AM);
@@ -91,16 +106,16 @@ begin
   LBadSig[TEd448.SignatureSize - 1] := Byte(LBadSig[TEd448.SignatureSize - 1] xor $80);
 
   System.SetLength(LSigGen, TEd448.SignatureSize);
-  TEd448.Sign(LSk, 0, LCtx, LM, 0, System.Length(LM), LSigGen, 0);
+  FEd448.Sign(LSk, 0, LCtx, LM, 0, System.Length(LM), LSigGen, 0);
   CheckTrue(AreEqual(LSig, LSigGen), AText);
 
-  TEd448.Sign(LSk, 0, LPk, 0, LCtx, LM, 0, System.Length(LM), LSigGen, 0);
+  FEd448.Sign(LSk, 0, LPk, 0, LCtx, LM, 0, System.Length(LM), LSigGen, 0);
   CheckTrue(AreEqual(LSig, LSigGen), AText);
 
-  LShouldVerify := TEd448.Verify(LSig, 0, LPk, 0, LCtx, LM, 0, System.Length(LM));
+  LShouldVerify := FEd448.Verify(LSig, 0, LPk, 0, LCtx, LM, 0, System.Length(LM));
   CheckTrue(LShouldVerify, AText);
 
-  LShouldNotVerify := TEd448.Verify(LBadSig, 0, LPk, 0, LCtx, LM, 0, System.Length(LM));
+  LShouldNotVerify := FEd448.Verify(LBadSig, 0, LPk, 0, LCtx, LM, 0, System.Length(LM));
   CheckFalse(LShouldNotVerify, AText);
 end;
 
@@ -114,7 +129,7 @@ begin
   LPk := DecodeHex(APK);
 
   System.SetLength(LPkGen, TEd448.PublicKeySize);
-  TEd448.GeneratePublicKey(LSk, 0, LPkGen, 0);
+  FEd448.GeneratePublicKey(LSk, 0, LPkGen, 0);
   CheckTrue(AreEqual(LPk, LPkGen), AText);
 
   LM := DecodeHex(AM);
@@ -126,41 +141,41 @@ begin
 
   System.SetLength(LSigGen, TEd448.SignatureSize);
 
-  LPrehash := TEd448.CreatePrehash();
+  LPrehash := FEd448.CreatePrehash();
   LPrehash.BlockUpdate(LM, 0, System.Length(LM));
   System.SetLength(LPh, TEd448.PrehashSize);
   LPrehash.OutputFinal(LPh, 0, System.Length(LPh));
 
-  TEd448.SignPrehash(LSk, 0, LCtx, LPh, 0, LSigGen, 0);
+  FEd448.SignPrehash(LSk, 0, LCtx, LPh, 0, LSigGen, 0);
   CheckTrue(AreEqual(LSig, LSigGen), AText);
 
-  TEd448.SignPrehash(LSk, 0, LPk, 0, LCtx, LPh, 0, LSigGen, 0);
+  FEd448.SignPrehash(LSk, 0, LPk, 0, LCtx, LPh, 0, LSigGen, 0);
   CheckTrue(AreEqual(LSig, LSigGen), AText);
 
-  LShouldVerify := TEd448.VerifyPrehash(LSig, 0, LPk, 0, LCtx, LPh, 0);
+  LShouldVerify := FEd448.VerifyPrehash(LSig, 0, LPk, 0, LCtx, LPh, 0);
   CheckTrue(LShouldVerify, AText);
 
-  LShouldNotVerify := TEd448.VerifyPrehash(LBadSig, 0, LPk, 0, LCtx, LPh, 0);
+  LShouldNotVerify := FEd448.VerifyPrehash(LBadSig, 0, LPk, 0, LCtx, LPh, 0);
   CheckFalse(LShouldNotVerify, AText);
 
-  LPrehash := TEd448.CreatePrehash();
+  LPrehash := FEd448.CreatePrehash();
   LPrehash.BlockUpdate(LM, 0, System.Length(LM));
-  TEd448.SignPrehash(LSk, 0, LCtx, LPrehash, LSigGen, 0);
+  FEd448.SignPrehash(LSk, 0, LCtx, LPrehash, LSigGen, 0);
   CheckTrue(AreEqual(LSig, LSigGen), AText);
 
-  LPrehash := TEd448.CreatePrehash();
+  LPrehash := FEd448.CreatePrehash();
   LPrehash.BlockUpdate(LM, 0, System.Length(LM));
-  TEd448.SignPrehash(LSk, 0, LPk, 0, LCtx, LPrehash, LSigGen, 0);
+  FEd448.SignPrehash(LSk, 0, LPk, 0, LCtx, LPrehash, LSigGen, 0);
   CheckTrue(AreEqual(LSig, LSigGen), AText);
 
-  LPrehash := TEd448.CreatePrehash();
+  LPrehash := FEd448.CreatePrehash();
   LPrehash.BlockUpdate(LM, 0, System.Length(LM));
-  LShouldVerify := TEd448.VerifyPrehash(LSig, 0, LPk, 0, LCtx, LPrehash);
+  LShouldVerify := FEd448.VerifyPrehash(LSig, 0, LPk, 0, LCtx, LPrehash);
   CheckTrue(LShouldVerify, AText);
 
-  LPrehash := TEd448.CreatePrehash();
+  LPrehash := FEd448.CreatePrehash();
   LPrehash.BlockUpdate(LM, 0, System.Length(LM));
-  LShouldNotVerify := TEd448.VerifyPrehash(LBadSig, 0, LPk, 0, LCtx, LPrehash);
+  LShouldNotVerify := FEd448.VerifyPrehash(LBadSig, 0, LPk, 0, LCtx, LPrehash);
   CheckFalse(LShouldNotVerify, AText);
 end;
 
@@ -169,10 +184,14 @@ begin
   inherited;
   TEd448.Precompute();
   FRandom := TSecureRandom.Create();
+  FEd448 := TEd448.Create();
+  FEd448Xof := TEd448Shake256.Create();
 end;
 
 procedure TTestEd448.TearDown;
 begin
+  FEd448Xof.Free;
+  FEd448.Free;
   inherited;
 end;
 
@@ -196,33 +215,107 @@ begin
 
   for I := 0 to 9 do
   begin
-    TEd448.GeneratePrivateKey(FRandom, LSk);
-    LPublicPoint := TEd448.GeneratePublicKey(LSk, 0);
+    FEd448.GeneratePrivateKey(FRandom, LSk);
+    LPublicPoint := FEd448.GeneratePublicKey(LSk, 0);
     TEd448.EncodePublicPoint(LPublicPoint, LPk, 0);
 
-    TEd448.GeneratePublicKey(LSk, 0, LPk2, 0);
+    FEd448.GeneratePublicKey(LSk, 0, LPk2, 0);
     CheckTrue(AreEqual(LPk, LPk2), Format('Ed448 consistent generation #%d', [I]));
 
     LMLen := FRandom.NextInt32() and 255;
 
-    TEd448.Sign(LSk, 0, LCtx, LM, 0, LMLen, LSig1, 0);
-    TEd448.Sign(LSk, 0, LPk, 0, LCtx, LM, 0, LMLen, LSig2, 0);
+    FEd448.Sign(LSk, 0, LCtx, LM, 0, LMLen, LSig1, 0);
+    FEd448.Sign(LSk, 0, LPk, 0, LCtx, LM, 0, LMLen, LSig2, 0);
 
     CheckTrue(AreEqual(LSig1, LSig2), Format('Ed448 consistent signatures #%d', [I]));
 
-    LShouldVerify := TEd448.Verify(LSig1, 0, LPk, 0, LCtx, LM, 0, LMLen);
+    LShouldVerify := FEd448.Verify(LSig1, 0, LPk, 0, LCtx, LM, 0, LMLen);
     CheckTrue(LShouldVerify, Format('Ed448 consistent sign/verify #%d', [I]));
 
-    LShouldVerify := TEd448.Verify(LSig1, 0, LPublicPoint, LCtx, LM, 0, LMLen);
+    LShouldVerify := FEd448.Verify(LSig1, 0, LPublicPoint, LCtx, LM, 0, LMLen);
     CheckTrue(LShouldVerify, Format('Ed448 consistent sign/verify #%d', [I]));
 
     LSig1[TEd448.PublicKeySize - 1] := Byte(LSig1[TEd448.PublicKeySize - 1] xor $80);
 
-    LShouldNotVerify := TEd448.Verify(LSig1, 0, LPk, 0, LCtx, LM, 0, LMLen);
+    LShouldNotVerify := FEd448.Verify(LSig1, 0, LPk, 0, LCtx, LM, 0, LMLen);
     CheckFalse(LShouldNotVerify, Format('Ed448 consistent verification failure #%d', [I]));
 
-    LShouldNotVerify := TEd448.Verify(LSig1, 0, LPublicPoint, LCtx, LM, 0, LMLen);
+    LShouldNotVerify := FEd448.Verify(LSig1, 0, LPublicPoint, LCtx, LM, 0, LMLen);
     CheckFalse(LShouldNotVerify, Format('Ed448 consistent verification failure #%d', [I]));
+  end;
+end;
+
+procedure TTestEd448.TestEd448ConsistencyDefaultMatchesXof;
+var
+  LSk, LPk, LPkDefault, LPkXof, LCtx, LM, LPh, LSig1, LSig2: TBytes;
+  LPublicPoint: TEd448.IPublicPoint;
+  I, LMLen: Int32;
+  LPrehash: IXof;
+begin
+  System.SetLength(LSk, TEd448.SecretKeySize);
+  System.SetLength(LPk, TEd448.PublicKeySize);
+  System.SetLength(LPkDefault, TEd448.PublicKeySize);
+  System.SetLength(LPkXof, TEd448.PublicKeySize);
+  System.SetLength(LCtx, FRandom.NextInt32() and 7);
+  System.SetLength(LM, 255);
+  System.SetLength(LPh, TEd448.PrehashSize);
+  System.SetLength(LSig1, TEd448.SignatureSize);
+  System.SetLength(LSig2, TEd448.SignatureSize);
+
+  FRandom.NextBytes(LCtx);
+  FRandom.NextBytes(LM);
+
+  for I := 0 to 9 do
+  begin
+    FEd448.GeneratePrivateKey(FRandom, LSk);
+
+    FEd448.GeneratePublicKey(LSk, 0, LPkDefault, 0);
+    FEd448Xof.GeneratePublicKey(LSk, 0, LPkXof, 0);
+    CheckTrue(AreEqual(LPkDefault, LPkXof), Format('Default vs XOF key gen #%d', [I]));
+    LPk := LPkDefault;
+    LPublicPoint := FEd448.GeneratePublicKey(LSk, 0);
+
+    LMLen := FRandom.NextInt32() and 255;
+
+    FEd448.Sign(LSk, 0, LCtx, LM, 0, LMLen, LSig1, 0);
+    FEd448Xof.Sign(LSk, 0, LCtx, LM, 0, LMLen, LSig2, 0);
+    CheckTrue(AreEqual(LSig1, LSig2), Format('Default vs XOF Sign #%d', [I]));
+
+    FEd448.Sign(LSk, 0, LPk, 0, LCtx, LM, 0, LMLen, LSig1, 0);
+    FEd448Xof.Sign(LSk, 0, LPk, 0, LCtx, LM, 0, LMLen, LSig2, 0);
+    CheckTrue(AreEqual(LSig1, LSig2), Format('Default vs XOF Sign with Pk #%d', [I]));
+
+    CheckTrue(FEd448.Verify(LSig1, 0, LPk, 0, LCtx, LM, 0, LMLen), Format('Default verify own sig #%d', [I]));
+    CheckTrue(FEd448Xof.Verify(LSig2, 0, LPk, 0, LCtx, LM, 0, LMLen), Format('XOF verify own sig #%d', [I]));
+    CheckTrue(FEd448Xof.Verify(LSig1, 0, LPk, 0, LCtx, LM, 0, LMLen), Format('Default sig with XOF pubkey Verify #%d', [I]));
+    CheckTrue(FEd448.Verify(LSig2, 0, LPk, 0, LCtx, LM, 0, LMLen), Format('XOF sig with default pubkey Verify #%d', [I]));
+
+    CheckTrue(FEd448.Verify(LSig1, 0, LPublicPoint, LCtx, LM, 0, LMLen), Format('Default verify PublicPoint own sig #%d', [I]));
+    CheckTrue(FEd448Xof.Verify(LSig2, 0, LPublicPoint, LCtx, LM, 0, LMLen), Format('XOF verify PublicPoint own sig #%d', [I]));
+    CheckTrue(FEd448Xof.Verify(LSig1, 0, LPublicPoint, LCtx, LM, 0, LMLen), Format('Default sig with XOF pubkey Verify PublicPoint #%d', [I]));
+    CheckTrue(FEd448.Verify(LSig2, 0, LPublicPoint, LCtx, LM, 0, LMLen), Format('XOF sig with default pubkey Verify PublicPoint #%d', [I]));
+
+    LPrehash := FEd448.CreatePrehash();
+    LPrehash.BlockUpdate(LM, 0, LMLen);
+    LPrehash.OutputFinal(LPh, 0, System.Length(LPh));
+
+    FEd448.SignPrehash(LSk, 0, LCtx, LPh, 0, LSig1, 0);
+    FEd448Xof.SignPrehash(LSk, 0, LCtx, LPh, 0, LSig2, 0);
+    CheckTrue(AreEqual(LSig1, LSig2), Format('Default vs XOF SignPrehash #%d', [I]));
+
+    FEd448.SignPrehash(LSk, 0, LPk, 0, LCtx, LPh, 0, LSig1, 0);
+    FEd448Xof.SignPrehash(LSk, 0, LPk, 0, LCtx, LPh, 0, LSig2, 0);
+    CheckTrue(AreEqual(LSig1, LSig2), Format('Default vs XOF SignPrehash with Pk #%d', [I]));
+
+    CheckTrue(FEd448.VerifyPrehash(LSig1, 0, LPk, 0, LCtx, LPh, 0), Format('Default VerifyPrehash own sig #%d', [I]));
+    CheckTrue(FEd448Xof.VerifyPrehash(LSig2, 0, LPk, 0, LCtx, LPh, 0), Format('XOF VerifyPrehash own sig #%d', [I]));
+    CheckTrue(FEd448Xof.VerifyPrehash(LSig1, 0, LPk, 0, LCtx, LPh, 0), Format('Default sig with XOF pubkey VerifyPrehash #%d', [I]));
+    CheckTrue(FEd448.VerifyPrehash(LSig2, 0, LPk, 0, LCtx, LPh, 0), Format('XOF sig with default pubkey VerifyPrehash #%d', [I]));
+
+    CheckTrue(FEd448.VerifyPrehash(LSig1, 0, LPublicPoint, LCtx, LPh, 0), Format('Default VerifyPrehash PublicPoint own sig #%d', [I]));
+    CheckTrue(FEd448Xof.VerifyPrehash(LSig2, 0, LPublicPoint, LCtx, LPh, 0), Format('XOF VerifyPrehash PublicPoint own sig #%d', [I]));
+    CheckTrue(FEd448Xof.VerifyPrehash(LSig1, 0, LPublicPoint, LCtx, LPh, 0), Format('Default sig with XOF pubkey VerifyPrehash PublicPoint #%d', [I]));
+    CheckTrue(FEd448.VerifyPrehash(LSig2, 0, LPublicPoint, LCtx, LPh, 0), Format('XOF sig with default pubkey VerifyPrehash PublicPoint #%d', [I]));
   end;
 end;
 
@@ -248,36 +341,36 @@ begin
 
   for I := 0 to 9 do
   begin
-    TEd448.GeneratePrivateKey(FRandom, LSk);
-    LPublicPoint := TEd448.GeneratePublicKey(LSk, 0);
+    FEd448.GeneratePrivateKey(FRandom, LSk);
+    LPublicPoint := FEd448.GeneratePublicKey(LSk, 0);
     TEd448.EncodePublicPoint(LPublicPoint, LPk, 0);
 
-    TEd448.GeneratePublicKey(LSk, 0, LPk2, 0);
+    FEd448.GeneratePublicKey(LSk, 0, LPk2, 0);
     CheckTrue(AreEqual(LPk, LPk2), Format('Ed448 consistent generation #%d', [I]));
 
     LMLen := FRandom.NextInt32() and 255;
 
-    LPrehash := TEd448.CreatePrehash();
+    LPrehash := FEd448.CreatePrehash();
     LPrehash.BlockUpdate(LM, 0, LMLen);
     LPrehash.OutputFinal(LPh, 0, System.Length(LPh));
 
-    TEd448.SignPrehash(LSk, 0, LCtx, LPh, 0, LSig1, 0);
-    TEd448.SignPrehash(LSk, 0, LPk, 0, LCtx, LPh, 0, LSig2, 0);
+    FEd448.SignPrehash(LSk, 0, LCtx, LPh, 0, LSig1, 0);
+    FEd448.SignPrehash(LSk, 0, LPk, 0, LCtx, LPh, 0, LSig2, 0);
 
     CheckTrue(AreEqual(LSig1, LSig2), Format('Ed448ph consistent signatures #%d', [I]));
 
-    LShouldVerify := TEd448.VerifyPrehash(LSig1, 0, LPk, 0, LCtx, LPh, 0);
+    LShouldVerify := FEd448.VerifyPrehash(LSig1, 0, LPk, 0, LCtx, LPh, 0);
     CheckTrue(LShouldVerify, Format('Ed448ph consistent sign/verify #%d', [I]));
 
-    LShouldVerify := TEd448.VerifyPrehash(LSig1, 0, LPublicPoint, LCtx, LPh, 0);
+    LShouldVerify := FEd448.VerifyPrehash(LSig1, 0, LPublicPoint, LCtx, LPh, 0);
     CheckTrue(LShouldVerify, Format('Ed448ph consistent sign/verify #%d', [I]));
 
     LSig1[TEd448.PublicKeySize - 1] := Byte(LSig1[TEd448.PublicKeySize - 1] xor $80);
 
-    LShouldNotVerify := TEd448.VerifyPrehash(LSig1, 0, LPk, 0, LCtx, LPh, 0);
+    LShouldNotVerify := FEd448.VerifyPrehash(LSig1, 0, LPk, 0, LCtx, LPh, 0);
     CheckFalse(LShouldNotVerify, Format('Ed448ph consistent verification failure #%d', [I]));
 
-    LShouldNotVerify := TEd448.VerifyPrehash(LSig1, 0, LPublicPoint, LCtx, LPh, 0);
+    LShouldNotVerify := FEd448.VerifyPrehash(LSig1, 0, LPublicPoint, LCtx, LPh, 0);
     CheckFalse(LShouldNotVerify, Format('Ed448ph consistent verification failure #%d', [I]));
   end;
 end;
@@ -436,8 +529,8 @@ begin
 
   for I := 0 to 9 do
   begin
-    TEd448.GeneratePrivateKey(FRandom, LSk);
-    TEd448.GeneratePublicKey(LSk, 0, LPk, 0);
+    FEd448.GeneratePrivateKey(FRandom, LSk);
+    FEd448.GeneratePublicKey(LSk, 0, LPk, 0);
     CheckTrue(TEd448.ValidatePublicKeyFull(LPk, 0));
   end;
 
@@ -487,8 +580,8 @@ begin
 
   for I := 0 to 9 do
   begin
-    TEd448.GeneratePrivateKey(FRandom, LSk);
-    TEd448.GeneratePublicKey(LSk, 0, LPk, 0);
+    FEd448.GeneratePrivateKey(FRandom, LSk);
+    FEd448.GeneratePublicKey(LSk, 0, LPk, 0);
     CheckTrue(TEd448.ValidatePublicKeyPartial(LPk, 0));
   end;
 

--- a/CryptoLib/src/Crypto/Parameters/ClpEd25519Parameters.pas
+++ b/CryptoLib/src/Crypto/Parameters/ClpEd25519Parameters.pas
@@ -244,12 +244,18 @@ end;
 
 function TEd25519PrivateKeyParameters.GeneratePublicKey: IEd25519PublicKeyParameters;
 var
+  LEd25519: TEd25519;
   LPoint: TEd25519.IPublicPoint;
 begin
   if FCachedPublicKey = nil then
   begin
-    LPoint := TEd25519.GeneratePublicKey(FData, 0);
-    FCachedPublicKey := TEd25519PublicKeyParameters.Create(LPoint);
+    LEd25519 := TEd25519.Create();
+    try
+      LPoint := LEd25519.GeneratePublicKey(FData, 0);
+      FCachedPublicKey := TEd25519PublicKeyParameters.Create(LPoint);
+    finally
+      LEd25519.Free;
+    end;
   end;
   Result := FCachedPublicKey;
 end;

--- a/CryptoLib/src/Crypto/Parameters/ClpEd448Parameters.pas
+++ b/CryptoLib/src/Crypto/Parameters/ClpEd448Parameters.pas
@@ -168,25 +168,32 @@ end;
 function TEd448PublicKeyParameters.Verify(AAlgorithm: TEd448.TAlgorithm;
   const ACtx, AMsg: TCryptoLibByteArray; AMsgOff, AMsgLen: Int32;
   const ASig: TCryptoLibByteArray; ASigOff: Int32): Boolean;
+var
+  LEd448: TEd448;
 begin
-  case AAlgorithm of
-    TEd448.TAlgorithm.Ed448:
-      begin
-        if System.Length(ACtx) > 255 then
-          raise EArgumentCryptoLibException.CreateRes(@SCtxLength);
-        Result := TEd448.Verify(ASig, ASigOff, FPublicPoint, ACtx, AMsg,
-          AMsgOff, AMsgLen);
-      end;
-    TEd448.TAlgorithm.Ed448ph:
-      begin
-        if System.Length(ACtx) > 255 then
-          raise EArgumentCryptoLibException.CreateRes(@SCtxLength);
-        if AMsgLen <> TEd448.PrehashSize then
-          raise EArgumentCryptoLibException.CreateRes(@SMsgLen);
-        Result := TEd448.VerifyPrehash(ASig, ASigOff, FPublicPoint, ACtx, AMsg, AMsgOff);
-      end;
-  else
-    raise EArgumentCryptoLibException.CreateRes(@SUnsupportedAlgorithm);
+  LEd448 := TEd448.Create();
+  try
+    case AAlgorithm of
+      TEd448.TAlgorithm.Ed448:
+        begin
+          if System.Length(ACtx) > 255 then
+            raise EArgumentCryptoLibException.CreateRes(@SCtxLength);
+          Result := LEd448.Verify(ASig, ASigOff, FPublicPoint, ACtx, AMsg,
+            AMsgOff, AMsgLen);
+        end;
+      TEd448.TAlgorithm.Ed448ph:
+        begin
+          if System.Length(ACtx) > 255 then
+            raise EArgumentCryptoLibException.CreateRes(@SCtxLength);
+          if AMsgLen <> TEd448.PrehashSize then
+            raise EArgumentCryptoLibException.CreateRes(@SMsgLen);
+          Result := LEd448.VerifyPrehash(ASig, ASigOff, FPublicPoint, ACtx, AMsg, AMsgOff);
+        end;
+    else
+      raise EArgumentCryptoLibException.CreateRes(@SUnsupportedAlgorithm);
+    end;
+  finally
+    LEd448.Free;
   end;
 end;
 
@@ -219,10 +226,17 @@ end;
 { TEd448PrivateKeyParameters }
 
 constructor TEd448PrivateKeyParameters.Create(const ARandom: ISecureRandom);
+var
+  LEd448: TEd448;
 begin
   inherited Create(True);
   System.SetLength(FData, KeySize);
-  TEd448.GeneratePrivateKey(ARandom, FData);
+  LEd448 := TEd448.Create();
+  try
+    LEd448.GeneratePrivateKey(ARandom, FData);
+  finally
+    LEd448.Free;
+  end;
 end;
 
 constructor TEd448PrivateKeyParameters.Create(const ABuf: TCryptoLibByteArray);
@@ -261,12 +275,18 @@ end;
 
 function TEd448PrivateKeyParameters.GeneratePublicKey: IEd448PublicKeyParameters;
 var
+  LEd448: TEd448;
   LPublicPoint: TEd448.IPublicPoint;
 begin
   if FCachedPublicKey = nil then
   begin
-    LPublicPoint := TEd448.GeneratePublicKey(FData, 0);
-    FCachedPublicKey := TEd448PublicKeyParameters.Create(LPublicPoint);
+    LEd448 := TEd448.Create();
+    try
+      LPublicPoint := LEd448.GeneratePublicKey(FData, 0);
+      FCachedPublicKey := TEd448PublicKeyParameters.Create(LPublicPoint);
+    finally
+      LEd448.Free;
+    end;
   end;
   Result := FCachedPublicKey;
 end;
@@ -275,26 +295,32 @@ procedure TEd448PrivateKeyParameters.Sign(AAlgorithm: TEd448.TAlgorithm;
   const ACtx, AMsg: TCryptoLibByteArray; AMsgOff, AMsgLen: Int32;
   const ASig: TCryptoLibByteArray; ASigOff: Int32);
 var
+  LEd448: TEd448;
   LPk: TCryptoLibByteArray;
 begin
   LPk := GeneratePublicKey().GetEncoded();
-  case AAlgorithm of
-    TEd448.TAlgorithm.Ed448:
-      begin
-        if System.Length(ACtx) > 255 then
-          raise EArgumentCryptoLibException.CreateRes(@SCtxLength);
-        TEd448.Sign(FData, 0, LPk, 0, ACtx, AMsg, AMsgOff, AMsgLen, ASig, ASigOff);
-      end;
-    TEd448.TAlgorithm.Ed448ph:
-      begin
-        if System.Length(ACtx) > 255 then
-          raise EArgumentCryptoLibException.CreateRes(@SCtxLength);
-        if AMsgLen <> TEd448.PrehashSize then
-          raise EArgumentCryptoLibException.CreateRes(@SMsgLen);
-        TEd448.SignPrehash(FData, 0, LPk, 0, ACtx, AMsg, AMsgOff, ASig, ASigOff);
-      end;
-  else
-    raise EArgumentCryptoLibException.CreateRes(@SUnsupportedAlgorithm);
+  LEd448 := TEd448.Create();
+  try
+    case AAlgorithm of
+      TEd448.TAlgorithm.Ed448:
+        begin
+          if System.Length(ACtx) > 255 then
+            raise EArgumentCryptoLibException.CreateRes(@SCtxLength);
+          LEd448.Sign(FData, 0, LPk, 0, ACtx, AMsg, AMsgOff, AMsgLen, ASig, ASigOff);
+        end;
+      TEd448.TAlgorithm.Ed448ph:
+        begin
+          if System.Length(ACtx) > 255 then
+            raise EArgumentCryptoLibException.CreateRes(@SCtxLength);
+          if AMsgLen <> TEd448.PrehashSize then
+            raise EArgumentCryptoLibException.CreateRes(@SMsgLen);
+          LEd448.SignPrehash(FData, 0, LPk, 0, ACtx, AMsg, AMsgOff, ASig, ASigOff);
+        end;
+    else
+      raise EArgumentCryptoLibException.CreateRes(@SUnsupportedAlgorithm);
+    end;
+  finally
+    LEd448.Free;
   end;
 end;
 

--- a/CryptoLib/src/Crypto/Signers/ClpEd25519PhSigner.pas
+++ b/CryptoLib/src/Crypto/Signers/ClpEd25519PhSigner.pas
@@ -82,10 +82,17 @@ begin
 end;
 
 constructor TEd25519PhSigner.Create(const AContext: TCryptoLibByteArray);
+var
+  LEd25519: TEd25519;
 begin
   Inherited Create();
   FContext := System.Copy(AContext);
-  FPreHash := TEd25519.CreatePreHash();
+  LEd25519 := TEd25519.Create();
+  try
+    FPreHash := LEd25519.CreatePreHash();
+  finally
+    LEd25519.Free;
+  end;
 end;
 
 destructor TEd25519PhSigner.Destroy;

--- a/CryptoLib/src/Crypto/Signers/ClpEd448PhSigner.pas
+++ b/CryptoLib/src/Crypto/Signers/ClpEd448PhSigner.pas
@@ -82,10 +82,17 @@ begin
 end;
 
 constructor TEd448PhSigner.Create(const AContext: TCryptoLibByteArray);
+var
+  LEd448: TEd448;
 begin
   Inherited Create();
   FContext := System.Copy(AContext);
-  FPreHash := TEd448.CreatePrehash();
+  LEd448 := TEd448.Create();
+  try
+    FPreHash := LEd448.CreatePrehash();
+  finally
+    LEd448.Free;
+  end;
 end;
 
 destructor TEd448PhSigner.Destroy;

--- a/CryptoLib/src/Math/EC/Rfc8032/ClpEd25519.pas
+++ b/CryptoLib/src/Math/EC/Rfc8032/ClpEd25519.pas
@@ -167,18 +167,12 @@ type
   class function CheckPointFullVar(const AP: TCryptoLibByteArray): Boolean; static;
   class function CheckPointVar(const AP: TCryptoLibByteArray): Boolean; static;
   class procedure CopyBytes(const ABuf: TCryptoLibByteArray; AOff: Int32; ALen: Int32; var AOut: TCryptoLibByteArray); static;
-  class function CreateDigest(): IDigest; static;
   class function DecodePointVar(const AP: TCryptoLibByteArray; ANegate: Boolean; var AR: TPointAffine): Boolean; static;
   class procedure Dom2(const AD: IDigest; APhflag: Byte; const ACtx: TCryptoLibByteArray); static;
   class procedure EncodePoint(const AP: TPointAffine; AR: TCryptoLibByteArray; AROff: Int32); static;
   class function EncodeResult(var AP: TPointAccum; AR: TCryptoLibByteArray; AROff: Int32): Int32; static;
   class function GetWindow4(const AX: TCryptoLibUInt32Array; AN: Int32): UInt32; static;
   class procedure GroupCombBits(AN: TCryptoLibUInt32Array); static;
-  class procedure ImplSign(const AD: IDigest; AH, &AS, APk: TCryptoLibByteArray; APkOff: Int32;
-    const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32;
-    ASig: TCryptoLibByteArray; ASigOff: Int32); overload; static;
-  class function ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray; APkOff: Int32;
-    const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean; overload; static;
   class procedure InitPointAccum(var AR: TPointAccum); static;
   class procedure InitPointAffine(var AR: TPointAffine); static;
   class procedure InitPointExtended(var AR: TPointExtended); static;
@@ -211,13 +205,22 @@ type
   class procedure ScalarMultStraus128Var(const ANb: TCryptoLibUInt32Array; const ANp: TCryptoLibUInt32Array; const AP: TPointAffine;
     const ANq: TCryptoLibUInt32Array; const AQ: TPointAffine; var AR: TPointAccum); static;
   class function ExportPoint(var AP: TPointAffine): IPublicPoint; static;
-  class function ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
-    const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean; overload; static;
-  class procedure ImplSign(const &AS: TCryptoLibByteArray; ASOff: Int32; const ACtx: TCryptoLibByteArray; APhflag: Byte;
-    const AM: TCryptoLibByteArray; AMOff: Int32; AMLen: Int32; const ASig: TCryptoLibByteArray; ASigOff: Int32); overload; static;
-  class procedure ImplSign(const &AS: TCryptoLibByteArray; ASOff: Int32; const APk: TCryptoLibByteArray; APkOff: Int32;
+
+  function CreateAndValidateDigest(): IDigest;
+  function ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray; APkOff: Int32;
+    const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean; overload;
+  function ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
+    const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean; overload;
+  procedure ImplSign(const AD: IDigest; AH, &AS, APk: TCryptoLibByteArray; APkOff: Int32;
+    const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32;
+    ASig: TCryptoLibByteArray; ASigOff: Int32); overload;
+  procedure ImplSign(const &AS: TCryptoLibByteArray; ASOff: Int32; const ACtx: TCryptoLibByteArray; APhflag: Byte;
+    const AM: TCryptoLibByteArray; AMOff: Int32; AMLen: Int32; const ASig: TCryptoLibByteArray; ASigOff: Int32); overload;
+  procedure ImplSign(const &AS: TCryptoLibByteArray; ASOff: Int32; const APk: TCryptoLibByteArray; APkOff: Int32;
     const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff: Int32; AMLen: Int32;
-    const ASig: TCryptoLibByteArray; ASigOff: Int32); overload; static;
+    const ASig: TCryptoLibByteArray; ASigOff: Int32); overload;
+  strict protected
+    function CreateDigest(): IDigest; virtual;
   public
     const
     PrehashSize = 64;
@@ -229,14 +232,13 @@ type
     class procedure ScalarMultBaseYZ(const AK: TCryptoLibByteArray; AKOff: Int32; AY, AZ: TCryptoLibInt32Array); static;
 
     class procedure EncodePublicPoint(const APublicPoint: IPublicPoint; APk: TCryptoLibByteArray; APkOff: Int32); static;
-    class function GeneratePublicKey(const &AS: TCryptoLibByteArray; ASOff: Int32): IPublicPoint; overload; static;
     class function ValidatePublicKeyFull(const APk: TCryptoLibByteArray; APkOff: Int32): Boolean; static;
     class function ValidatePublicKeyFullExport(const APk: TCryptoLibByteArray; APkOff: Int32): IPublicPoint; static;
     class function ValidatePublicKeyPartial(const APk: TCryptoLibByteArray; APkOff: Int32): Boolean; static;
     class function ValidatePublicKeyPartialExport(const APk: TCryptoLibByteArray; APkOff: Int32): IPublicPoint; static;
-    class function CreatePreHash(): IDigest; static;
 
-    function GetAlgorithmName: String;
+    function CreatePreHash(): IDigest;
+    function GeneratePublicKey(const &AS: TCryptoLibByteArray; ASOff: Int32): IPublicPoint; overload;
     procedure GeneratePrivateKey(const ARandom: ISecureRandom; const AK: TCryptoLibByteArray);
     procedure GeneratePublicKey(const &AS: TCryptoLibByteArray; ASOff: Int32; APk: TCryptoLibByteArray; APkOff: Int32); overload;
     procedure Sign(const &AS: TCryptoLibByteArray; ASOff: Int32; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32;
@@ -449,11 +451,16 @@ begin
     System.Move(ABuf[AOff], AOut[0], ALen);
 end;
 
-class function TEd25519.CreateDigest(): IDigest;
+function TEd25519.CreateDigest(): IDigest;
+begin
+  Result := TDigestUtilities.GetDigest('SHA-512');
+end;
+
+function TEd25519.CreateAndValidateDigest(): IDigest;
 var
   LD: IDigest;
 begin
-  LD := TDigestUtilities.GetDigest('SHA-512');
+  LD := CreateDigest();
   if LD.GetDigestSize() <> 64 then
     raise EInvalidOperationCryptoLibException.CreateRes(@SDigestSize);
   Result := LD;
@@ -1146,14 +1153,14 @@ begin
   APk[APkOff + PointBytes - 1] := APk[APkOff + PointBytes - 1] or Byte((LData[0] and 1) shl 7);
 end;
 
-class function TEd25519.GeneratePublicKey(const &AS: TCryptoLibByteArray; ASOff: Int32): IPublicPoint;
+function TEd25519.GeneratePublicKey(const &AS: TCryptoLibByteArray; ASOff: Int32): IPublicPoint;
 var
   LD: IDigest;
   LH, LS: TCryptoLibByteArray;
   LP: TPointAccum;
   LQ: TPointAffine;
 begin
-  LD := CreateDigest();
+  LD := CreateAndValidateDigest();
   System.SetLength(LH, 64);
   LD.BlockUpdate(&AS, ASOff, SecretKeySize);
   LD.DoFinal(LH, 0);
@@ -1437,14 +1444,9 @@ begin
   end;
 end;
 
-function TEd25519.GetAlgorithmName: String;
+function TEd25519.CreatePreHash(): IDigest;
 begin
-  Result := 'Ed25519';
-end;
-
-class function TEd25519.CreatePreHash(): IDigest;
-begin
-  Result := CreateDigest();
+  Result := CreateAndValidateDigest();
 end;
 
 procedure TEd25519.GeneratePrivateKey(const ARandom: ISecureRandom; const AK: TCryptoLibByteArray);
@@ -1458,7 +1460,7 @@ var
   LH: TCryptoLibByteArray;
   LS: TCryptoLibByteArray;
 begin
-  LD := CreateDigest();
+  LD := CreateAndValidateDigest();
   System.SetLength(LH, 64);
   LD.BlockUpdate(&AS, ASOff, SecretKeySize);
   LD.DoFinal(LH, 0);
@@ -1539,7 +1541,7 @@ begin
   SignPreHash(&AS, ASOff, APk, APkOff, ACtx, LM, 0, ASig, ASigOff);
 end;
 
-class procedure TEd25519.ImplSign(const AD: IDigest; AH, &AS, APk: TCryptoLibByteArray; APkOff: Int32;
+procedure TEd25519.ImplSign(const AD: IDigest; AH, &AS, APk: TCryptoLibByteArray; APkOff: Int32;
   const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32;
   ASig: TCryptoLibByteArray; ASigOff: Int32);
 var
@@ -1632,7 +1634,7 @@ begin
   Result := VerifyPreHash(ASig, ASigOff, APublicPoint, ACtx, LM, 0);
 end;
 
-class function TEd25519.ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
+function TEd25519.ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
   const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean;
 var
   LR, LS, LA: TCryptoLibByteArray;
@@ -1670,7 +1672,7 @@ begin
   LData := APublicPoint.Data;
   TX25519Field.Negate(LData, LPA.X);
   TX25519Field.Copy(LData, TX25519Field.Size, LPA.Y, 0);
-  LD := CreateDigest();
+  LD := CreateAndValidateDigest();
   System.SetLength(LH, 64);
   if (ACtx <> nil) or (APhflag = $01) then
     Dom2(LD, APhflag, ACtx);
@@ -1691,7 +1693,7 @@ begin
   Result := NormalizeToNeutralElementVar(LPZ);
 end;
 
-class function TEd25519.ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray; APkOff: Int32;
+function TEd25519.ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray; APkOff: Int32;
   const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean;
 var
   LR, LS, LA: TCryptoLibByteArray;
@@ -1730,7 +1732,7 @@ begin
   begin
     Exit(False);
   end;
-  LD := CreateDigest();
+  LD := CreateAndValidateDigest();
   System.SetLength(LH, 64);
   if (ACtx <> nil) or (APhflag = $01) then
     Dom2(LD, APhflag, ACtx);
@@ -1751,13 +1753,13 @@ begin
   Result := NormalizeToNeutralElementVar(LPZ);
 end;
 
-class procedure TEd25519.ImplSign(const &AS: TCryptoLibByteArray; ASOff: Int32; const ACtx: TCryptoLibByteArray; APhflag: Byte;
+procedure TEd25519.ImplSign(const &AS: TCryptoLibByteArray; ASOff: Int32; const ACtx: TCryptoLibByteArray; APhflag: Byte;
   const AM: TCryptoLibByteArray; AMOff: Int32; AMLen: Int32; const ASig: TCryptoLibByteArray; ASigOff: Int32);
 var
   LD: IDigest;
   LH, LS, LPk: TCryptoLibByteArray;
 begin
-  LD := CreateDigest();
+  LD := CreateAndValidateDigest();
   System.SetLength(LH, 64);
   LD.BlockUpdate(&AS, ASOff, SecretKeySize);
   LD.DoFinal(LH, 0);
@@ -1768,14 +1770,14 @@ begin
   ImplSign(LD, LH, LS, LPk, 0, ACtx, APhflag, AM, AMOff, AMLen, ASig, ASigOff);
 end;
 
-class procedure TEd25519.ImplSign(const &AS: TCryptoLibByteArray; ASOff: Int32; const APk: TCryptoLibByteArray; APkOff: Int32;
+procedure TEd25519.ImplSign(const &AS: TCryptoLibByteArray; ASOff: Int32; const APk: TCryptoLibByteArray; APkOff: Int32;
   const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff: Int32; AMLen: Int32;
   const ASig: TCryptoLibByteArray; ASigOff: Int32);
 var
   LD: IDigest;
   LH, LS: TCryptoLibByteArray;
 begin
-  LD := CreateDigest();
+  LD := CreateAndValidateDigest();
   System.SetLength(LH, 64);
   LD.BlockUpdate(&AS, ASOff, SecretKeySize);
   LD.DoFinal(LH, 0);

--- a/CryptoLib/src/Math/EC/Rfc8032/ClpEd448.pas
+++ b/CryptoLib/src/Math/EC/Rfc8032/ClpEd448.pas
@@ -127,28 +127,28 @@ type
   class function CheckPointFullVar(const AP: TCryptoLibByteArray): Boolean; static;
   class function CheckPointVar(const AP: TCryptoLibByteArray): Boolean; static;
   class function CopyBytes(const ABuf: TCryptoLibByteArray; AOff, ALen: Int32): TCryptoLibByteArray; static;
-  class function CreateXof(): IXof; static;
   class function DecodePointVar(const AP: TCryptoLibByteArray; ANegate: Boolean; var AR: TPointAffine): Boolean; static;
   class procedure Dom4(const AD: IXof; APhflag: Byte; const ACtx: TCryptoLibByteArray); static;
   class procedure EncodePoint(var AP: TPointAffine; const AR: TCryptoLibByteArray; AROff: Int32); static;
   class function EncodeResult(var AP: TPointProjective; const AR: TCryptoLibByteArray; AROff: Int32): Int32; static;
   class function ExportPoint(var AP: TPointAffine): IPublicPoint; static;
   class function GetWindow4(const AX: TCryptoLibUInt32Array; AN: Int32): UInt32; static;
-  class procedure ImplSign(const AD: IXof; AH, &AS, APk: TCryptoLibByteArray; APkOff: Int32;
+  function CreateAndValidateXof(): IXof;
+  procedure ImplSign(const AD: IXof; AH, &AS, APk: TCryptoLibByteArray; APkOff: Int32;
     const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32;
-    ASig: TCryptoLibByteArray; ASigOff: Int32); overload; static;
-  class procedure ImplSign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const ACtx: TCryptoLibByteArray;
+    ASig: TCryptoLibByteArray; ASigOff: Int32); overload;
+  procedure ImplSign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const ACtx: TCryptoLibByteArray;
     APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32;
-    ASig: TCryptoLibByteArray; ASigOff: Int32); overload; static;
-  class procedure ImplSign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const APk: TCryptoLibByteArray; APkOff: Int32;
+    ASig: TCryptoLibByteArray; ASigOff: Int32); overload;
+  procedure ImplSign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const APk: TCryptoLibByteArray; APkOff: Int32;
     const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32;
-    ASig: TCryptoLibByteArray; ASigOff: Int32); overload; static;
-  class function ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray;
+    ASig: TCryptoLibByteArray; ASigOff: Int32); overload;
+  function ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray;
     APkOff: Int32; const ACtx: TCryptoLibByteArray; APhflag: Byte;
-    const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean; overload; static;
-  class function ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
+    const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean; overload;
+  function ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
     const ACtx: TCryptoLibByteArray; APhflag: Byte;
-    const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean; overload; static;
+    const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean; overload;
   class procedure InitPointAffine(var AR: TPointAffine); static;
   class procedure InitPointProjective(var AR: TPointProjective); static;
   class procedure InitPointTemp(var AR: TPointTemp); static;
@@ -176,6 +176,8 @@ type
   class procedure ScalarMultOrderVar(var AP: TPointAffine; var AR: TPointProjective); static;
   class procedure ScalarMultStraus225Var(const ANb: TCryptoLibUInt32Array; const ANp: TCryptoLibUInt32Array;
     var AP: TPointAffine; const ANq: TCryptoLibUInt32Array; var AQ: TPointAffine; var AR: TPointProjective); static;
+  strict protected
+    function CreateXof(): IXof; virtual;
   public
   class var
     PrehashSize: Int32;
@@ -184,40 +186,41 @@ type
     SignatureSize: Int32;
 
     class procedure EncodePublicPoint(const APublicPoint: IPublicPoint; const APk: TCryptoLibByteArray; APkOff: Int32); static;
-    class function CreatePrehash(): IXof; static;
 
-    class procedure GeneratePrivateKey(const ARandom: ISecureRandom; const AK: TCryptoLibByteArray); static;
+    function CreatePrehash(): IXof;
 
-    class procedure GeneratePublicKey(const ASk: TCryptoLibByteArray; ASkOff: Int32;
-      APk: TCryptoLibByteArray; APkOff: Int32); overload; static;
+    procedure GeneratePrivateKey(const ARandom: ISecureRandom; const AK: TCryptoLibByteArray);
 
-    class function GeneratePublicKey(const ASk: TCryptoLibByteArray; ASkOff: Int32): IPublicPoint; overload; static;
+    procedure GeneratePublicKey(const ASk: TCryptoLibByteArray; ASkOff: Int32;
+      APk: TCryptoLibByteArray; APkOff: Int32); overload;
+
+    function GeneratePublicKey(const ASk: TCryptoLibByteArray; ASkOff: Int32): IPublicPoint; overload;
 
     class procedure Precompute; static;
 
     class procedure ScalarMultBaseXY(const AK: TCryptoLibByteArray; AKOff: Int32;
       const AX, AY: TCryptoLibUInt32Array); static;
 
-    class procedure Sign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const ACtx: TCryptoLibByteArray;
-      const AM: TCryptoLibByteArray; AMOff, AMLen: Int32; ASig: TCryptoLibByteArray; ASigOff: Int32); overload; static;
+    procedure Sign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const ACtx: TCryptoLibByteArray;
+      const AM: TCryptoLibByteArray; AMOff, AMLen: Int32; ASig: TCryptoLibByteArray; ASigOff: Int32); overload;
 
-    class procedure Sign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const APk: TCryptoLibByteArray; APkOff: Int32;
+    procedure Sign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const APk: TCryptoLibByteArray; APkOff: Int32;
       const ACtx: TCryptoLibByteArray; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32;
-      ASig: TCryptoLibByteArray; ASigOff: Int32); overload; static;
+      ASig: TCryptoLibByteArray; ASigOff: Int32); overload;
 
-    class procedure SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32; const ACtx: TCryptoLibByteArray;
-      const APh: TCryptoLibByteArray; APhOff: Int32; ASig: TCryptoLibByteArray; ASigOff: Int32); overload; static;
+    procedure SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32; const ACtx: TCryptoLibByteArray;
+      const APh: TCryptoLibByteArray; APhOff: Int32; ASig: TCryptoLibByteArray; ASigOff: Int32); overload;
 
-    class procedure SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32; const APk: TCryptoLibByteArray;
+    procedure SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32; const APk: TCryptoLibByteArray;
       APkOff: Int32; const ACtx: TCryptoLibByteArray; const APh: TCryptoLibByteArray; APhOff: Int32;
-      ASig: TCryptoLibByteArray; ASigOff: Int32); overload; static;
+      ASig: TCryptoLibByteArray; ASigOff: Int32); overload;
 
-    class procedure SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32; const ACtx: TCryptoLibByteArray;
-      const APh: IXof; ASig: TCryptoLibByteArray; ASigOff: Int32); overload; static;
+    procedure SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32; const ACtx: TCryptoLibByteArray;
+      const APh: IXof; ASig: TCryptoLibByteArray; ASigOff: Int32); overload;
 
-    class procedure SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32; const APk: TCryptoLibByteArray;
+    procedure SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32; const APk: TCryptoLibByteArray;
       APkOff: Int32; const ACtx: TCryptoLibByteArray; const APh: IXof;
-      ASig: TCryptoLibByteArray; ASigOff: Int32); overload; static;
+      ASig: TCryptoLibByteArray; ASigOff: Int32); overload;
 
     class function ValidatePublicKeyFull(const APk: TCryptoLibByteArray; APkOff: Int32): Boolean; static;
 
@@ -227,23 +230,23 @@ type
 
     class function ValidatePublicKeyPartialExport(const APk: TCryptoLibByteArray; APkOff: Int32): IPublicPoint; static;
 
-    class function Verify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray;
-      APkOff: Int32; const ACtx: TCryptoLibByteArray; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean; overload; static;
+    function Verify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray;
+      APkOff: Int32; const ACtx: TCryptoLibByteArray; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean; overload;
 
-    class function Verify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
-      const ACtx: TCryptoLibByteArray; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean; overload; static;
+    function Verify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
+      const ACtx: TCryptoLibByteArray; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean; overload;
 
-    class function VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray;
-      APkOff: Int32; const ACtx: TCryptoLibByteArray; const APh: TCryptoLibByteArray; APhOff: Int32): Boolean; overload; static;
+    function VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray;
+      APkOff: Int32; const ACtx: TCryptoLibByteArray; const APh: TCryptoLibByteArray; APhOff: Int32): Boolean; overload;
 
-    class function VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
-      const ACtx: TCryptoLibByteArray; const APh: TCryptoLibByteArray; APhOff: Int32): Boolean; overload; static;
+    function VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
+      const ACtx: TCryptoLibByteArray; const APh: TCryptoLibByteArray; APhOff: Int32): Boolean; overload;
 
-    class function VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray;
-      APkOff: Int32; const ACtx: TCryptoLibByteArray; const APh: IXof): Boolean; overload; static;
+    function VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray;
+      APkOff: Int32; const ACtx: TCryptoLibByteArray; const APh: IXof): Boolean; overload;
 
-    class function VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
-      const ACtx: TCryptoLibByteArray; const APh: IXof): Boolean; overload; static;
+    function VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
+      const ACtx: TCryptoLibByteArray; const APh: IXof): Boolean; overload;
   end;
 
 implementation
@@ -462,12 +465,17 @@ begin
   System.Move(ABuf[AOff], Result[0], ALen);
 end;
 
-class function TEd448.CreatePrehash(): IXof;
+function TEd448.CreateAndValidateXof(): IXof;
 begin
   Result := CreateXof();
 end;
 
-class function TEd448.CreateXof(): IXof;
+function TEd448.CreatePrehash(): IXof;
+begin
+  Result := CreateAndValidateXof();
+end;
+
+function TEd448.CreateXof(): IXof;
 begin
   Result := TDigestUtilities.GetDigest('SHAKE256-512') as IXof;
 end;
@@ -1286,7 +1294,7 @@ begin
   PointDouble(AR, LT);
 end;
 
-class procedure TEd448.ImplSign(const AD: IXof; AH, &AS, APk: TCryptoLibByteArray; APkOff: Int32;
+procedure TEd448.ImplSign(const AD: IXof; AH, &AS, APk: TCryptoLibByteArray; APkOff: Int32;
   const ACtx: TCryptoLibByteArray; APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32;
   ASig: TCryptoLibByteArray; ASigOff: Int32);
 var
@@ -1314,7 +1322,7 @@ begin
   System.Move(LSS[0], ASig[ASigOff + PointBytes], ScalarBytes);
 end;
 
-class procedure TEd448.ImplSign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const ACtx: TCryptoLibByteArray;
+procedure TEd448.ImplSign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const ACtx: TCryptoLibByteArray;
   APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32;
   ASig: TCryptoLibByteArray; ASigOff: Int32);
 var
@@ -1324,7 +1332,7 @@ begin
   if not CheckContextVar(ACtx) then
     raise EArgumentCryptoLibException.CreateRes(@SInvalidCtx);
 
-  LD := CreateXof();
+  LD := CreateAndValidateXof();
   System.SetLength(LH, ScalarBytes * 2);
   LD.BlockUpdate(ASk, ASkOff, SecretKeySize);
   LD.OutputFinal(LH, 0, System.Length(LH));
@@ -1338,7 +1346,7 @@ begin
   ImplSign(LD, LH, LS, LPk, 0, ACtx, APhflag, AM, AMOff, AMLen, ASig, ASigOff);
 end;
 
-class procedure TEd448.ImplSign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const APk: TCryptoLibByteArray;
+procedure TEd448.ImplSign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const APk: TCryptoLibByteArray;
   APkOff: Int32; const ACtx: TCryptoLibByteArray; APhflag: Byte;
   const AM: TCryptoLibByteArray; AMOff, AMLen: Int32; ASig: TCryptoLibByteArray; ASigOff: Int32);
 var
@@ -1348,7 +1356,7 @@ begin
   if not CheckContextVar(ACtx) then
     raise EArgumentCryptoLibException.CreateRes(@SInvalidCtx);
 
-  LD := CreateXof();
+  LD := CreateAndValidateXof();
   System.SetLength(LH, ScalarBytes * 2);
   LD.BlockUpdate(ASk, ASkOff, SecretKeySize);
   LD.OutputFinal(LH, 0, System.Length(LH));
@@ -1359,7 +1367,7 @@ begin
   ImplSign(LD, LH, LS, APk, APkOff, ACtx, APhflag, AM, AMOff, AMLen, ASig, ASigOff);
 end;
 
-class function TEd448.ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32;
+function TEd448.ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32;
   const APk: TCryptoLibByteArray; APkOff: Int32; const ACtx: TCryptoLibByteArray;
   APhflag: Byte; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean;
 var
@@ -1411,7 +1419,7 @@ begin
     Exit;
   end;
 
-  LD := CreateXof();
+  LD := CreateAndValidateXof();
   System.SetLength(LH, ScalarBytes * 2);
 
   Dom4(LD, APhflag, ACtx);
@@ -1438,7 +1446,7 @@ begin
   Result := NormalizeToNeutralElementVar(LPZ);
 end;
 
-class function TEd448.ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32;
+function TEd448.ImplVerify(const ASig: TCryptoLibByteArray; ASigOff: Int32;
   const APublicPoint: IPublicPoint; const ACtx: TCryptoLibByteArray; APhflag: Byte;
   const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean;
 var
@@ -1483,7 +1491,7 @@ begin
   System.SetLength(LA, PublicKeySize);
   EncodePublicPoint(APublicPoint, LA, 0);
 
-  LD := CreateXof();
+  LD := CreateAndValidateXof();
   System.SetLength(LH, ScalarBytes * 2);
 
   Dom4(LD, APhflag, ACtx);
@@ -1510,20 +1518,20 @@ begin
   Result := NormalizeToNeutralElementVar(LPZ);
 end;
 
-class procedure TEd448.GeneratePrivateKey(const ARandom: ISecureRandom; const AK: TCryptoLibByteArray);
+procedure TEd448.GeneratePrivateKey(const ARandom: ISecureRandom; const AK: TCryptoLibByteArray);
 begin
   if System.Length(AK) <> SecretKeySize then
     raise EArgumentCryptoLibException.CreateRes(@SInvalidCtx);
   ARandom.NextBytes(AK);
 end;
 
-class procedure TEd448.GeneratePublicKey(const ASk: TCryptoLibByteArray; ASkOff: Int32;
+procedure TEd448.GeneratePublicKey(const ASk: TCryptoLibByteArray; ASkOff: Int32;
   APk: TCryptoLibByteArray; APkOff: Int32);
 var
   LD: IXof;
   LH, LS: TCryptoLibByteArray;
 begin
-  LD := CreateXof();
+  LD := CreateAndValidateXof();
   System.SetLength(LH, ScalarBytes * 2);
   LD.BlockUpdate(ASk, ASkOff, SecretKeySize);
   LD.OutputFinal(LH, 0, System.Length(LH));
@@ -1533,14 +1541,14 @@ begin
   ScalarMultBaseEncoded(LS, APk, APkOff);
 end;
 
-class function TEd448.GeneratePublicKey(const ASk: TCryptoLibByteArray; ASkOff: Int32): IPublicPoint;
+function TEd448.GeneratePublicKey(const ASk: TCryptoLibByteArray; ASkOff: Int32): IPublicPoint;
 var
   LD: IXof;
   LH, LS: TCryptoLibByteArray;
   LP: TPointProjective;
   LQ: TPointAffine;
 begin
-  LD := CreateXof();
+  LD := CreateAndValidateXof();
   System.SetLength(LH, ScalarBytes * 2);
   LD.BlockUpdate(ASk, ASkOff, SecretKeySize);
   LD.OutputFinal(LH, 0, System.Length(LH));
@@ -1560,34 +1568,34 @@ begin
   Result := ExportPoint(LQ);
 end;
 
-class procedure TEd448.Sign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const ACtx: TCryptoLibByteArray;
+procedure TEd448.Sign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const ACtx: TCryptoLibByteArray;
   const AM: TCryptoLibByteArray; AMOff, AMLen: Int32; ASig: TCryptoLibByteArray; ASigOff: Int32);
 begin
   ImplSign(ASk, ASkOff, ACtx, $00, AM, AMOff, AMLen, ASig, ASigOff);
 end;
 
-class procedure TEd448.Sign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const APk: TCryptoLibByteArray;
+procedure TEd448.Sign(const ASk: TCryptoLibByteArray; ASkOff: Int32; const APk: TCryptoLibByteArray;
   APkOff: Int32; const ACtx: TCryptoLibByteArray; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32;
   ASig: TCryptoLibByteArray; ASigOff: Int32);
 begin
   ImplSign(ASk, ASkOff, APk, APkOff, ACtx, $00, AM, AMOff, AMLen, ASig, ASigOff);
 end;
 
-class procedure TEd448.SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32;
+procedure TEd448.SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32;
   const ACtx: TCryptoLibByteArray; const APh: TCryptoLibByteArray; APhOff: Int32;
   ASig: TCryptoLibByteArray; ASigOff: Int32);
 begin
   ImplSign(ASk, ASkOff, ACtx, $01, APh, APhOff, PrehashSize, ASig, ASigOff);
 end;
 
-class procedure TEd448.SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32;
+procedure TEd448.SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32;
   const APk: TCryptoLibByteArray; APkOff: Int32; const ACtx: TCryptoLibByteArray;
   const APh: TCryptoLibByteArray; APhOff: Int32; ASig: TCryptoLibByteArray; ASigOff: Int32);
 begin
   ImplSign(ASk, ASkOff, APk, APkOff, ACtx, $01, APh, APhOff, PrehashSize, ASig, ASigOff);
 end;
 
-class procedure TEd448.SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32;
+procedure TEd448.SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32;
   const ACtx: TCryptoLibByteArray; const APh: IXof; ASig: TCryptoLibByteArray; ASigOff: Int32);
 var
   LM: TCryptoLibByteArray;
@@ -1598,7 +1606,7 @@ begin
   ImplSign(ASk, ASkOff, ACtx, $01, LM, 0, System.Length(LM), ASig, ASigOff);
 end;
 
-class procedure TEd448.SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32;
+procedure TEd448.SignPrehash(const ASk: TCryptoLibByteArray; ASkOff: Int32;
   const APk: TCryptoLibByteArray; APkOff: Int32; const ACtx: TCryptoLibByteArray;
   const APh: IXof; ASig: TCryptoLibByteArray; ASigOff: Int32);
 var
@@ -1702,33 +1710,33 @@ begin
   Result := ExportPoint(LPA);
 end;
 
-class function TEd448.Verify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray;
+function TEd448.Verify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APk: TCryptoLibByteArray;
   APkOff: Int32; const ACtx: TCryptoLibByteArray; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean;
 begin
   Result := ImplVerify(ASig, ASigOff, APk, APkOff, ACtx, $00, AM, AMOff, AMLen);
 end;
 
-class function TEd448.Verify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
+function TEd448.Verify(const ASig: TCryptoLibByteArray; ASigOff: Int32; const APublicPoint: IPublicPoint;
   const ACtx: TCryptoLibByteArray; const AM: TCryptoLibByteArray; AMOff, AMLen: Int32): Boolean;
 begin
   Result := ImplVerify(ASig, ASigOff, APublicPoint, ACtx, $00, AM, AMOff, AMLen);
 end;
 
-class function TEd448.VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32;
+function TEd448.VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32;
   const APk: TCryptoLibByteArray; APkOff: Int32; const ACtx: TCryptoLibByteArray;
   const APh: TCryptoLibByteArray; APhOff: Int32): Boolean;
 begin
   Result := ImplVerify(ASig, ASigOff, APk, APkOff, ACtx, $01, APh, APhOff, PrehashSize);
 end;
 
-class function TEd448.VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32;
+function TEd448.VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32;
   const APublicPoint: IPublicPoint; const ACtx: TCryptoLibByteArray;
   const APh: TCryptoLibByteArray; APhOff: Int32): Boolean;
 begin
   Result := ImplVerify(ASig, ASigOff, APublicPoint, ACtx, $01, APh, APhOff, PrehashSize);
 end;
 
-class function TEd448.VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32;
+function TEd448.VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32;
   const APk: TCryptoLibByteArray; APkOff: Int32; const ACtx: TCryptoLibByteArray; const APh: IXof): Boolean;
 var
   LM: TCryptoLibByteArray;
@@ -1739,7 +1747,7 @@ begin
   Result := ImplVerify(ASig, ASigOff, APk, APkOff, ACtx, $01, LM, 0, System.Length(LM));
 end;
 
-class function TEd448.VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32;
+function TEd448.VerifyPrehash(const ASig: TCryptoLibByteArray; ASigOff: Int32;
   const APublicPoint: IPublicPoint; const ACtx: TCryptoLibByteArray; const APh: IXof): Boolean;
 var
   LM: TCryptoLibByteArray;


### PR DESCRIPTION
## Summary

Enables digest customization for Ed25519 and Ed448 by converting the
API from static class methods to instance methods with virtual factory
methods. Callers can subclass and override `CreateDigest()` (Ed25519)
or `CreateXof()` (Ed448) to substitute alternative hash functions.

## Approach

Rather than adding `IDigest` parameter overloads to every public method
(which would balloon the API, especially for prehash variants), this PR
takes a cleaner architectural approach:

**TEd25519:**
- `CreateDigest(): IDigest` moved to `strict protected virtual`
- `CreateAndValidateDigest()` wrapper added for internal use
- All public methods (`Sign`, `Verify`, `GeneratePublicKey`,
  `SignPrehash`, `VerifyPrehash`, `CreatePrehash`) converted from
  `class static` to instance methods
- Internal `ImplSign`/`ImplVerify` converted from `class static`
  to instance methods
- Heavy math (point arithmetic, precomputation, scalar ops) remains
  `class static` — shared across all instances at zero cost

**TEd448:**
- Same pattern: `CreateXof(): IXof` is now `strict protected virtual`
- All public methods converted from `class static` to instance
- `CreateAndValidateXof()` wrapper for internal use

**Call sites updated:**
- `ClpEd25519Parameters`, `ClpEd448Parameters`: now instantiate
  `TEd25519`/`TEd448` to call instance methods
- `ClpEd25519PhSigner`, `ClpEd448PhSigner`: same
- All tests updated to use instances

## Usage
```pascal
type
  TEd25519Blake2b = class(TEd25519)
  strict protected
    function CreateDigest(): IDigest; override;
  end;

function TEd25519Blake2b.CreateDigest(): IDigest;
begin
  Result := TDigestUtilities.GetDigest('BLAKE2B-512');
end;

// Usage
var Ed: TEd25519;
begin
  Ed := TEd25519Blake2b.Create();
  try
    Ed.GeneratePublicKey(sk, 0, pk, 0);
    Ed.Sign(sk, 0, msg, 0, Length(msg), sig, 0);
    Ed.SignPrehash(sk, 0, ctx, ph, 0, sig, 0); // prehash works too
    valid := Ed.Verify(sig, 0, pk, 0, msg, 0, Length(msg));
  finally
    Ed.Free;
  end;
end;
```

## Tests added

- **Ed25519 Blake2b-512 vectors**: 5 test vectors with known-good
  sk/pk/msg/sig values for Ed25519 with Blake2b-512
- **Ed25519 SHA-512 equivalence**: verifies that `TEd25519Sha512`
  subclass produces identical results to default `TEd25519` across
  keygen, sign, verify, and prehash flows
- **Ed448 SHAKE256 equivalence**: verifies that `TEd448Shake256`
  subclass produces identical results to default `TEd448` across
  all flows including prehash

## Important notes

- Signatures produced with a non-default digest are **not** standard
  EdDSA (RFC 8032) and will not interoperate with standard
  implementations
- Callers must use the same digest consistently across key generation,
  signing, and verification