### PR TITLE
Fixes, so I can compile CryptoLib4Pascal with fpc 3.2-fixes

### DIFF
--- a/CryptoLib/src/Crypto/Generators/ClpArgon2ParametersGenerator.pas
+++ b/CryptoLib/src/Crypto/Generators/ClpArgon2ParametersGenerator.pas
@@ -239,12 +239,12 @@ begin
   case argon2Version of
     TCryptoLibArgon2Version.Argon2Version10:
       begin
-        LArgon2Version := TArgon2Version.a2vARGON2_VERSION_10;
+        LArgon2Version := TArgon2Version.VERSION10;
       end;
 
     TCryptoLibArgon2Version.Argon2Version13:
       begin
-        LArgon2Version := TArgon2Version.a2vARGON2_VERSION_13;
+        LArgon2Version := TArgon2Version.VERSION13;
       end
   else
     begin

--- a/CryptoLib/src/Utils/Encoders/ClpEncoders.pas
+++ b/CryptoLib/src/Utils/Encoders/ClpEncoders.pas
@@ -58,6 +58,8 @@ type
 
 implementation
 
+uses SbpBase16Alphabet, {SbpIBase16,} SbpICodingAlphabet;
+
 { TBase58 }
 
 class function TBase58.Decode(const Input: String): TCryptoLibByteArray;
@@ -86,17 +88,27 @@ end;
 
 class function THex.Decode(const Hex: String): TCryptoLibByteArray;
 begin
-  result := SbpBase16.TBase16.Decode(Hex);
+  with SbpBase16.TBase16.Create(TBase16Alphabet.Create('0123456789ABCDEF') as ICodingAlphabet) do
+    try;
+      result := Decode(Hex);
+    finally
+      Free;
+    end;
 end;
 
 class function THex.Encode(const Input: TCryptoLibByteArray;
   UpperCase: Boolean): String;
+var
+  Base16: SbpBase16.TBase16;
 begin
-  case UpperCase of
-    True:
-      result := SbpBase16.TBase16.EncodeUpper(Input);
-    False:
-      result := SbpBase16.TBase16.EncodeLower(Input);
+  if UpperCase then
+    Base16 := SbpBase16.TBase16.Create(TBase16Alphabet.Create('0123456789ABCDEF') as ICodingAlphabet)
+  else
+    Base16 := SbpBase16.TBase16.Create(TBase16Alphabet.Create('0123456789abcdef') as ICodingAlphabet);
+  try
+    result := Base16.Encode(Input)
+  finally
+    Base16.Free;
   end;
 end;
 


### PR DESCRIPTION
Hello,

I tried to compile CryptoLib4Pascal with the current state of fpc 3.2-fixes. Unfortunately I had to do some modifications, which I attached in this pull request.

Best regards,

Jan