### PR TITLE
Fix RFC 4514 DN parsing and enforce country code length

### DIFF
--- a/CryptoLib.Tests/src/Asn1/X509/X509NameTests.pas
+++ b/CryptoLib.Tests/src/Asn1/X509/X509NameTests.pas
@@ -30,6 +30,8 @@ uses
 {$ELSE}
   TestFramework,
 {$ENDIF FPC}
+  ClpIAsn1Core,
+  ClpIAsn1Objects,
   ClpX509Asn1Objects,
   ClpIX509Asn1Objects,
   ClpCryptoLibTypes,
@@ -54,10 +56,17 @@ type
     procedure TestRegeneration;
     procedure TestHexRegeneration;
     procedure TestEquality;
+    procedure TestRfc4514UnescapedEqualsInAttributeValue;
+    procedure TestInvalidHexDnFailsAtConstruction;
+    procedure TestCountryCodeLength;
 
   end;
 
 implementation
+
+uses
+  ClpAsn1Objects,
+  ClpX509DefaultEntryConverter;
 
 { TX509NameTest }
 
@@ -74,7 +83,7 @@ begin
   FSubjects[7] := 'CN=*.canal-plus.com,OU=Provided by TBS INTERNET https://www.tbs-certificats.com/,OU=\ CANAL \+,O=CANAL\+DISTRIBUTION,L=issy les moulineaux,ST=Hauts de Seine,C=FR';
   FSubjects[8] := 'O=CryptoLib4Pascal,CN=www.cryptolib4pascal.org\ ';
   FSubjects[9] := 'O=CryptoLib4Pascal,CN=c:\\fred\\bob';
-  FSubjects[10] := 'C=0,O=1,OU=2,T=3,CN=4,SERIALNUMBER=5,STREET=6,SERIALNUMBER=7,L=8,ST=9,SURNAME=10,GIVENNAME=11,INITIALS=12,' +
+  FSubjects[10] := 'C=AU,O=1,OU=2,T=3,CN=4,SERIALNUMBER=5,STREET=6,SERIALNUMBER=7,L=8,ST=9,SURNAME=10,GIVENNAME=11,INITIALS=12,' +
     'GENERATION=13,UniqueIdentifier=14,BusinessCategory=15,PostalCode=16,DN=17,Pseudonym=18,PlaceOfBirth=19,' +
     'Gender=20,CountryOfCitizenship=21,CountryOfResidence=22,NameAtBirth=23,PostalAddress=24,2.5.4.54=25,' +
     'TelephoneNumber=26,Name=27,E=28,unstructuredName=29,unstructuredAddress=30,E=31,DC=32,UID=33';
@@ -184,6 +193,122 @@ begin
   LName1 := TX509Name.Create('CN=  the     legion ');
   LName2 := TX509Name.Create('CN=The Legion');
   CheckTrue(LName1.Equivalent(LName2), 'Equality test 5 failed');
+end;
+
+procedure TX509NameTest.TestRfc4514UnescapedEqualsInAttributeValue;
+var
+  LSubjects: array [0 .. 3] of String;
+  LExpectedValues: array [0 .. 3] of String;
+  I: Int32;
+  LName: IX509Name;
+begin
+  // RFC 4514 allows '=' in attributeValue; only the first '=' separates type from value.
+  LSubjects[0] := 'CN=foo=bar';
+  LSubjects[1] := 'CN==^_^=';
+  LSubjects[2] := 'CN=a=b=c';
+  LSubjects[3] := 'CN=\=^_^\=';
+
+  LExpectedValues[0] := 'foo=bar';
+  LExpectedValues[1] := '=^_^=';
+  LExpectedValues[2] := 'a=b=c';
+  LExpectedValues[3] := '=^_^=';
+
+  for I := Low(LSubjects) to High(LSubjects) do
+  begin
+    LName := TX509Name.Create(LSubjects[I]);
+    CheckEquals(LExpectedValues[I], LName.GetValueList()[0],
+      'unexpected CN value for ' + LSubjects[I]);
+  end;
+
+  try
+    TX509Name.Create('CN');
+    Fail('malformed DN without ''='' should raise');
+  except
+    on EArgumentCryptoLibException do
+      ; // expected
+  end;
+end;
+
+procedure TX509NameTest.TestInvalidHexDnFailsAtConstruction;
+begin
+  try
+    TX509Name.Create('CN=#GG');
+    Fail('invalid hex-encoded DN value should raise during construction');
+  except
+    on E: ECryptoLibException do
+      CheckTrue(Pos('can''t recode value', E.Message) > 0,
+        'unexpected exception message: ' + E.Message);
+  end;
+end;
+
+procedure TX509NameTest.TestCountryCodeLength;
+var
+  LConverter: TX509DefaultEntryConverter;
+  LCountryOids: array [0 .. 1] of IDerObjectIdentifier;
+  LBadValues: array [0 .. 2] of String;
+  I, J: Int32;
+  LParsed: IX509Name;
+  LOid: IDerObjectIdentifier;
+begin
+  CheckTrue(TX509Name.DefaultLookup.TryGetValue('jurisdictionCountry', LOid),
+    'DefaultLookup should contain jurisdictionCountry');
+  CheckTrue(LOid.Equals(TX509Name.JurisdictionC),
+    'DefaultLookup[jurisdictionCountry] should be JurisdictionC');
+  CheckTrue(TX509Name.DefaultLookup.TryGetValue('jurisdictionState', LOid),
+    'DefaultLookup should contain jurisdictionState');
+  CheckTrue(LOid.Equals(TX509Name.JurisdictionST),
+    'DefaultLookup[jurisdictionState] should be JurisdictionST');
+  CheckTrue(TX509Name.DefaultLookup.TryGetValue('jurisdictionLocality', LOid),
+    'DefaultLookup should contain jurisdictionLocality');
+  CheckTrue(LOid.Equals(TX509Name.JurisdictionL),
+    'DefaultLookup[jurisdictionLocality] should be JurisdictionL');
+
+  LCountryOids[0] := TX509Name.C;
+  LCountryOids[1] := TX509Name.JurisdictionC;
+  LBadValues[0] := 'USA';
+  LBadValues[1] := 'U';
+  LBadValues[2] := '';
+
+  LConverter := TX509DefaultEntryConverter.Create();
+  try
+    LConverter.GetConvertedValue(TX509Name.C, 'US');
+    LConverter.GetConvertedValue(TX509Name.JurisdictionC, 'US');
+
+    for I := Low(LCountryOids) to High(LCountryOids) do
+      for J := Low(LBadValues) to High(LBadValues) do
+      begin
+        try
+          LConverter.GetConvertedValue(LCountryOids[I], LBadValues[J]);
+          Fail(Format('country code attribute %s accepted ''%s''',
+            [LCountryOids[I].Id, LBadValues[J]]));
+        except
+          on EArgumentCryptoLibException do
+            ; // expected
+        end;
+      end;
+  finally
+    LConverter.Free;
+  end;
+
+  LParsed := TX509Name.Create('C=AU');
+
+  try
+    TX509Name.Create('C=USA');
+    Fail('X509Name(''C=USA'') accepted 3-character country code');
+  except
+    on EArgumentCryptoLibException do
+      ; // expected
+  end;
+
+  // Lenient parse of existing DER with non-conforming C length (do not block reading wild certs).
+  LParsed := TX509Name.GetInstance(
+    TDerSequence.FromElement(
+      TDerSet.FromElement(
+        TDerSequence.Create([
+          TX509Name.C,
+          TDerPrintableString.Create('USA') as IDerPrintableString]) as IDerSequence)));
+  CheckEquals('USA', LParsed.GetValueList(TX509Name.C)[0],
+    'lenient parse of 3-character C failed');
 end;
 
 initialization

--- a/CryptoLib.Tests/src/Others/CertTests.pas
+++ b/CryptoLib.Tests/src/Others/CertTests.pas
@@ -109,6 +109,7 @@ type
     procedure CheckSelfSignedCertificate(AId: Int32; const ACertBytes: TCryptoLibByteArray);
     procedure CheckNameCertificate(AId: Int32; const ACertBytes: TCryptoLibByteArray);
     procedure CheckCrl(AId: Int32; const ACrlBytes: TCryptoLibByteArray);
+    procedure CheckCertificateCriticalExtendedKeyUsage;
     procedure CheckCreation1;
     procedure CheckCreation2;
     procedure CheckCreation3;
@@ -145,6 +146,7 @@ type
     procedure TestSelfSignedProbSelfSignedCert;
     procedure TestCrl1;
     procedure TestEmptyDNCert;
+    procedure TestCertificateCriticalExtendedKeyUsage;
     procedure TestCreation1;
     procedure TestCreation2;
     procedure TestCreation3;
@@ -173,6 +175,38 @@ type
   end;
 
 const
+
+  /// <summary>PEM-less Base64 DER end-entity certificate with critical extendedKeyUsage (RFC 5280 section 4.2.1.12).</summary>
+  CRITICAL_EXTENDED_KEY_USAGE_CERT_B64 =
+    'MIIFaTCCA1GgAwIBAgIIAUwqL4ejTt0wDQYJKoZIhvcNAQELBQAwWDELMAkGA1UE' +
+    'BhMCQ0gxEDAOBgNVBAcTB1p1ZXJpY2gxGDAWBgNVBAoTD0JvYXJkZXJab25lLm5l' +
+    'dDEdMBsGA1UEAxMUQm9hcmRlclpvbmUgVHJ1c3QgQ0EwHhcNMTgxMjE5MjExOTI5' +
+    'WhcNMjIxMjE5MjExOTI5WjB4MQswCQYDVQQGEwJDSDEQMA4GA1UEBxMHWnVlcmlj' +
+    'aDEYMBYGA1UEChMPQm9hcmRlclpvbmUubmV0MRowGAYDVQQDExFRdWFsaXR5IEFz' +
+    'c3VyYW5jZTEhMB8GCSqGSIb3DQEJARYScWFAYm9hcmRlcnpvbmUubmV0MIIBIjAN' +
+    'BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu5Y1gLUCfCP+n52o8bDHDCwvj1dW' +
+    'yc8yqaj/9RiyPn+je2hWRkYCe7gOuwz5KTFq6j7qXJ53aElTeJJoXA+DRy3nlmPY' +
+    'x5xBVnb8eONtJdLlIjXpF5Hz+NDNM9neD1Qaq/cEw+zBMubsHISjSiIc5BYRL9LE' +
+    'rU/l7LV0k1sLOIKF6YzBarLhl+QJLqNyl5mLAjlOW5SV8n5Vu0BM4jOSe998xsR2' +
+    'JR1fOfxJdIE6YVe4AfpoCmlMhy6la5Eg1pC4nS3TB8uKHvrYrjf0xvmNB0B+zyUO' +
+    'qJ+brtDBVZee22b+tBuXjSWOMIKZ8+/NFMsi9fHV57LM+VSTl+OKmo+pQQIDAQAB' +
+    'o4IBFTCCAREwDAYDVR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCBsAwFgYDVR0lAQH/' +
+    'BAwwCgYIKwYBBQUHAwMwHQYDVR0OBBYEFK8qHWuUOothpG8y2/3G3dfp5gSwMB8G' +
+    'A1UdIwQYMBaAFIwZJnuz6MIe1hRzikDhyKh46F6BMEYGA1UdHwQ/MD0wO6A5oDeG' +
+    'NWh0dHA6Ly93d3cuYm9hcmRlcnpvbmUubmV0L2FwaS9jYS9jcmwvYnotdHJ1c3Qt' +
+    'Y2EuY3JsMFEGCCsGAQUFBwEBBEUwQzBBBggrBgEFBQcwAoY1aHR0cDovL3d3dy5i' +
+    'b2FyZGVyem9uZS5uZXQvYXBpL2NhL2NydC9iei10cnVzdC1jYS5jcnQwDQYJKoZI' +
+    'hvcNAQELBQADggIBAIyt5U6rh/KSCnFfHuRjyClKjYizrw6Enl+6Df/IiAlRcudb' +
+    '6AIwG8R9ywMyb+JxIwipmwjhYDJR4PKKdMgtsmldmQN4zngFjDqp6+k+wM9Cj5Rw' +
+    'tScmqPnPDaTprxjwYnyLU0/71R3Sd+ERUpBj3TP5mEOr1kgIUBucr6QYYCZrSs5l' +
+    'IyHGd73g1Mn7YlrsFIhfzyrUz6gnsToehHVsOfPEqeVDsrEts51imC8ZuF7EMy9g' +
+    'GRnt2rV0XnpLfUGK9nuUvaV9sOvshXnOBV/XZudgvPQoJ4gs+gGwC3Z+ZFUabpe+' +
+    'QbbY9jCN8ZcCv5mJZuA9y2fCkWZ0S30VcbY/6aSFpb0P8fOSJf89HuKts4P6IFfp' +
+    'Xkay7uu/lgkynHrAcVUSi9NJ/xA/7mcO1M/ai77/llmvASYtSapd/t+LbWtOlAyw' +
+    'EaFafaNx22nJeHe3iyIxIyl7qS/jOgwgdL1y6HaWEbYhJdFs/GBUhTeb/fOWZ9fG' +
+    'XZtuNJtVECc1gl+rBHY/bypzbv5phK0gRXBqQ1VQ6srho01CAtc48EDooRFsAhH0' +
+    'hVps7WSHS/GEjWFZ3yHBkOKH/gsigZgqqD0c2VuaDMmnnhk1SNI4+Fz6xT07tNr6' +
+    'DVHa59dv36r7WyNAwacMVDNPYvGGwB0VAlW/ppbqXuFnk7hQfR3vUIQatdm5';
 
   CERTIFICATE_1_PEM =
     '-----BEGIN X509 CERTIFICATE-----' + #13 +
@@ -915,6 +949,53 @@ begin
     + 'RRsRsjse3i2/KClFVd6YLZ+7K1BE0WxFyY2bbytkwQJSxvv3vLSuweFUbhNxutb68wl/yW4GLy4b'
     + '1QdyswNxrNDXTuu5ILKhRDDuWeocz83aG2KGtr3JlFyr3biWGEyn5WUOE6tbONoQDJ0oPYgI6CAc'
     + 'EHdUp0lioOCt6UOw7Cs='));
+end;
+
+procedure TCertTest.TestCertificateCriticalExtendedKeyUsage;
+begin
+  CheckCertificateCriticalExtendedKeyUsage;
+end;
+
+// RFC 5280 section 4.2.1.12: extendedKeyUsage may be critical; assert OID listing and parsed usages.
+procedure TCertTest.CheckCertificateCriticalExtendedKeyUsage;
+var
+  LParser: IX509CertificateParser;
+  LCert: IX509Certificate;
+  LCritical: TCryptoLibStringArray;
+  LEku: TCryptoLibGenericArray<IDerObjectIdentifier>;
+  I: Int32;
+  LEkuOid: String;
+  LFound: Boolean;
+begin
+  try
+    LParser := TX509CertificateParser.Create;
+    LCert := LParser.ReadCertificate(DecodeBase64(CRITICAL_EXTENDED_KEY_USAGE_CERT_B64));
+    if LCert = nil then
+      Fail('critical extendedKeyUsage cert: null certificate');
+
+    LEkuOid := TX509Extensions.ExtendedKeyUsage.ID;
+    LCritical := LCert.GetCriticalExtensionOids;
+    if LCritical = nil then
+      Fail('EKU not in critical OIDs');
+
+    LFound := False;
+    for I := 0 to System.High(LCritical) do
+      if LCritical[I] = LEkuOid then
+      begin
+        LFound := True;
+        Break;
+      end;
+
+    if not LFound then
+      Fail('EKU not in critical OIDs');
+
+    LEku := LCert.GetExtendedKeyUsage;
+    if (LEku = nil) or (System.Length(LEku) < 1) then
+      Fail('extended key usage empty after parse');
+  except
+    on E: Exception do
+      Fail('critical extendedKeyUsage cert: ' + E.Message);
+  end;
 end;
 
 procedure TCertTest.CheckCreation1;

--- a/CryptoLib/src/Asn1/X509/ClpX509Asn1Objects.pas
+++ b/CryptoLib/src/Asn1/X509/ClpX509Asn1Objects.pas
@@ -671,6 +671,10 @@ type
     FIdKpCmcCa: IDerObjectIdentifier;
     FIdKpCmcRa: IDerObjectIdentifier;
     FIdKpCmKga: IDerObjectIdentifier;
+    FIdKpConfigSigning: IDerObjectIdentifier;
+    FIdKpTrustAnchorConfigSigning: IDerObjectIdentifier;
+    FIdKpUpdatePackageSigning: IDerObjectIdentifier;
+    FIdKpSafetyCommunication: IDerObjectIdentifier;
     FIdKpSmartcardlogon: IDerObjectIdentifier;
     FIdKpMacAddress: IDerObjectIdentifier;
     FIdKpMsSgc: IDerObjectIdentifier;
@@ -705,6 +709,10 @@ type
     class function GetIdKpCmcCa: IDerObjectIdentifier; static; inline;
     class function GetIdKpCmcRa: IDerObjectIdentifier; static; inline;
     class function GetIdKpCmKga: IDerObjectIdentifier; static; inline;
+    class function GetIdKpConfigSigning: IDerObjectIdentifier; static; inline;
+    class function GetIdKpTrustAnchorConfigSigning: IDerObjectIdentifier; static; inline;
+    class function GetIdKpUpdatePackageSigning: IDerObjectIdentifier; static; inline;
+    class function GetIdKpSafetyCommunication: IDerObjectIdentifier; static; inline;
     class function GetIdKpSmartcardlogon: IDerObjectIdentifier; static; inline;
     class function GetIdKpMacAddress: IDerObjectIdentifier; static; inline;
     class function GetIdKpMsSgc: IDerObjectIdentifier; static; inline;
@@ -743,6 +751,14 @@ type
     class property IdKpCmcCa: IDerObjectIdentifier read GetIdKpCmcCa;
     class property IdKpCmcRa: IDerObjectIdentifier read GetIdKpCmcRa;
     class property IdKpCmKga: IDerObjectIdentifier read GetIdKpCmKga;
+    /// <summary>RFC 9809 sec. 3 — signing general-purpose configuration files (<c>id-kp-configSigning</c>, <c>{ id-kp 41 }</c>).</summary>
+    class property IdKpConfigSigning: IDerObjectIdentifier read GetIdKpConfigSigning;
+    /// <summary>RFC 9809 sec. 3 — signing trust anchor configuration files (<c>id-kp-trustAnchorConfigSigning</c>, <c>{ id-kp 42 }</c>).</summary>
+    class property IdKpTrustAnchorConfigSigning: IDerObjectIdentifier read GetIdKpTrustAnchorConfigSigning;
+    /// <summary>RFC 9809 sec. 3 — signing software or firmware update packages (<c>id-kp-updatePackageSigning</c>, <c>{ id-kp 43 }</c>).</summary>
+    class property IdKpUpdatePackageSigning: IDerObjectIdentifier read GetIdKpUpdatePackageSigning;
+    /// <summary>RFC 9809 sec. 3 — authenticating communication peers for safety-critical communication (<c>id-kp-safetyCommunication</c>, <c>{ id-kp 44 }</c>).</summary>
+    class property IdKpSafetyCommunication: IDerObjectIdentifier read GetIdKpSafetyCommunication;
     class property IdKpSmartcardlogon: IDerObjectIdentifier read GetIdKpSmartcardlogon;
     class property IdKpMacAddress: IDerObjectIdentifier read GetIdKpMacAddress;
     class property IdKpMsSgc: IDerObjectIdentifier read GetIdKpMsSgc;
@@ -940,12 +956,12 @@ type
       const AOidSymbols: TDictionary<IDerObjectIdentifier, String>;
       const AOid: IDerObjectIdentifier; const AVal: String); static;
     class function EquivalentStrings(const AS1, AS2: String): Boolean; static;
-    class function NextToken(const ATokenizer: IX509NameTokenizer): String; overload; static;
-    class function NextToken(const ATokenizer: IX509NameTokenizer; AExpectMoreTokens: Boolean): String; overload; static;
+    class function NextToken(const ATokenizer: IX509NameTokenizer): String; static;
   strict private
     procedure AddAttribute(const ALookup: TDictionary<String, IDerObjectIdentifier>;
       const AToken: String; AAdded: Boolean; const AOidList: TList<IDerObjectIdentifier>;
-      const AValueList: TList<String>; const AAddedList: TList<Boolean>);
+      const AValueList: TList<String>; const AAddedList: TList<Boolean>;
+      const AConverter: IX509NameEntryConverter);
 
   end;
 
@@ -5479,6 +5495,10 @@ begin
   FIdKpCmcCa := TDerObjectIdentifier.Create(LIdKp.ID + '.27');
   FIdKpCmcRa := TDerObjectIdentifier.Create(LIdKp.ID + '.28');
   FIdKpCmKga := TDerObjectIdentifier.Create(LIdKp.ID + '.32');
+  FIdKpConfigSigning := TDerObjectIdentifier.Create(LIdKp.ID + '.41');
+  FIdKpTrustAnchorConfigSigning := TDerObjectIdentifier.Create(LIdKp.ID + '.42');
+  FIdKpUpdatePackageSigning := TDerObjectIdentifier.Create(LIdKp.ID + '.43');
+  FIdKpSafetyCommunication := TDerObjectIdentifier.Create(LIdKp.ID + '.44');
   FIdKpSmartcardlogon := TDerObjectIdentifier.Create('1.3.6.1.4.1.311.20.2.2');
   FIdKpMacAddress := TDerObjectIdentifier.Create('1.3.6.1.1.1.1.22');
   FIdKpMsSgc := TDerObjectIdentifier.Create('1.3.6.1.4.1.311.10.3.3');
@@ -5605,6 +5625,26 @@ end;
 class function TKeyPurposeId.GetIdKpCmKga: IDerObjectIdentifier;
 begin
   Result := FIdKpCmKga;
+end;
+
+class function TKeyPurposeId.GetIdKpConfigSigning: IDerObjectIdentifier;
+begin
+  Result := FIdKpConfigSigning;
+end;
+
+class function TKeyPurposeId.GetIdKpTrustAnchorConfigSigning: IDerObjectIdentifier;
+begin
+  Result := FIdKpTrustAnchorConfigSigning;
+end;
+
+class function TKeyPurposeId.GetIdKpUpdatePackageSigning: IDerObjectIdentifier;
+begin
+  Result := FIdKpUpdatePackageSigning;
+end;
+
+class function TKeyPurposeId.GetIdKpSafetyCommunication: IDerObjectIdentifier;
+begin
+  Result := FIdKpSafetyCommunication;
 end;
 
 class function TKeyPurposeId.GetIdKpSmartcardlogon: IDerObjectIdentifier;
@@ -6250,6 +6290,8 @@ begin
     if not AAttributes.TryGetValue(LOid, LAttribute) then
       raise EArgumentCryptoLibException.CreateFmt('No attribute for object id - %s - passed to distinguished name', [LOid.Id]);
 
+    AConverter.GetConvertedValue(LOid, LAttribute);
+
     FValues[LI] := LAttribute;
     FAdded[LI] := False;
   end;
@@ -6271,6 +6313,9 @@ begin
 
   if AOids.Count <> AValues.Count then
     raise EArgumentCryptoLibException.Create('''oids'' must be same length as ''values''.');
+
+  for LI := 0 to AOids.Count - 1 do
+    AConverter.GetConvertedValue(AOids[LI], AValues[LI]);
 
   FOids := TCollectionUtilities.ToArray<IDerObjectIdentifier>(AOids);
   FValues := TCollectionUtilities.ToArray<String>(AValues);
@@ -6324,11 +6369,11 @@ begin
       LRdn := NextToken(LNameTokenizer);
 
       LRdnTokenizer := TX509NameTokenizer.Create(LRdn, '+');
-      AddAttribute(ALookup, NextToken(LRdnTokenizer), False, LOidList, LValueList, LAddedList);
+      AddAttribute(ALookup, NextToken(LRdnTokenizer), False, LOidList, LValueList, LAddedList, AConverter);
 
       while LRdnTokenizer.HasMoreTokens() do
       begin
-        AddAttribute(ALookup, NextToken(LRdnTokenizer), True, LOidList, LValueList, LAddedList);
+        AddAttribute(ALookup, NextToken(LRdnTokenizer), True, LOidList, LValueList, LAddedList, AConverter);
       end;
     end;
 
@@ -6382,6 +6427,13 @@ var
 begin
   inherited Create();
   FConverter := CreateDefaultConverter();
+
+  if System.Length(AOids) <> System.Length(AValues) then
+    raise EArgumentCryptoLibException.Create('''oids'' must be same length as ''values''.');
+
+  for LI := 0 to System.Length(AOids) - 1 do
+    FConverter.GetConvertedValue(AOids[LI], AValues[LI]);
+
   FOids := TArrayUtilities.Clone<IDerObjectIdentifier>(AOids, IdentityOid);
   FValues := System.Copy(AValues);
   FValueList := System.Copy(AValues);
@@ -6786,17 +6838,6 @@ begin
   Result := LToken;
 end;
 
-class function TX509Name.NextToken(const ATokenizer: IX509NameTokenizer; AExpectMoreTokens: Boolean): String;
-var
-  LToken: String;
-begin
-  LToken := ATokenizer.NextToken();
-  if (LToken = '') or (ATokenizer.HasMoreTokens() <> AExpectMoreTokens) then
-    raise EArgumentCryptoLibException.Create('badly formatted directory string');
-  Result := LToken;
-end;
-
-
 class function TX509Name.EquivalentStrings(const AS1, AS2: String): Boolean;
 var
   LV1, LV2: String;
@@ -6827,7 +6868,8 @@ end;
 
 procedure TX509Name.AddAttribute(const ALookup: TDictionary<String, IDerObjectIdentifier>;
   const AToken: String; AAdded: Boolean; const AOidList: TList<IDerObjectIdentifier>;
-  const AValueList: TList<String>; const AAddedList: TList<Boolean>);
+  const AValueList: TList<String>; const AAddedList: TList<Boolean>;
+  const AConverter: IX509NameEntryConverter);
 var
   LTokenizer: IX509NameTokenizer;
   LTypeToken, LValueToken: String;
@@ -6835,11 +6877,15 @@ var
   LUnescapedValue: String;
 begin
   LTokenizer := TX509NameTokenizer.Create(AToken, '=');
-  LTypeToken := NextToken(LTokenizer, True);
-  LValueToken := NextToken(LTokenizer, False);
+  LTypeToken := LTokenizer.NextToken();
+  if (LTypeToken = '') or not LTokenizer.HasMoreTokens() then
+    raise EArgumentCryptoLibException.Create('badly formatted directory string');
+
+  LValueToken := LTokenizer.Remaining();
 
   LOid := DecodeOid(Trim(LTypeToken), ALookup);
   LUnescapedValue := TIetfUtilities.Unescape(LValueToken);
+  AConverter.GetConvertedValue(LOid, LUnescapedValue);
 
   AOidList.Add(LOid);
   AValueList.Add(LUnescapedValue);

--- a/CryptoLib/src/Asn1/X509/ClpX509DefaultEntryConverter.pas
+++ b/CryptoLib/src/Asn1/X509/ClpX509DefaultEntryConverter.pas
@@ -85,9 +85,21 @@ begin
     Exit;
   end;
 
-  // C, SerialNumber, DnQualifier, TelephoneNumber
-  if AOid.Equals(TX509Name.C) or
-    AOid.Equals(TX509Name.SerialNumber) or
+  // RFC 5280 sec. 4.1.2.4 / X.520: countryName is PrintableString (SIZE (2)).
+  // CAB Forum Baseline narrows to ISO 3166-1 alpha-2; reject wrong-length input at build time.
+  if AOid.Equals(TX509Name.C) or AOid.Equals(TX509Name.JurisdictionC) then
+  begin
+    if System.Length(LValue) <> 2 then
+      raise EArgumentCryptoLibException.CreateFmt(
+        'country code attribute %s must be exactly 2 characters per ISO 3166-1 / X.520, got %d: ''%s''',
+        [AOid.Id, System.Length(LValue), LValue]);
+
+    Result := TDerPrintableString.Create(LValue);
+    Exit;
+  end;
+
+  // SerialNumber, DnQualifier, TelephoneNumber
+  if AOid.Equals(TX509Name.SerialNumber) or
     AOid.Equals(TX509Name.DnQualifier) or
     AOid.Equals(TX509Name.TelephoneNumber) then
   begin

--- a/CryptoLib/src/Asn1/X509/ClpX509NameTokenizer.pas
+++ b/CryptoLib/src/Asn1/X509/ClpX509NameTokenizer.pas
@@ -22,6 +22,7 @@ interface
 
 uses
   SysUtils,
+  ClpStringUtilities,
   ClpCryptoLibTypes,
   ClpIX509NameTokenizer;
 
@@ -43,6 +44,7 @@ type
 
     function HasMoreTokens: Boolean;
     function NextToken: String;
+    function Remaining: String;
 
   end;
 
@@ -93,7 +95,7 @@ begin
   LBeginIndex := FIndex + 2;
 
   // increments first, then checks
-  // This means: increment m_index, then check if less than Length, then enter loop
+  // This means: increment FIndex, then check if less than Length, then enter loop
   // Equivalent: increment first, then check in while condition
   System.Inc(FIndex); // Increment first
   while FIndex < System.Length(FValue) do
@@ -118,7 +120,7 @@ begin
     end
     else if LC = FSeparator then
     begin
-      Result := System.Copy(FValue, LBeginIndex, FIndex - (LBeginIndex - 1));
+      Result := TStringUtilities.Substring(FValue, LBeginIndex, FIndex - (LBeginIndex - 1));
       Exit;
     end;
 
@@ -128,7 +130,22 @@ begin
   if LEscaped or LQuoted then
     raise EArgumentCryptoLibException.Create('badly formatted directory string');
 
-  Result := System.Copy(FValue, LBeginIndex, FIndex - (LBeginIndex - 1));
+  Result := TStringUtilities.Substring(FValue, LBeginIndex, FIndex - (LBeginIndex - 1));
+end;
+
+function TX509NameTokenizer.Remaining: String;
+var
+  LLen: Int32;
+begin
+  LLen := System.Length(FValue);
+  if FIndex >= LLen then
+  begin
+    Result := '';
+    Exit;
+  end;
+
+  Result := TStringUtilities.Substring(FValue, FIndex + 2, LLen - FIndex - 1);
+  FIndex := LLen;
 end;
 
 end.

--- a/CryptoLib/src/Interfaces/Asn1/X509/ClpIX509NameTokenizer.pas
+++ b/CryptoLib/src/Interfaces/Asn1/X509/ClpIX509NameTokenizer.pas
@@ -29,6 +29,8 @@ type
 
     function HasMoreTokens: Boolean;
     function NextToken: String;
+    /// <summary>Returns all characters after the current scan position through end-of-string.</summary>
+    function Remaining: String;
   end;
 
 implementation


### PR DESCRIPTION
Two related fixes to X.509 name handling: the DN tokenizer now correctly handles unescaped `=` characters in attribute values (RFC 4514), and the default entry converter rejects non-conforming country code lengths (RFC 5280 / X.520). Also registers the four RFC 9809 extended key purpose OIDs and adds a regression test for critical `extendedKeyUsage`.

## DN parsing — RFC 4514 compliant `=` handling

`TX509NameTokenizer` gains a `Remaining` method that returns everything from the current scan position to end-of-string. `TX509Name.AddAttribute` now consumes the type with `NextToken` and the value with `Remaining`, so only the *first* `=` separates type from value. Inputs like `CN=foo=bar`, `CN==^_^=`, and `CN=a=b=c` now parse with the full RHS preserved as the attribute value, matching RFC 4514. The dead `NextToken(tokenizer, AExpectMoreTokens)` overload that enforced exactly-one-token-per-side is removed; the well-formedness check (non-empty type, at least one `=`) moves inline into `AddAttribute`.

The substring extraction inside `NextToken` switches from `System.Copy` to `TStringUtilities.Substring` to keep indexing consistent with the new `Remaining` path.

## Country code length enforcement

`TX509DefaultEntryConverter.GetConvertedValue` splits the `C` / `JurisdictionC` branch out from the `SerialNumber` / `DnQualifier` / `TelephoneNumber` group and requires `Length(value) = 2` per ISO 3166-1 alpha-2 / X.520, raising `EArgumentCryptoLibException` otherwise. `'C=USA'`, `'C=U'`, and `'C='` now fail at construction time.

For interoperability with existing certificates already in the wild, the validation only runs at *build* time. `TX509Name.GetInstance` over DER that already contains a non-conforming country length still parses (lenient read of pre-existing certs).

The validating constructors now also call `AConverter.GetConvertedValue` during construction so length checks fire before DN object materialisation:
- `Create(ordering, attributes, converter)`
- `Create(oids, values, converter)`
- `Create(reverse, lookup, dirName, converter)` (per-attribute, via `AddAttribute`)
- `Create(oids, values)` array overload — additionally gains the length-mismatch check that the `TList` overload already had.

## RFC 9809 extended key purposes

`TKeyPurposeId` registers four new OIDs under `id-kp`:
- `IdKpConfigSigning` (`{ id-kp 41 }`)
- `IdKpTrustAnchorConfigSigning` (`{ id-kp 42 }`)
- `IdKpUpdatePackageSigning` (`{ id-kp 43 }`)
- `IdKpSafetyCommunication` (`{ id-kp 44 }`)

## Tests

`X509NameTests` adds three tests:
- `TestRfc4514UnescapedEqualsInAttributeValue` — four DN forms with embedded `=`, plus a malformed `'CN'` input that should raise.
- `TestInvalidHexDnFailsAtConstruction` — `'CN=#GG'` must raise at construction with a `can't recode value` message (no longer silently accepted).
- `TestCountryCodeLength` — verifies `DefaultLookup` exposes `jurisdictionCountry` / `jurisdictionState` / `jurisdictionLocality`; rejects `'USA'`, `'U'`, and `''` through `TX509DefaultEntryConverter.GetConvertedValue` for both `C` and `JurisdictionC`; rejects `'C=USA'` in the string constructor; confirms `GetInstance` still parses a DER-encoded `C=USA` leniently.

The existing `FSubjects[10]` test data is updated from `'C=0,...'` to `'C=AU,...'` to satisfy the new length check.

`CertTests` adds `TestCertificateCriticalExtendedKeyUsage`, parsing a self-contained base64-encoded end-entity certificate and asserting that `extendedKeyUsage` appears in `GetCriticalExtensionOids` and `GetExtendedKeyUsage` returns at least one purpose (RFC 5280 §4.2.1.12 allows EKU to be marked critical).