### PR TITLE
Refactor buffered block ciphers around IsFullBufferRetained virtual

### DIFF
--- a/CryptoLib.Tests/src/Crypto/PaddingTests.pas
+++ b/CryptoLib.Tests/src/Crypto/PaddingTests.pas
@@ -346,8 +346,9 @@ begin
   DoBlockAlignedRoundTrip(16);
 
   // Two full blocks - gap-fill flushes the first block, tail-store
-  // completes the second, AfterTailStored is a no-op in TPaddedBufferedBlockCipher,
-  // then DoFinal sees FBufOff = LBlockSize again.
+  // completes the second; IsFullBufferRetained returns True in
+  // TPaddedBufferedBlockCipher so the second block stays in FBuf until
+  // DoFinal sees FBufOff = LBlockSize again.
   DoBlockAlignedRoundTrip(32);
 end;
 

--- a/CryptoLib/src/Crypto/ClpBufferedBlockCipher.pas
+++ b/CryptoLib/src/Crypto/ClpBufferedBlockCipher.pas
@@ -51,8 +51,12 @@ type
   /// </summary>
   /// <remarks>
   /// <para>
-  /// The instance outputs a block only when the buffer is full and more data is being added, or on
-  /// <c>DoFinal</c>.
+  /// In this plain (non-padded) base class the instance flushes a block as soon as <see cref="FBuf"/>
+  /// becomes full during <c>ProcessByte</c> / <c>ProcessBytes</c>; any leftover partial block is
+  /// emitted by <c>DoFinal</c> (only legal when the underlying mode reports
+  /// <see cref="IBlockCipherMode.IsPartialBlockOkay"/>). Subclasses that need to hold the last full
+  /// block back for finalisation (padded ciphers, CTS) override <see cref="IsFullBufferRetained"/>
+  /// to change this timing.
   /// </para>
   /// <para>
   /// In the case where the underlying cipher is a stream-oriented mode (like CFB or OFB), the last
@@ -85,31 +89,17 @@ type
     constructor Create(); overload;
 
     /// <summary>
-    /// Processes the aligned middle chunk of a ProcessBytes call, after
-    /// the in-flight FBuf block has been emitted by the gap-fill step.
-    /// Default implementation consumes <c>(ALen - 1) div BlockSize</c>
-    /// blocks from AInput using the cached FBulkCipherMode fast path
-    /// (single ProcessBlocks call) when available, or a per-block
-    /// ProcessBlock loop otherwise. Subclasses override to add semantic
-    /// restrictions such as "hold the last block back for padding /
-    /// DoFinal" (CTS holds the last two). The hook must update AInOff
-    /// and ALen to reflect exactly what it consumed, and return the
-    /// number of output bytes written at AOutput[AOutOff..].
+    /// True when a fully-populated <see cref="FBuf"/> must be retained
+    /// for <c>DoFinal</c> rather than flushed by <c>ProcessBytes</c> or
+    /// <c>ProcessByte</c>. The plain <see cref="TBufferedBlockCipher"/>
+    /// returns False so a just-filled FBuf is flushed eagerly during
+    /// streaming. Padded subclasses return True so DoFinal can apply
+    /// (encrypting) or strip (decrypting) the padding on the held
+    /// block. Subclasses that own their own <c>ProcessBytes</c> (such
+    /// as CTS) do not rely on this decision but should still override
+    /// it for honesty.
     /// </summary>
-    function ProcessBytesBulkMiddle(const AInput: TCryptoLibByteArray;
-      var AInOff: Int32; var ALen: Int32;
-      const AOutput: TCryptoLibByteArray; AOutOff: Int32): Int32; virtual;
-
-    /// <summary>
-    /// Called from ProcessBytes after the tail bytes have been stored
-    /// into FBuf whenever FBuf ends up completely full. Default flushes
-    /// the single in-flight block with one ProcessBlock call and resets
-    /// FBufOff to 0. Subclasses that MUST hold the tail back for
-    /// finalisation (padded ciphers, CTS) override to a no-op so the
-    /// final block(s) remain in FBuf until DoFinal.
-    /// </summary>
-    function AfterTailStored(const AOutput: TCryptoLibByteArray;
-      AOutOff: Int32): Int32; virtual;
+    function IsFullBufferRetained: Boolean; virtual;
 
   public
     /// <summary>
@@ -398,33 +388,45 @@ begin
   FCipherMode.Init(AForEncryption, TParameterUtilities.IgnoreRandom(AParameters));
 
   // Probe after the inner Init so modes that only decide their fast-path
-  // wiring at Init time are observed in their post-Init state. The result
-  // is held for the lifetime of this wrapper to keep ProcessBytes free of
-  // per-call QueryInterface overhead.
+  // wiring at Init time are observed in their post-Init state.
   TBlockCipherBulkUtilities.TryResolveBulkCipherMode(FCipherMode,
     FBulkCipherMode);
 end;
 
 function TBufferedBlockCipher.ProcessByte(AInput: Byte;
   const AOutput: TCryptoLibByteArray; AOutOff: Int32): Int32;
+var
+  LRetain: Boolean;
+  LBlockSize: Int32;
 begin
+  Result := 0;
+  LRetain := IsFullBufferRetained();
+  LBlockSize := System.Length(FBuf);
+
+  // Retained-buffer ciphers (padded) may carry a full FBuf from a
+  // previous call. The arrival of another byte proves more data is
+  // coming, so the held block can now be emitted before we store.
+  if LRetain and (FBufOff = LBlockSize) then
+  begin
+    if ((AOutOff + LBlockSize) > System.Length(AOutput)) then
+      raise EDataLengthCryptoLibException.CreateRes(@SOutputBufferTooSmall);
+    Result := FCipherMode.ProcessBlock(FBuf, 0, AOutput, AOutOff);
+    FBufOff := 0;
+  end;
 
   FBuf[FBufOff] := AInput;
   System.Inc(FBufOff);
 
-  if (FBufOff = System.Length(FBuf)) then
+  // Eager-flush ciphers (plain) emit immediately when this byte just
+  // filled FBuf.
+  if (not LRetain) and (FBufOff = LBlockSize) then
   begin
-    if ((AOutOff + System.Length(FBuf)) > System.Length(AOutput)) then
-    begin
+    if ((AOutOff + Result + LBlockSize) > System.Length(AOutput)) then
       raise EDataLengthCryptoLibException.CreateRes(@SOutputBufferTooSmall);
-    end;
-
+    Result := Result + FCipherMode.ProcessBlock(FBuf, 0, AOutput,
+      AOutOff + Result);
     FBufOff := 0;
-    Result := FCipherMode.ProcessBlock(FBuf, 0, AOutput, AOutOff);
-    Exit;
   end;
-
-  Result := 0;
 end;
 
 function TBufferedBlockCipher.ProcessByte(AInput: Byte): TCryptoLibByteArray;
@@ -456,53 +458,17 @@ begin
   Result := LOutBytes;
 end;
 
-function TBufferedBlockCipher.ProcessBytesBulkMiddle(
-  const AInput: TCryptoLibByteArray; var AInOff: Int32; var ALen: Int32;
-  const AOutput: TCryptoLibByteArray; AOutOff: Int32): Int32;
-var
-  LBlockSize, LBulkBlocks, LBulkBytes: Int32;
+function TBufferedBlockCipher.IsFullBufferRetained: Boolean;
 begin
-  Result := 0;
-  LBlockSize := GetBlockSize();
-
-  // Dispatch every full aligned block that would have been fed to
-  // FCipherMode.ProcessBlock in the original per-block loop. The loop
-  // ran while ALen > LBlockSize, which consumes exactly
-  // floor((ALen - 1) / LBlockSize) blocks before the trailing bytes
-  // accumulate into FBuf again.
-  if (FBulkCipherMode <> nil) and (ALen > LBlockSize) then
-  begin
-    LBulkBlocks := (ALen - 1) div LBlockSize;
-    LBulkBytes := LBulkBlocks * LBlockSize;
-    Result := Result + FBulkCipherMode.ProcessBlocks(AInput, AInOff,
-      LBulkBlocks, AOutput, AOutOff);
-    ALen := ALen - LBulkBytes;
-    AInOff := AInOff + LBulkBytes;
-  end
-  else
-  begin
-    while (ALen > LBlockSize) do
-    begin
-      Result := Result + FCipherMode.ProcessBlock(AInput, AInOff,
-        AOutput, AOutOff + Result);
-      ALen := ALen - LBlockSize;
-      AInOff := AInOff + LBlockSize;
-    end;
-  end;
-end;
-
-function TBufferedBlockCipher.AfterTailStored(
-  const AOutput: TCryptoLibByteArray; AOutOff: Int32): Int32;
-begin
-  Result := FCipherMode.ProcessBlock(FBuf, 0, AOutput, AOutOff);
-  FBufOff := 0;
+  Result := False;
 end;
 
 function TBufferedBlockCipher.ProcessBytes(const AInput: TCryptoLibByteArray;
   AInOff, ALength: Int32; const AOutput: TCryptoLibByteArray;
   AOutOff: Int32): Int32;
 var
-  LOutLength, LResultLen, LGapLen, LShiftBytes, LBlockSize: Int32;
+  LOutLength, LResultLen, LGapLen, LBlockSize,
+    LBulkBlocks, LBulkBytes: Int32;
 begin
   if (ALength < 1) then
   begin
@@ -523,39 +489,59 @@ begin
   end;
 
   LResultLen := 0;
-  LGapLen := System.Length(FBuf) - FBufOff;
+  LGapLen := LBlockSize - FBufOff;
+
   if (ALength > LGapLen) then
   begin
-    // Gap-fill: complete the in-flight FBuf block, emit it, and shift
-    // any remaining buffered bytes (for multi-block FBuf subclasses such
-    // as CTS) down so FBuf[0..LBlockSize-1] holds the next lookahead
-    // block. For single-block FBuf (the TBuffered and TPadded default)
-    // the shift is a no-op and FBufOff simply resets to 0.
+    // Gap-fill: complete the in-flight FBuf block and emit it. FBuf is
+    // always exactly one block here, so no lookahead shift is needed -
+    // subclasses with a multi-block FBuf (CTS) own their own
+    // ProcessBytes.
     System.Move(AInput[AInOff], FBuf[FBufOff], LGapLen * System.SizeOf(Byte));
-    LResultLen := LResultLen + FCipherMode.ProcessBlock(FBuf, 0, AOutput, AOutOff);
-    LShiftBytes := System.Length(FBuf) - LBlockSize;
-    if (LShiftBytes > 0) then
-      System.Move(FBuf[LBlockSize], FBuf[0], LShiftBytes * System.SizeOf(Byte));
-    FBufOff := LShiftBytes;
+    LResultLen := LResultLen + FCipherMode.ProcessBlock(FBuf, 0, AOutput,
+      AOutOff);
+    FBufOff := 0;
     ALength := ALength - LGapLen;
     AInOff := AInOff + LGapLen;
 
-    // Aligned middle: process every full block that the original
-    // sequential code would have emitted before starting to accumulate
-    // into FBuf again. Delegated to the virtual hook so CTS can plug in
-    // its "stage first block through FBuf lookahead, bulk the rest,
-    // refresh lookahead" semantics.
-    LResultLen := LResultLen + ProcessBytesBulkMiddle(AInput, AInOff, ALength,
-      AOutput, AOutOff + LResultLen);
+    // Aligned middle: process (ALength - 1) div LBlockSize full blocks
+    // directly from AInput, leaving at least one byte to seed the tail
+    // store below. The cached bulk fast path collapses the per-block
+    // ProcessBlock loop into a single ProcessBlocks call so accelerated
+    // modes can pipeline / SIMD across many blocks.
+    if (FBulkCipherMode <> nil) and (ALength > LBlockSize) then
+    begin
+      LBulkBlocks := (ALength - 1) div LBlockSize;
+      LBulkBytes := LBulkBlocks * LBlockSize;
+      LResultLen := LResultLen + FBulkCipherMode.ProcessBlocks(AInput, AInOff,
+        LBulkBlocks, AOutput, AOutOff + LResultLen);
+      ALength := ALength - LBulkBytes;
+      AInOff := AInOff + LBulkBytes;
+    end
+    else
+    begin
+      while (ALength > LBlockSize) do
+      begin
+        LResultLen := LResultLen + FCipherMode.ProcessBlock(AInput, AInOff,
+          AOutput, AOutOff + LResultLen);
+        ALength := ALength - LBlockSize;
+        AInOff := AInOff + LBlockSize;
+      end;
+    end;
   end;
+
+  // Tail store + optional eager flush. Retained-buffer subclasses
+  // (padded) leave the now-full FBuf for DoFinal to consume; plain
+  // cipher flushes the block immediately.
   System.Move(AInput[AInOff], FBuf[FBufOff], ALength * System.SizeOf(Byte));
   FBufOff := FBufOff + ALength;
-  if (FBufOff = System.Length(FBuf)) then
+  if (FBufOff = LBlockSize) and (not IsFullBufferRetained()) then
   begin
-    // Let subclasses decide whether a full FBuf should flush (default
-    // TBuffered) or be held back for DoFinal (TPadded, CTS).
-    LResultLen := LResultLen + AfterTailStored(AOutput, AOutOff + LResultLen);
+    LResultLen := LResultLen + FCipherMode.ProcessBlock(FBuf, 0, AOutput,
+      AOutOff + LResultLen);
+    FBufOff := 0;
   end;
+
   Result := LResultLen;
 end;
 

--- a/CryptoLib/src/Crypto/Modes/ClpCtsBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpCtsBlockCipher.pas
@@ -22,6 +22,7 @@ interface
 
 uses
   SysUtils,
+  ClpCheck,
   ClpIBlockCipher,
   ClpIBlockCipherMode,
   ClpICtsBlockCipher,
@@ -45,27 +46,12 @@ type
 
   strict protected
     /// <summary>
-    /// CTS holds the last two FBuf blocks back for DoFinal, so we walk
-    /// the aligned middle differently from the default: the first post
-    /// gap-fill block always comes from the FBuf lookahead (staging one
-    /// AInput block into FBuf, processing the lookahead, shifting the
-    /// staged block into the lookahead slot), then any remaining N-1
-    /// blocks run through FBulkCipherMode.ProcessBlocks directly on
-    /// AInput. After the bulk call we refresh FBuf[0..LBlockSize-1] with
-    /// the last AInput block the bulk call consumed so DoFinal and any
-    /// follow-up ProcessBytes observe the same lookahead state the
-    /// scalar path would have produced.
+    /// CTS retains both FBuf blocks for DoFinal's ciphertext-stealing
+    /// finalisation. Reported for honesty; CTS owns its own
+    /// ProcessBytes / ProcessByte so the predicate is not consulted
+    /// internally.
     /// </summary>
-    function ProcessBytesBulkMiddle(const AInput: TCryptoLibByteArray;
-      var AInOff: Int32; var ALen: Int32;
-      const AOutput: TCryptoLibByteArray; AOutOff: Int32): Int32; override;
-
-    /// <summary>
-    /// CTS never flushes on tail-store: the last two blocks must remain
-    /// in FBuf for DoFinal's ciphertext-stealing finalisation.
-    /// </summary>
-    function AfterTailStored(const AOutput: TCryptoLibByteArray;
-      AOutOff: Int32): Int32; override;
+    function IsFullBufferRetained: Boolean; override;
 
   public
     constructor Create(const ACipher: IBlockCipher); overload;
@@ -74,6 +60,19 @@ type
     function GetUpdateOutputSize(AInputLen: Int32): Int32; override;
     function ProcessByte(AInput: Byte; const AOutput: TCryptoLibByteArray;
       AOutOff: Int32): Int32; override;
+
+    /// <summary>
+    /// CTS-specific ProcessBytes. FBuf is two blocks wide and is used
+    /// as a one-block lookahead, so this override carries its own
+    /// gap-fill (with the shift to refresh the lookahead) and its own
+    /// aligned middle (stage one scalar block, bulk-process the rest,
+    /// refresh the lookahead from the last bulk-consumed block). The
+    /// final two blocks always remain in FBuf for DoFinal.
+    /// </summary>
+    function ProcessBytes(const AInput: TCryptoLibByteArray;
+      AInOff, ALength: Int32; const AOutput: TCryptoLibByteArray; AOutOff: Int32)
+      : Int32; overload; override;
+
     function DoFinal(const AOutput: TCryptoLibByteArray; AOutOff: Int32): Int32;
       override;
   end;
@@ -217,67 +216,105 @@ begin
   System.Inc(FBufOff);
 end;
 
-function TCtsBlockCipher.ProcessBytesBulkMiddle(
-  const AInput: TCryptoLibByteArray; var AInOff: Int32; var ALen: Int32;
-  const AOutput: TCryptoLibByteArray; AOutOff: Int32): Int32;
-var
-  LBlockSize, LN, LBulkBlocks, LBulkBytes: Int32;
+function TCtsBlockCipher.IsFullBufferRetained: Boolean;
 begin
-  Result := 0;
-  LBlockSize := GetBlockSize();
-
-  // FBuf[0..LBlockSize-1] holds the lookahead from gap-fill and FBufOff
-  // equals LBlockSize (single-slot staging area at FBuf[LBlockSize..]).
-  // The scalar loop below stages one AInput block into FBuf[LBlockSize],
-  // processes FBuf[0] (the lookahead), and shifts. The first iteration
-  // MUST stay scalar because its input is the FBuf lookahead, not
-  // AInput; iterations 1..N-1 are pure contiguous-AInput transforms and
-  // can be routed through one ProcessBlocks call. N = (ALen - 1) div BS
-  // is the total iteration count the scalar loop would perform, so we
-  // need N >= 2 (i.e. ALen > 2*BS) to get at least one bulk block.
-  if (FBulkCipherMode <> nil) and (ALen > 2 * LBlockSize) then
-  begin
-    LN := (ALen - 1) div LBlockSize;
-
-    System.Move(AInput[AInOff], FBuf[FBufOff], LBlockSize * System.SizeOf(Byte));
-    Result := Result + FCipherMode.ProcessBlock(FBuf, 0, AOutput, AOutOff);
-    System.Move(FBuf[LBlockSize], FBuf[0], LBlockSize * System.SizeOf(Byte));
-    ALen := ALen - LBlockSize;
-    AInOff := AInOff + LBlockSize;
-
-    LBulkBlocks := LN - 1;
-    LBulkBytes := LBulkBlocks * LBlockSize;
-    Result := Result + FBulkCipherMode.ProcessBlocks(AInput, AInOff,
-      LBulkBlocks, AOutput, AOutOff + Result);
-
-    // Refresh FBuf[0..LBlockSize-1] with the last AInput block the bulk
-    // call consumed. That block would have been the post-shift lookahead
-    // after the scalar loop's final iteration, so DoFinal and subsequent
-    // ProcessBytes observe the same FBuf state either way.
-    System.Move(AInput[AInOff + LBulkBytes - LBlockSize], FBuf[0],
-      LBlockSize * System.SizeOf(Byte));
-
-    ALen := ALen - LBulkBytes;
-    AInOff := AInOff + LBulkBytes;
-  end
-  else
-  begin
-    while (ALen > LBlockSize) do
-    begin
-      System.Move(AInput[AInOff], FBuf[FBufOff], LBlockSize * System.SizeOf(Byte));
-      Result := Result + FCipherMode.ProcessBlock(FBuf, 0, AOutput, AOutOff + Result);
-      System.Move(FBuf[LBlockSize], FBuf[0], LBlockSize * System.SizeOf(Byte));
-
-      ALen := ALen - LBlockSize;
-      AInOff := AInOff + LBlockSize;
-    end;
-  end;
+  Result := True;
 end;
 
-function TCtsBlockCipher.AfterTailStored(const AOutput: TCryptoLibByteArray;
+function TCtsBlockCipher.ProcessBytes(const AInput: TCryptoLibByteArray;
+  AInOff, ALength: Int32; const AOutput: TCryptoLibByteArray;
   AOutOff: Int32): Int32;
+var
+  LOutLength, LResultLen, LGapLen, LN,
+    LBulkBlocks, LBulkBytes: Int32;
 begin
-  Result := 0;
+  if (ALength < 1) then
+  begin
+    if (ALength < 0) then
+      raise EArgumentCryptoLibException.CreateRes(@SInvalidLength);
+    Result := 0;
+    Exit;
+  end;
+
+  LOutLength := GetUpdateOutputSize(ALength);
+  if (LOutLength > 0) then
+    TCheck.OutputLength(AOutput, AOutOff, LOutLength, SOutputBufferTooSmall);
+
+  LResultLen := 0;
+  LGapLen := System.Length(FBuf) - FBufOff;
+
+  if (ALength > LGapLen) then
+  begin
+    // Gap-fill: complete the in-flight FBuf (two blocks wide), emit
+    // FBuf[0..FBlockSize-1], and shift FBuf[FBlockSize..] down so
+    // FBuf[0..FBlockSize-1] now holds the lookahead.
+    System.Move(AInput[AInOff], FBuf[FBufOff], LGapLen * System.SizeOf(Byte));
+    LResultLen := LResultLen + FCipherMode.ProcessBlock(FBuf, 0, AOutput,
+      AOutOff);
+    System.Move(FBuf[FBlockSize], FBuf[0],
+      FBlockSize * System.SizeOf(Byte));
+    FBufOff := FBlockSize;
+    ALength := ALength - LGapLen;
+    AInOff := AInOff + LGapLen;
+
+    // Aligned middle. FBuf[0..FBlockSize-1] holds the lookahead and
+    // FBufOff equals FBlockSize. The scalar loop stages one AInput
+    // block into FBuf[FBlockSize..], processes FBuf[0..FBlockSize-1]
+    // (the lookahead), then shifts. The first iteration MUST stay
+    // scalar because its input is the lookahead, not AInput; the next
+    // N-1 iterations are pure contiguous-AInput transforms and can ride
+    // the bulk fast path. N = (ALength - 1) div FBlockSize is the
+    // scalar iteration count, so we need N >= 2 (i.e.
+    // ALength > 2 * FBlockSize) for the bulk path to amortise.
+    if (FBulkCipherMode <> nil) and (ALength > 2 * FBlockSize) then
+    begin
+      LN := (ALength - 1) div FBlockSize;
+
+      System.Move(AInput[AInOff], FBuf[FBufOff],
+        FBlockSize * System.SizeOf(Byte));
+      LResultLen := LResultLen + FCipherMode.ProcessBlock(FBuf, 0, AOutput,
+        AOutOff + LResultLen);
+      System.Move(FBuf[FBlockSize], FBuf[0],
+        FBlockSize * System.SizeOf(Byte));
+      ALength := ALength - FBlockSize;
+      AInOff := AInOff + FBlockSize;
+
+      LBulkBlocks := LN - 1;
+      LBulkBytes := LBulkBlocks * FBlockSize;
+      LResultLen := LResultLen + FBulkCipherMode.ProcessBlocks(AInput, AInOff,
+        LBulkBlocks, AOutput, AOutOff + LResultLen);
+
+      // Refresh FBuf[0..FBlockSize-1] with the last AInput block the
+      // bulk call consumed - the post-shift lookahead the scalar loop's
+      // final iteration would have left behind. DoFinal and any
+      // follow-up ProcessBytes observe the same FBuf state either way.
+      System.Move(AInput[AInOff + LBulkBytes - FBlockSize], FBuf[0],
+        FBlockSize * System.SizeOf(Byte));
+
+      ALength := ALength - LBulkBytes;
+      AInOff := AInOff + LBulkBytes;
+    end
+    else
+    begin
+      while (ALength > FBlockSize) do
+      begin
+        System.Move(AInput[AInOff], FBuf[FBufOff],
+          FBlockSize * System.SizeOf(Byte));
+        LResultLen := LResultLen + FCipherMode.ProcessBlock(FBuf, 0, AOutput,
+          AOutOff + LResultLen);
+        System.Move(FBuf[FBlockSize], FBuf[0],
+          FBlockSize * System.SizeOf(Byte));
+        ALength := ALength - FBlockSize;
+        AInOff := AInOff + FBlockSize;
+      end;
+    end;
+  end;
+
+  // Tail store. CTS always retains both blocks for DoFinal's
+  // ciphertext-stealing finalisation, so we never flush here.
+  System.Move(AInput[AInOff], FBuf[FBufOff], ALength * System.SizeOf(Byte));
+  FBufOff := FBufOff + ALength;
+  Result := LResultLen;
 end;
 
 end.

--- a/CryptoLib/src/Crypto/Paddings/ClpPaddedBufferedBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Paddings/ClpPaddedBufferedBlockCipher.pas
@@ -25,7 +25,6 @@ uses
   ClpCheck,
   ClpIBlockCipher,
   ClpIBlockCipherMode,
-  ClpBlockCipherBulkUtilities,
   ClpEcbBlockCipher,
   ClpPkcs7Padding,
   ClpIPkcs7Padding,
@@ -64,10 +63,9 @@ type
   strict protected
     /// <summary>
     /// Padded cipher must retain the last block in FBuf so DoFinal can
-    /// apply (or strip) padding - never flush on tail-store.
+    /// apply (encrypting) or strip (decrypting) the padding.
     /// </summary>
-    function AfterTailStored(const AOutput: TCryptoLibByteArray;
-      AOutOff: Int32): Int32; override;
+    function IsFullBufferRetained: Boolean; override;
 
   public
 
@@ -135,30 +133,6 @@ type
     /// of input.
     /// </returns>
     function GetUpdateOutputSize(ALength: Int32): Int32; override;
-
-    /// <summary>
-    /// process a single byte, producing an output block if necessary.
-    /// </summary>
-    /// <param name="AInput">
-    /// the input byte.
-    /// </param>
-    /// <param name="AOutput">
-    /// the space for any output that might be produced.
-    /// </param>
-    /// <param name="AOutOff">
-    /// the offset from which the output will be copied.
-    /// </param>
-    /// <returns>
-    /// the number of output bytes copied to output.
-    /// </returns>
-    /// <exception cref="EDataLengthCryptoLibException">
-    /// if there isn't enough space in output.
-    /// </exception>
-    /// <exception cref="EInvalidOperationCryptoLibException">
-    /// if the cipher isn't initialised.
-    /// </exception>
-    function ProcessByte(AInput: Byte; const AOutput: TCryptoLibByteArray;
-      AOutOff: Int32): Int32; override;
 
     /// <summary>
     /// process an array of bytes, producing output if necessary.
@@ -267,7 +241,7 @@ begin
       // Block-aligned input is handled by the if-branch above, which flushes
       // the full block and resets FBufOff to 0 - so AddPadding always sees
       // a value in the valid range. The guard below is a tripwire for future
-      // refactors of ProcessBytes / AfterTailStored / DoFinal.
+      // refactors of ProcessBytes / IsFullBufferRetained / DoFinal.
       if (FBufOff < 0) or (FBufOff >= LBlockSize) then
         raise EInvalidOperationCryptoLibException.CreateRes(@SBufOffInvariant);
 
@@ -319,46 +293,16 @@ procedure TPaddedBufferedBlockCipher.Init(AForEncryption: Boolean;
   const AParameters: ICipherParameters);
 var
   LInitRandom: ISecureRandom;
-  LParameters: ICipherParameters;
+  LParams: ICipherParameters;
 begin
-  FForEncryption := AForEncryption;
-  LParameters := TParameterUtilities.GetRandom(AParameters, LInitRandom);
-
-  Reset();
+  LParams := TParameterUtilities.GetRandom(AParameters, LInitRandom);
   FPadding.Init(LInitRandom);
-  FCipherMode.Init(AForEncryption, LParameters);
-
-  // Cache the bulk-capable view of FCipherMode.
-  TBlockCipherBulkUtilities.TryResolveBulkCipherMode(FCipherMode,
-    FBulkCipherMode);
+  inherited Init(AForEncryption, LParams);
 end;
 
-function TPaddedBufferedBlockCipher.ProcessByte(AInput: Byte;
-  const AOutput: TCryptoLibByteArray; AOutOff: Int32): Int32;
-var
-  LResultLen: Int32;
+function TPaddedBufferedBlockCipher.IsFullBufferRetained: Boolean;
 begin
-  LResultLen := 0;
-
-  if (FBufOff = System.Length(FBuf)) then
-  begin
-    TCheck.OutputLength(AOutput, AOutOff, System.Length(FBuf),
-      SOutputBufferTooSmall);
-
-    LResultLen := FCipherMode.ProcessBlock(FBuf, 0, AOutput, AOutOff);
-    FBufOff := 0;
-  end;
-
-  FBuf[FBufOff] := AInput;
-  System.Inc(FBufOff);
-
-  Result := LResultLen;
-end;
-
-function TPaddedBufferedBlockCipher.AfterTailStored(
-  const AOutput: TCryptoLibByteArray; AOutOff: Int32): Int32;
-begin
-  Result := 0;
+  Result := True;
 end;
 
 end.


### PR DESCRIPTION
Replace TBufferedBlockCipher's two ad-hoc virtual hooks (ProcessBytesBulkMiddle, AfterTailStored) with a single honest decision point, IsFullBufferRetained: Boolean. The plain base returns False (flush on full); padded subclasses return True so DoFinal can apply or strip padding on the held block.
- TBufferedBlockCipher: inline the bulk fast path into ProcessBytes, unify ProcessByte, gate the tail flush on IsFullBufferRetained.
- TPaddedBufferedBlockCipher: drop AfterTailStored / ProcessByte overrides; dedupe Init via inherited.
- TCtsBlockCipher: drop the hook overrides; add a full ProcessBytes override that owns CTS's 2-block lookahead end-to-end.