### PR TITLE
Wire (X)ChaCha20 into key/parameter utilities and expand test coverage

### DIFF
--- a/CryptoLib.Tests/src/Crypto/XChaCha20Poly1305Tests.pas
+++ b/CryptoLib.Tests/src/Crypto/XChaCha20Poly1305Tests.pas
@@ -42,8 +42,16 @@ uses
   ClpEncoders,
   ClpIBufferedCipher,
   ClpCipherUtilities,
+  ClpGeneratorUtilities,
+  ClpICipherKeyGenerator,
+  ClpParameterUtilities,
+  ClpIAsn1Core,
+  ClpIAsn1Objects,
   ClpChaChaEngine,
   ClpChaCha7539Engine,
+  ClpIChaCha7539Engine,
+  ClpSecureRandom,
+  ClpISecureRandom,
   ClpArrayUtilities,
   ClpCryptoLibTypes,
   CryptoLibTestBase;
@@ -64,6 +72,12 @@ type
     procedure TestRejectNonce12Byte;
     procedure TestReuseNonceEncryptionRejected;
     procedure TestGetCipherRegistry;
+    procedure TestRandomRoundTrip;
+    procedure TestRejectInvalidKeySize;
+    procedure TestKeyGenerator256Bit;
+    procedure TestParameterUtilitiesIv24Bytes;
+    procedure TestCipherUtilitiesStreamRoundTrip;
+    procedure TestCipherUtilitiesAeadDraftVector;
   end;
 
 implementation
@@ -95,7 +109,7 @@ function TTestXChaCha20Poly1305.InitCipher(AForEncryption: Boolean;
 var
   LCipher: IXChaCha20Poly1305;
 begin
-  LCipher := TXChaCha20Poly1305.Create;
+  LCipher := TXChaCha20Poly1305.Create() as IXChaCha20Poly1305;
   LCipher.Init(AForEncryption, AParams as ICipherParameters);
   Result := LCipher;
 end;
@@ -157,7 +171,7 @@ end;
 procedure TTestXChaCha20Poly1305.TestAppendixA1Poly1305OneTimeKey;
 var
   LK, LN, LNoncePrefix, LSubKey, LInnerIv, LZero, LFirstBlock, LExpected: TBytes;
-  LE: TChaCha7539Engine;
+  LE: IChaCha7539Engine;
   LParams: IParametersWithIV;
   LIdx: Int32;
 begin
@@ -181,20 +195,16 @@ begin
   System.Move(LN[16], LInnerIv[4], 8);
 
   LE := TChaCha7539Engine.Create;
-  try
-    LParams := TParametersWithIV.Create(TKeyParameter.Create(LSubKey) as IKeyParameter,
-      LInnerIv);
-    LE.Init(True, LParams);
-    System.SetLength(LZero, 64);
-    for LIdx := 0 to 63 do
-      LZero[LIdx] := 0;
-    System.SetLength(LFirstBlock, 64);
-    LE.ProcessBytes(LZero, 0, 64, LFirstBlock, 0);
-  finally
-    LE.Free;
-    TArrayUtilities.Fill<Byte>(LSubKey, 0, 32, 0);
-    TArrayUtilities.Fill<Byte>(LInnerIv, 0, 12, 0);
-  end;
+  LParams := TParametersWithIV.Create(TKeyParameter.Create(LSubKey) as IKeyParameter,
+    LInnerIv);
+  LE.Init(True, LParams);
+  System.SetLength(LZero, 64);
+  for LIdx := 0 to 63 do
+    LZero[LIdx] := 0;
+  System.SetLength(LFirstBlock, 64);
+  LE.ProcessBytes(LZero, 0, 64, LFirstBlock, 0);
+  TArrayUtilities.Fill<Byte>(LSubKey, 0, 32, 0);
+  TArrayUtilities.Fill<Byte>(LInnerIv, 0, 12, 0);
 
   CheckEqual('XChaCha20Poly1305 A.3.1 Poly1305 one-time key', LExpected,
     CopyOfRange(LFirstBlock, 0, 32));
@@ -355,6 +365,193 @@ begin
   LCipher := TCipherUtilities.GetCipher('XChaCha20-Poly1305');
   if LCipher = nil then
     Fail('GetCipher(XChaCha20-Poly1305) nil');
+end;
+
+procedure TTestXChaCha20Poly1305.TestRandomRoundTrip;
+var
+  LRandom: ISecureRandom;
+  LI, LPLen, LALen, LLen, EL, DL, LTamperIdx: Int32;
+  LKey, LNonce, LPlain, LAad, LCt, LPt, LJunk: TCryptoLibByteArray;
+  LParams: IAeadParameters;
+  LEnc, LDec, LBad: IXChaCha20Poly1305;
+begin
+  LRandom := TSecureRandom.Create;
+  for LI := 0 to 49 do
+  begin
+    System.SetLength(LKey, 32);
+    LRandom.NextBytes(LKey);
+    System.SetLength(LNonce, 24);
+    LRandom.NextBytes(LNonce);
+    LPLen := LRandom.Next(4096);
+    System.SetLength(LPlain, LPLen);
+    if LPLen > 0 then
+      LRandom.NextBytes(LPlain);
+    LALen := LRandom.Next(256);
+    System.SetLength(LAad, LALen);
+    if LALen > 0 then
+      LRandom.NextBytes(LAad);
+
+    LParams := TAeadParameters.Create(TKeyParameter.Create(LKey) as IKeyParameter,
+      128, LNonce, LAad);
+
+    LEnc := InitCipher(True, LParams);
+    System.SetLength(LCt, LEnc.GetOutputSize(LPLen));
+    LLen := LEnc.ProcessBytes(LPlain, 0, LPLen, LCt, 0);
+    LLen := LLen + LEnc.DoFinal(LCt, LLen);
+    if System.Length(LCt) <> LLen then
+      Fail('round-trip: encryption length mismatch');
+
+    LDec := InitCipher(False, LParams);
+    System.SetLength(LPt, LDec.GetOutputSize(LLen));
+    DL := LDec.ProcessBytes(LCt, 0, LLen, LPt, 0);
+    DL := DL + LDec.DoFinal(LPt, DL);
+    if DL <> LPLen then
+      Fail('round-trip: decryption length mismatch');
+    CheckEqual('round-trip: plaintext mismatch', LPlain,
+      CopyOfRange(LPt, 0, LPLen));
+
+    if LLen > 0 then
+    begin
+      LTamperIdx := LRandom.Next(LLen);
+      LCt[LTamperIdx] := Byte(LCt[LTamperIdx] xor $01);
+      LBad := InitCipher(False, LParams);
+      System.SetLength(LJunk, LBad.GetOutputSize(LLen));
+      try
+        EL := LBad.ProcessBytes(LCt, 0, LLen, LJunk, 0);
+        LBad.DoFinal(LJunk, EL);
+        Fail('round-trip: tampered ciphertext was accepted');
+      except
+        on E: EInvalidCipherTextCryptoLibException do
+          ; // expected
+      end;
+    end;
+  end;
+end;
+
+procedure TTestXChaCha20Poly1305.TestRejectInvalidKeySize;
+var
+  LKey16, LNonce: TCryptoLibByteArray;
+  LParams: IAeadParameters;
+  LCipher: IXChaCha20Poly1305;
+begin
+  System.SetLength(LKey16, 16);
+  System.SetLength(LNonce, 24);
+  LParams := TAeadParameters.Create(TKeyParameter.Create(LKey16) as IKeyParameter,
+    128, LNonce, nil);
+  LCipher := TXChaCha20Poly1305.Create();
+  try
+    LCipher.Init(True, LParams as ICipherParameters);
+    Fail('XChaCha20Poly1305 unexpectedly accepted a 128-bit key');
+  except
+    on E: EArgumentCryptoLibException do
+    begin
+      if E.Message <> 'Key must be 256 bits' then
+        Fail('unexpected key size message: ' + E.Message);
+    end;
+  end;
+end;
+
+procedure TTestXChaCha20Poly1305.TestKeyGenerator256Bit;
+var
+  LKg1, LKg2: ICipherKeyGenerator;
+begin
+  LKg1 := TGeneratorUtilities.GetKeyGenerator('XCHACHA20');
+  if LKg1.DefaultStrength <> 256 then
+    Fail('GeneratorUtilities default key size for XCHACHA20 is wrong');
+  LKg2 := TGeneratorUtilities.GetKeyGenerator('XCHACHA20-POLY1305');
+  if LKg2.DefaultStrength <> 256 then
+    Fail('GeneratorUtilities default key size for XCHACHA20-POLY1305 is wrong');
+end;
+
+procedure TTestXChaCha20Poly1305.TestParameterUtilitiesIv24Bytes;
+var
+  LRandom: ISecureRandom;
+  LParams: IAsn1Encodable;
+  LOctet: IAsn1OctetString;
+begin
+  LRandom := TSecureRandom.Create;
+  LParams := TParameterUtilities.GenerateParameters('XCHACHA20', LRandom);
+  if not Supports(LParams, IAsn1OctetString, LOctet) then
+    Fail('ParameterUtilities did not return an octet string for XCHACHA20');
+  if System.Length(LOctet.GetOctets) <> 24 then
+    Fail('ParameterUtilities generated wrong IV length for XCHACHA20');
+end;
+
+procedure TTestXChaCha20Poly1305.TestCipherUtilitiesStreamRoundTrip;
+var
+  LKey, LNonce, LPlain, LCt, LPt: TCryptoLibByteArray;
+  LParams: IParametersWithIV;
+  LEnc, LDec: IBufferedCipher;
+begin
+  LKey := THexEncoder.Decode(
+    '808182838485868788898a8b8c8d8e8f' +
+    '909192939495969798999a9b9c9d9e9f');
+  LNonce := THexEncoder.Decode(
+    '404142434445464748494a4b4c4d4e4f5051525354555657');
+  LPlain := THexEncoder.Decode(
+    '4c616469657320616e642047656e746c' +
+    '656d656e206f662074686520636c6173' +
+    '73206f66202739393a20496620492063' +
+    '6f756c64206f6666657220796f75206f' +
+    '6e6c79206f6e652074697020666f7220' +
+    '746865206675747572652c2073756e73' +
+    '637265656e20776f756c642062652069' +
+    '742e');
+
+  LParams := TParametersWithIV.Create(TKeyParameter.Create(LKey) as IKeyParameter,
+    LNonce);
+  LEnc := TCipherUtilities.GetCipher('XCHACHA20');
+  LEnc.Init(True, LParams);
+  LCt := LEnc.DoFinal(LPlain);
+  LDec := TCipherUtilities.GetCipher('XCHACHA20');
+  LDec.Init(False, LParams);
+  LPt := LDec.DoFinal(LCt);
+  CheckEqual('CipherUtilities XCHACHA20 round-trip', LPlain, LPt);
+end;
+
+procedure TTestXChaCha20Poly1305.TestCipherUtilitiesAeadDraftVector;
+var
+  LKey, LNonce, LAad, LPlain, LExpectedCipher, LExpectedTag, LExpected, LCt: TBytes;
+  LParams: IAeadParameters;
+  LCipher: IBufferedCipher;
+begin
+  LKey := THexEncoder.Decode(
+    '808182838485868788898a8b8c8d8e8f' +
+    '909192939495969798999a9b9c9d9e9f');
+  LNonce := THexEncoder.Decode(
+    '404142434445464748494a4b4c4d4e4f5051525354555657');
+  LAad := THexEncoder.Decode('50515253c0c1c2c3c4c5c6c7');
+  LPlain := THexEncoder.Decode(
+    '4c616469657320616e642047656e746c' +
+    '656d656e206f662074686520636c6173' +
+    '73206f66202739393a20496620492063' +
+    '6f756c64206f6666657220796f75206f' +
+    '6e6c79206f6e652074697020666f7220' +
+    '746865206675747572652c2073756e73' +
+    '637265656e20776f756c642062652069' +
+    '742e');
+  LExpectedCipher := THexEncoder.Decode(
+    'bd6d179d3e83d43b9576579493c0e939' +
+    '572a1700252bfaccbed2902c21396cbb' +
+    '731c7f1b0b4aa6440bf3a82f4eda7e39' +
+    'ae64c6708c54c216cb96b72e1213b452' +
+    '2f8c9ba40db5d945b11b69b982c1bb9e' +
+    '3f3fac2bc369488f76b2383565d3fff9' +
+    '21f9664c97637da9768812f615c68b13' +
+    'b52e');
+  LExpectedTag := THexEncoder.Decode('c0875924c1c7987947deafd8780acf49');
+  System.SetLength(LExpected, System.Length(LExpectedCipher) +
+    System.Length(LExpectedTag));
+  System.Move(LExpectedCipher[0], LExpected[0], System.Length(LExpectedCipher));
+  System.Move(LExpectedTag[0], LExpected[System.Length(LExpectedCipher)],
+    System.Length(LExpectedTag));
+
+  LParams := TAeadParameters.Create(TKeyParameter.Create(LKey) as IKeyParameter,
+    System.Length(LExpectedTag) * 8, LNonce, LAad);
+  LCipher := TCipherUtilities.GetCipher('XCHACHA20-POLY1305');
+  LCipher.Init(True, LParams as ICipherParameters);
+  LCt := LCipher.DoFinal(LPlain);
+  CheckEqual('CipherUtilities XCHACHA20-POLY1305 draft vector', LExpected, LCt);
 end;
 
 initialization

--- a/CryptoLib.Tests/src/Crypto/XChaCha20Poly1305Tests.pas
+++ b/CryptoLib.Tests/src/Crypto/XChaCha20Poly1305Tests.pas
@@ -109,7 +109,7 @@ function TTestXChaCha20Poly1305.InitCipher(AForEncryption: Boolean;
 var
   LCipher: IXChaCha20Poly1305;
 begin
-  LCipher := TXChaCha20Poly1305.Create() as IXChaCha20Poly1305;
+  LCipher := TXChaCha20Poly1305.Create();
   LCipher.Init(AForEncryption, AParams as ICipherParameters);
   Result := LCipher;
 end;

--- a/CryptoLib.Tests/src/Crypto/XChaCha20Tests.pas
+++ b/CryptoLib.Tests/src/Crypto/XChaCha20Tests.pas
@@ -32,6 +32,8 @@ uses
 {$ENDIF FPC}
   ClpXChaCha20Engine,
   ClpIXChaCha20Engine,
+  ClpChaCha7539Engine,
+  ClpIChaCha7539Engine,
   ClpIStreamCipher,
   ClpKeyParameter,
   ClpIKeyParameter,
@@ -40,6 +42,8 @@ uses
   ClpEncoders,
   ClpIBufferedCipher,
   ClpCipherUtilities,
+  ClpSecureRandom,
+  ClpISecureRandom,
   ClpCryptoLibTypes,
   CryptoLibTestBase;
 
@@ -53,8 +57,14 @@ type
     procedure TestAppendixA3_2_2CiphertextCounter1;
     procedure TestGetCipherXChaCha20Aliases;
     procedure TestRoundTrip1024;
+    procedure TestHChaCha20Indirect;
+    procedure TestDraftStreamVector;
+    procedure TestRandomRoundTrip;
+    procedure TestChunkedProcessing;
     procedure TestRejectShortNonce64Bits;
     procedure TestRejectShortNonce96Bits;
+    procedure TestRejectShortNonce23Bytes;
+    procedure TestRejectInvalidKeySize;
   end;
 
 implementation
@@ -357,6 +367,225 @@ begin
     LEngine.Init(True, TParametersWithIV.Create(TKeyParameter.Create(LKey)
       as IKeyParameter, LNonce12));
     Fail('XChaCha20 unexpectedly accepted a 12-byte nonce');
+  except
+    on E: EArgumentCryptoLibException do
+      ; // expected
+  end;
+end;
+
+procedure TTestXChaCha20.TestHChaCha20Indirect;
+const
+  HChaChaKeyHex = '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f';
+  HChaChaNonceHex = '000000090000004a0000000031415927';
+  HChaChaOutHex = '82413b4227b27bfed30e42508a877d73a0f9e4d58a74a853c12ec41326d3ecdc';
+var
+  LKey, LHNonce, LSubKey, LXNonce, LZeros, LStreamX, LStreamC: TCryptoLibByteArray;
+  LXEng: IXChaCha20Engine;
+  LCEng: IChaCha7539Engine;
+  LXParams, LCParams: IParametersWithIV;
+  LInnerNonce: TCryptoLibByteArray;
+begin
+  LKey := THexEncoder.Decode(HChaChaKeyHex);
+  LHNonce := THexEncoder.Decode(HChaChaNonceHex);
+  LSubKey := THexEncoder.Decode(HChaChaOutHex);
+  System.SetLength(LXNonce, 24);
+  System.Move(LHNonce[0], LXNonce[0], 16);
+  System.FillChar(LXNonce[16], 8, 0);
+
+  System.SetLength(LZeros, 256);
+  System.FillChar(LZeros[0], 256, 0);
+  System.SetLength(LStreamX, 256);
+  System.SetLength(LStreamC, 256);
+
+  LXEng := TXChaCha20Engine.Create;
+  LXParams := TParametersWithIV.Create(TKeyParameter.Create(LKey) as IKeyParameter,
+    LXNonce);
+  LXEng.Init(True, LXParams);
+  LXEng.ProcessBytes(LZeros, 0, 256, LStreamX, 0);
+
+  System.SetLength(LInnerNonce, 12);
+  System.FillChar(LInnerNonce[0], 12, 0);
+  LCEng := TChaCha7539Engine.Create;
+  LCParams := TParametersWithIV.Create(TKeyParameter.Create(LSubKey) as IKeyParameter,
+    LInnerNonce);
+  LCEng.Init(True, LCParams);
+  LCEng.ProcessBytes(LZeros, 0, 256, LStreamC, 0);
+
+  if not AreEqual(LStreamX, LStreamC) then
+    Fail('HChaCha20 subkey derivation does not match draft test vector');
+end;
+
+procedure TTestXChaCha20.TestDraftStreamVector;
+var
+  LKey, LNonce, LPlain, LExpectedCipher, LInput, LOutput, LActualCipher,
+    LRoundTrip: TCryptoLibByteArray;
+  LEng, LDecEng: IXChaCha20Engine;
+  LParams: IParametersWithIV;
+begin
+  LKey := THexEncoder.Decode(
+    '808182838485868788898a8b8c8d8e8f' +
+    '909192939495969798999a9b9c9d9e9f');
+  LNonce := THexEncoder.Decode(
+    '404142434445464748494a4b4c4d4e4f5051525354555657');
+  LPlain := THexEncoder.Decode(
+    '4c616469657320616e642047656e746c' +
+    '656d656e206f662074686520636c6173' +
+    '73206f66202739393a20496620492063' +
+    '6f756c64206f6666657220796f75206f' +
+    '6e6c79206f6e652074697020666f7220' +
+    '746865206675747572652c2073756e73' +
+    '637265656e20776f756c642062652069' +
+    '742e');
+  LExpectedCipher := THexEncoder.Decode(
+    'bd6d179d3e83d43b9576579493c0e939' +
+    '572a1700252bfaccbed2902c21396cbb' +
+    '731c7f1b0b4aa6440bf3a82f4eda7e39' +
+    'ae64c6708c54c216cb96b72e1213b452' +
+    '2f8c9ba40db5d945b11b69b982c1bb9e' +
+    '3f3fac2bc369488f76b2383565d3fff9' +
+    '21f9664c97637da9768812f615c68b13' +
+    'b52e');
+
+  System.SetLength(LInput, 64 + System.Length(LPlain));
+  System.FillChar(LInput[0], 64, 0);
+  System.Move(LPlain[0], LInput[64], System.Length(LPlain));
+  System.SetLength(LOutput, System.Length(LInput));
+
+  LEng := TXChaCha20Engine.Create;
+  LParams := TParametersWithIV.Create(TKeyParameter.Create(LKey) as IKeyParameter,
+    LNonce);
+  LEng.Init(True, LParams);
+  LEng.ProcessBytes(LInput, 0, System.Length(LInput), LOutput, 0);
+
+  System.SetLength(LActualCipher, System.Length(LExpectedCipher));
+  System.Move(LOutput[64], LActualCipher[0], System.Length(LExpectedCipher));
+  if not AreEqual(LExpectedCipher, LActualCipher) then
+    Fail(Format('XChaCha20 keystream does not match draft AEAD vector: expected %s got %s',
+      [EncodeHex(LExpectedCipher), EncodeHex(LActualCipher)]));
+
+  System.SetLength(LRoundTrip, System.Length(LOutput));
+  LDecEng := TXChaCha20Engine.Create;
+  LDecEng.Init(False, LParams);
+  LDecEng.ProcessBytes(LOutput, 0, System.Length(LOutput), LRoundTrip, 0);
+  if not AreEqual(LInput, LRoundTrip) then
+    Fail('XChaCha20 round-trip mismatch on draft stream vector');
+end;
+
+procedure TTestXChaCha20.TestRandomRoundTrip;
+var
+  LRandom: ISecureRandom;
+  LI, LLen: Int32;
+  LKey, LNonce, LPlain, LCipher, LBack: TCryptoLibByteArray;
+  LEnc, LDec: IXChaCha20Engine;
+  LParams: IParametersWithIV;
+begin
+  LRandom := TSecureRandom.Create;
+  for LI := 0 to 49 do
+  begin
+    System.SetLength(LKey, 32);
+    LRandom.NextBytes(LKey);
+    System.SetLength(LNonce, 24);
+    LRandom.NextBytes(LNonce);
+    LLen := LRandom.Next(8192);
+    System.SetLength(LPlain, LLen);
+    if LLen > 0 then
+      LRandom.NextBytes(LPlain);
+
+    System.SetLength(LCipher, LLen);
+    LEnc := TXChaCha20Engine.Create;
+    LParams := TParametersWithIV.Create(TKeyParameter.Create(LKey) as IKeyParameter,
+      LNonce);
+    LEnc.Init(True, LParams);
+    if LLen > 0 then
+      LEnc.ProcessBytes(LPlain, 0, LLen, LCipher, 0);
+
+    System.SetLength(LBack, LLen);
+    LDec := TXChaCha20Engine.Create;
+    LDec.Init(False, LParams);
+    if LLen > 0 then
+      LDec.ProcessBytes(LCipher, 0, LLen, LBack, 0);
+
+    if not AreEqual(LPlain, LBack) then
+      Fail(Format('XChaCha20 randomized round-trip failed at length %d', [LLen]));
+  end;
+end;
+
+procedure TTestXChaCha20.TestChunkedProcessing;
+const
+  ChunkSizes: array[0..8] of Int32 = (1, 7, 32, 63, 64, 65, 127, 128, 129);
+var
+  LKey, LNonce, LPlain, LWhole, LPiecewise: TCryptoLibByteArray;
+  LEng: IXChaCha20Engine;
+  LParams: IParametersWithIV;
+  LRandom: ISecureRandom;
+  LI, LChunk, LOff, LN: Int32;
+begin
+  LKey := THexEncoder.Decode(
+    '808182838485868788898a8b8c8d8e8f' +
+    '909192939495969798999a9b9c9d9e9f');
+  LNonce := THexEncoder.Decode(
+    '404142434445464748494a4b4c4d4e4f5051525354555657');
+  System.SetLength(LPlain, 1024);
+  LRandom := TSecureRandom.Create;
+  LRandom.NextBytes(LPlain);
+
+  System.SetLength(LWhole, System.Length(LPlain));
+  LEng := TXChaCha20Engine.Create;
+  LParams := TParametersWithIV.Create(TKeyParameter.Create(LKey) as IKeyParameter,
+    LNonce);
+  LEng.Init(True, LParams);
+  LEng.ProcessBytes(LPlain, 0, System.Length(LPlain), LWhole, 0);
+
+  for LI := Low(ChunkSizes) to High(ChunkSizes) do
+  begin
+    LChunk := ChunkSizes[LI];
+    System.SetLength(LPiecewise, System.Length(LPlain));
+    LEng := TXChaCha20Engine.Create;
+    LEng.Init(True, LParams);
+    LOff := 0;
+    while LOff < System.Length(LPlain) do
+    begin
+      LN := LChunk;
+      if LN > System.Length(LPlain) - LOff then
+        LN := System.Length(LPlain) - LOff;
+      LEng.ProcessBytes(LPlain, LOff, LN, LPiecewise, LOff);
+      System.Inc(LOff, LN);
+    end;
+    if not AreEqual(LWhole, LPiecewise) then
+      Fail(Format('chunked processing differs from bulk at chunk size %d', [LChunk]));
+  end;
+end;
+
+procedure TTestXChaCha20.TestRejectShortNonce23Bytes;
+var
+  LKey, LNonce23: TCryptoLibByteArray;
+  LEngine: IXChaCha20Engine;
+begin
+  System.SetLength(LKey, 32);
+  System.SetLength(LNonce23, 23);
+  try
+    LEngine := TXChaCha20Engine.Create;
+    LEngine.Init(True, TParametersWithIV.Create(TKeyParameter.Create(LKey)
+      as IKeyParameter, LNonce23));
+    Fail('XChaCha20 unexpectedly accepted a 23-byte nonce');
+  except
+    on E: EArgumentCryptoLibException do
+      ; // expected
+  end;
+end;
+
+procedure TTestXChaCha20.TestRejectInvalidKeySize;
+var
+  LKey16, LNonce: TCryptoLibByteArray;
+  LEngine: IXChaCha20Engine;
+begin
+  System.SetLength(LKey16, 16);
+  System.SetLength(LNonce, 24);
+  try
+    LEngine := TXChaCha20Engine.Create;
+    LEngine.Init(True, TParametersWithIV.Create(TKeyParameter.Create(LKey16)
+      as IKeyParameter, LNonce));
+    Fail('XChaCha20 unexpectedly accepted a 128-bit key');
   except
     on E: EArgumentCryptoLibException do
       ; // expected

--- a/CryptoLib/src/Crypto/Generators/ClpGeneratorUtilities.pas
+++ b/CryptoLib/src/Crypto/Generators/ClpGeneratorUtilities.pas
@@ -214,6 +214,11 @@ begin
 
   AddKgAlgorithm('BLOWFISH', ['1.3.6.1.4.1.3029.1.2']);
 
+  AddKgAlgorithm('CHACHA', []);
+  AddKgAlgorithm('CHACHA7539', ['CHACHA20', 'CHACHA20-POLY1305', TPkcsObjectIdentifiers.IdAlgAeadChaCha20Poly1305.ID]);
+
+  AddKgAlgorithm('XCHACHA20', ['XCHACHA20-POLY1305']);
+
   AddKgAlgorithm('RIJNDAEL', []);
   AddKgAlgorithm('SALSA20', []);
 
@@ -321,7 +326,8 @@ begin
     'HMACSHA3-256',
     'HMACKECCAK256',
     'HMACSHA256',
-    'HMACSHA512/256'
+    'HMACSHA512/256',
+    'XCHACHA20'
     ]);
   AddDefaultKeySizeEntries(288, ['HMACKECCAK288']);
   AddDefaultKeySizeEntries(384, ['HMACSHA3-384', 'HMACKECCAK384', 'HMACSHA384']);

--- a/CryptoLib/src/Crypto/Parameters/ClpParameterUtilities.pas
+++ b/CryptoLib/src/Crypto/Parameters/ClpParameterUtilities.pas
@@ -36,6 +36,7 @@ uses
   ClpKeyParameter,
   ClpMiscObjectIdentifiers,
   ClpNistObjectIdentifiers,
+  ClpPkcsObjectIdentifiers,
   ClpParametersWithRandom,
   ClpParametersWithIV,
   ClpSecureRandom;
@@ -242,11 +243,18 @@ begin
 
   AddAlgorithm('BLOWFISH', ['1.3.6.1.4.1.3029.1.2', TMiscObjectIdentifiers.CryptlibAlgorithmBlowfishCbc.ID]);
 
+  AddAlgorithm('CHACHA', []);
+  AddAlgorithm('CHACHA7539', ['CHACHA20', 'CHACHA20-POLY1305', TPkcsObjectIdentifiers.IdAlgAeadChaCha20Poly1305.ID]);
+
+  AddAlgorithm('XCHACHA20', ['XCHACHA20-POLY1305']);
+
   AddAlgorithm('RIJNDAEL', []);
   AddAlgorithm('SALSA20', []);
 
   AddBasicIVSizeEntries(8, ['BLOWFISH', 'SALSA20']);
+  AddBasicIVSizeEntries(12, ['CHACHA7539']);
   AddBasicIVSizeEntries(16, ['AES', 'AES128', 'AES192', 'AES256']);
+  AddBasicIVSizeEntries(24, ['XCHACHA20']);
 end;
 
 class constructor TParameterUtilities.Create;


### PR DESCRIPTION
Registers `CHACHA`, `CHACHA7539`, `XCHACHA20`, and `XCHACHA20-POLY1305` in `TGeneratorUtilities` and `TParameterUtilities` so the standard factory paths (`GetCipher`, `GetKeyGenerator`, `GenerateParameters`) work end-to-end for both algorithms. Adds randomised and chunked test coverage alongside additional draft test vectors.

## Registry wiring

**`TGeneratorUtilities`**
- Adds `CHACHA` and `CHACHA7539` entries, with `CHACHA20`, `CHACHA20-POLY1305`, and the `IdAlgAeadChaCha20Poly1305` OID as aliases of `CHACHA7539`.
- Adds `XCHACHA20` with `XCHACHA20-POLY1305` as alias.
- Adds `XCHACHA20` to the 256-bit default key size entries so `GetKeyGenerator('XCHACHA20').DefaultStrength` returns 256.

**`TParameterUtilities`**
- Same algorithm registrations as above.
- IV size table gains `CHACHA7539` at 12 bytes and `XCHACHA20` at 24 bytes, so `GenerateParameters('XCHACHA20', random)` returns a DER OCTET STRING containing a 24-byte IV.

## Test coverage

**`XChaCha20Tests`** gains six tests:
- `TestHChaCha20Indirect` — derives the subkey from the `draft-irtf-cfrg-xchacha §2.2.1` HChaCha20 vector by running XChaCha20 against a constructed nonce, then a separate ChaCha20-IETF instance keyed with the expected subkey, and asserts both 256-byte keystreams match. Indirectly verifies HChaCha20 without exposing it as public API.
- `TestDraftStreamVector` — encrypts the draft AEAD plaintext starting at block counter 1 (by prepending 64 bytes of keystream-consuming zeros), checks the ciphertext matches the AEAD vector, then round-trips it.
- `TestRandomRoundTrip` — 50 iterations of random key/nonce/plaintext (up to 8KB) encrypt-then-decrypt; asserts byte equality.
- `TestChunkedProcessing` — bulk-encrypts 1KB, then re-encrypts the same plaintext in chunk sizes 1, 7, 32, 63, 64, 65, 127, 128, 129, and asserts piecewise output matches the bulk output. Catches block-boundary and tail-byte regressions.
- `TestRejectShortNonce23Bytes` and `TestRejectInvalidKeySize` — round out the validation matrix alongside the existing 8/12-byte nonce rejections.

**`XChaCha20Poly1305Tests`** gains six tests:
- `TestRandomRoundTrip` — 50 iterations of random AEAD encrypt/decrypt with random AAD (up to 256 bytes) and plaintext (up to 4KB). After each successful round-trip, flips a random ciphertext byte and asserts `EInvalidCipherTextCryptoLibException`.
- `TestRejectInvalidKeySize` — confirms the parent's 256-bit key check fires with the expected message.
- `TestKeyGenerator256Bit` — verifies `TGeneratorUtilities.GetKeyGenerator('XCHACHA20')` and `('XCHACHA20-POLY1305')` both default to 256-bit strength.
- `TestParameterUtilitiesIv24Bytes` — verifies `TParameterUtilities.GenerateParameters('XCHACHA20', random)` returns a 24-byte octet string.
- `TestCipherUtilitiesStreamRoundTrip` — round-trips the draft plaintext through `TCipherUtilities.GetCipher('XCHACHA20')` using `IParametersWithIV`, exercising the non-AEAD stream-cipher path.
- `TestCipherUtilitiesAeadDraftVector` — encrypts the draft Appendix A.1 plaintext via `TCipherUtilities.GetCipher('XCHACHA20-POLY1305')` and asserts the concatenated ciphertext + tag exactly matches the draft vector.

## Misc cleanups

- `TestAppendixA1Poly1305OneTimeKey` drops the `try/finally` around the `TChaCha7539Engine` instance and switches to the `IChaCha7539Engine` interface, matching the rest of the test surface and avoiding manual `.Free`.