### PR TITLE
refactor: move dynamic import resolution to unit initialization

### DIFF
--- a/CryptoLib/src/Misc/ClpArmHwCapProvider.pas
+++ b/CryptoLib/src/Misc/ClpArmHwCapProvider.pas
@@ -108,10 +108,9 @@ type
   strict private
   class var
     FGetAuxVal: TGetAuxValFunc;
-    FResolved: Boolean;
 
-  strict private
-    class procedure ResolveOnce(); static;
+  private
+    class procedure ResolveDynamicImports(); static;
 
   public
     class function GetHwCap(): UInt64; static;
@@ -126,10 +125,9 @@ type
   strict private
   class var
     FElfAuxInfo: TElfAuxInfoFunc;
-    FResolved: Boolean;
 
-  strict private
-    class procedure ResolveOnce(); static;
+  private
+    class procedure ResolveDynamicImports(); static;
 
   public
     class function GetHwCap(): UInt64; static;
@@ -155,15 +153,11 @@ implementation
 
 {$IF DEFINED(CRYPTOLIB_LINUX) OR DEFINED(CRYPTOLIB_ANDROID)}
 
-class procedure TArmHwCapProvider.ResolveOnce();
+class procedure TArmHwCapProvider.ResolveDynamicImports();
 var
   LHandle: Pointer;
 begin
-  if FResolved then
-    Exit;
-
   FGetAuxVal := nil;
-  FResolved := True;
 
   LHandle := dlopen(nil, RTLD_NOW);
   if LHandle = nil then
@@ -179,7 +173,6 @@ end;
 
 class function TArmHwCapProvider.GetHwCap(): UInt64;
 begin
-  ResolveOnce();
   if System.Assigned(FGetAuxVal) then
     Result := FGetAuxVal(AT_HWCAP)
   else
@@ -188,7 +181,6 @@ end;
 
 class function TArmHwCapProvider.GetHwCap2(): UInt64;
 begin
-  ResolveOnce();
   if System.Assigned(FGetAuxVal) then
     Result := FGetAuxVal(AT_HWCAP2)
   else
@@ -201,15 +193,11 @@ end;
 
 {$IF DEFINED(CRYPTOLIB_BSD)}
 
-class procedure TArmHwCapProvider.ResolveOnce();
+class procedure TArmHwCapProvider.ResolveDynamicImports();
 var
   LHandle: Pointer;
 begin
-  if FResolved then
-    Exit;
-
   FElfAuxInfo := nil;
-  FResolved := True;
 
   LHandle := dlopen(nil, RTLD_NOW);
   if LHandle = nil then
@@ -232,7 +220,6 @@ class function TArmHwCapProvider.GetHwCap(): UInt64;
 var
   LValue: UInt64;
 begin
-  ResolveOnce();
   if System.Assigned(FElfAuxInfo) then
   begin
     LValue := 0;
@@ -249,7 +236,6 @@ class function TArmHwCapProvider.GetHwCap2(): UInt64;
 var
   LValue: UInt64;
 begin
-  ResolveOnce();
   if System.Assigned(FElfAuxInfo) then
   begin
     LValue := 0;
@@ -274,6 +260,11 @@ begin
 end;
 
 {$IFEND} // CRYPTOLIB_MSWINDOWS
+
+{$IF DEFINED(CRYPTOLIB_LINUX) OR DEFINED(CRYPTOLIB_ANDROID) OR DEFINED(CRYPTOLIB_BSD)}
+initialization
+  TArmHwCapProvider.ResolveDynamicImports;
+{$IFEND}
 
 {$IFEND} // CRYPTOLIB_ARM
 

--- a/CryptoLib/src/Misc/ClpDarwinSysCtl.pas
+++ b/CryptoLib/src/Misc/ClpDarwinSysCtl.pas
@@ -47,11 +47,11 @@ type
   strict private
   class var
     FSysCtlByName: TSysCtlByNameFunc;
-    FResolved: Boolean;
+
+  private
+    class procedure ResolveDynamicImports(); static;
 
   strict private
-    class procedure ResolveOnce(); static;
-
     /// <summary>
     /// Queries a single sysctl key. Returns True if the key exists and
     /// its integer value is >= 1.
@@ -79,15 +79,11 @@ implementation
 
 { TDarwinSysCtl }
 
-class procedure TDarwinSysCtl.ResolveOnce();
+class procedure TDarwinSysCtl.ResolveDynamicImports();
 var
   LHandle: Pointer;
 begin
-  if FResolved then
-    Exit;
-
   FSysCtlByName := nil;
-  FResolved := True;
 
   LHandle := dlopen(nil, RTLD_NOW);
   if LHandle = nil then
@@ -123,8 +119,6 @@ end;
 class function TDarwinSysCtl.HasFeature(const AModernName: PAnsiChar;
   const ALegacyName: PAnsiChar): Boolean;
 begin
-  ResolveOnce();
-
   if not System.Assigned(FSysCtlByName) then
   begin
     Result := False;
@@ -138,6 +132,9 @@ begin
   if (not Result) and (ALegacyName <> nil) then
     Result := QueryKey(ALegacyName);
 end;
+
+initialization
+  TDarwinSysCtl.ResolveDynamicImports;
 
 {$IFEND} // CRYPTOLIB_MACOS OR CRYPTOLIB_IOS
 {$IFEND} // CRYPTOLIB_ARM


### PR DESCRIPTION
## Summary

Move dynamic library symbol resolution (`dlopen`/`dlsym`) from lazy
per-call resolution to one-time unit initialization for ARM hardware
capability detection on Linux, Android, BSD, and macOS (Darwin).

## Changes

### ClpArmHwCapProvider.pas (Linux/Android and BSD)

- Renamed `ResolveOnce` to `ResolveDynamicImports` and removed the
  manual `FResolved` boolean guard, since the initialization section
  guarantees single execution.
- Removed `ResolveOnce` calls from `GetHwCap` and `GetHwCap2` — the
  function pointers are already resolved by the time any caller can
  reach them.
- Added an `initialization` section that calls
  `ResolveDynamicImports` at unit load time.
- Relaxed visibility from `strict private` to `private` so the
  initialization section can access the method.

### ClpDarwinSysCtl.pas (macOS/iOS)

- Same refactor: renamed `ResolveOnce` to `ResolveDynamicImports`,
  removed the `FResolved` guard, removed the call from `HasFeature`,
  and moved resolution to an `initialization` section.
- Retained `strict private` on `QueryKey` and other internal members;
  only `ResolveDynamicImports` was relaxed to `private`.

## Rationale

The previous pattern resolved imports lazily on first use with a
boolean guard. This worked but added a branch to every call of
`GetHwCap`, `GetHwCap2`, and `HasFeature`. Since these function
pointers never change after resolution, performing the `dlopen`/`dlsym`
once at unit initialization is simpler, removes the redundant flag
field, and eliminates repeated nil-check overhead on the hot path.