### PR TITLE
Add SelectSlot to SIMD feature gates and unify x86/x86-64 ABI handling across SIMD prologues

### DIFF
--- a/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.dpr
+++ b/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.dpr
@@ -864,6 +864,7 @@ uses
   X509CertificatePairTests in '..\src\X509\X509CertificatePairTests.pas',
   Bip340SchnorrTests in '..\src\Crypto\Bip340SchnorrTests.pas',
   Bip327MuSig2Tests in '..\src\Crypto\Bip327MuSig2Tests.pas',
+  SimdSelectSlotTests in '..\src\Misc\SimdSelectSlotTests.pas',
   CryptoLibTestBase in '..\src\CryptoLibTestBase.pas';
 
 begin

--- a/CryptoLib.Tests/FreePascal.Tests/CryptoLib.Tests.lpi
+++ b/CryptoLib.Tests/FreePascal.Tests/CryptoLib.Tests.lpi
@@ -23,7 +23,7 @@
           </Target>
           <SearchPaths>
             <IncludeFiles Value="$(ProjOutDir)"/>
-            <OtherUnitFiles Value="..\src\Asn1;..\src\Math;..\src\Math\EC\Custom\Sec;..\src\Others;..\src\Security;..\src\Utils;..\src\Crypto;..\src\Math\EC;..\src\Math\EC\Rfc7748;..\src\Math\EC\Rfc8032;..\src;..\src\Asn1\X509;..\src\X509;..\src\Asn1\Pkcs;..\src\Utils\Pem;..\src\Utils\Net;..\src\OpenSsl;..\src\Utils\NumberUtilities;..\src\Pkcs"/>
+            <OtherUnitFiles Value="..\src\Asn1;..\src\Math;..\src\Math\EC\Custom\Sec;..\src\Others;..\src\Security;..\src\Utils;..\src\Crypto;..\src\Math\EC;..\src\Math\EC\Rfc7748;..\src\Math\EC\Rfc8032;..\src;..\src\Misc;..\src\Asn1\X509;..\src\X509;..\src\Asn1\Pkcs;..\src\Utils\Pem;..\src\Utils\Net;..\src\OpenSsl;..\src\Utils\NumberUtilities;..\src\Pkcs"/>
             <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
           </SearchPaths>
           <Parsing>
@@ -79,7 +79,7 @@
         <PackageName Value="FCL"/>
       </Item4>
     </RequiredPackages>
-    <Units Count="150">
+    <Units Count="151">
       <Unit0>
         <Filename Value="CryptoLib.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -681,6 +681,10 @@
         <Filename Value="..\src\Asn1\X509\AuthorityKeyIdentifierTests.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit149>
+      <Unit150>
+        <Filename Value="..\src\Misc\SimdSelectSlotTests.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit150>
     </Units>
   </ProjectOptions>
   <CompilerOptions>
@@ -691,7 +695,7 @@
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
-      <OtherUnitFiles Value="..\src\Asn1;..\src\Math;..\src\Math\EC\Custom\Sec;..\src\Others;..\src\Security;..\src\Utils;..\src\Crypto;..\src\Math\EC;..\src\Math\EC\Rfc7748;..\src\Math\EC\Rfc8032;..\src;..\src\Asn1\X509;..\src\X509;..\src\Asn1\Pkcs;..\src\Utils\Pem;..\src\Utils\Net;..\src\OpenSsl;..\src\Utils\NumberUtilities;..\src\Pkcs"/>
+      <OtherUnitFiles Value="..\src\Asn1;..\src\Math;..\src\Math\EC\Custom\Sec;..\src\Others;..\src\Security;..\src\Utils;..\src\Crypto;..\src\Math\EC;..\src\Math\EC\Rfc7748;..\src\Math\EC\Rfc8032;..\src;..\src\Misc;..\src\Asn1\X509;..\src\X509;..\src\Asn1\Pkcs;..\src\Utils\Pem;..\src\Utils\Net;..\src\OpenSsl;..\src\Utils\NumberUtilities;..\src\Pkcs"/>
       <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <CodeGeneration>

--- a/CryptoLib.Tests/FreePascal.Tests/CryptoLib.lpr
+++ b/CryptoLib.Tests/FreePascal.Tests/CryptoLib.lpr
@@ -39,7 +39,7 @@ uses
   RijndaelTests, BlowfishTests, Poly1305Tests, MacTests, ChaCha20Poly1305Tests,
   OcbTests, CcmTests, EaxTests, CMacTests, AeadTestUtilities, GcmReorderTests,
   GCMTests, GcmSivTests, GMacTests, Pkcs12Tests, Bip327MuSig2Tests,
-  Bip340SchnorrTests, CryptoLibTestBase, PkcsEncryptedPrivateKeyInfoTests,
+  Bip340SchnorrTests, CryptoLibTestBase, SimdSelectSlotTests, PkcsEncryptedPrivateKeyInfoTests,
   Pkcs12StoreTests, OpenSslReaderTests, OpenSslWriterTests, X509CertGenTests,
   X509CertificatePairTests, ClpFixedSecureRandom, ClpShortenedDigest,
   ClpCertTestUtilities, ClpFusedKernelToggle, Int32Tests, Int64Tests,

--- a/CryptoLib.Tests/FreePascal.Tests/CryptoLibConsole.lpi
+++ b/CryptoLib.Tests/FreePascal.Tests/CryptoLibConsole.lpi
@@ -39,7 +39,7 @@
         <PackageName Value="FCL"/>
       </Item2>
     </RequiredPackages>
-    <Units Count="150">
+    <Units Count="151">
       <Unit0>
         <Filename Value="CryptoLibConsole.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -640,6 +640,10 @@
         <Filename Value="..\src\Asn1\X509\AuthorityKeyIdentifierTests.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit149>
+      <Unit150>
+        <Filename Value="..\src\Misc\SimdSelectSlotTests.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit150>
     </Units>
   </ProjectOptions>
   <CompilerOptions>
@@ -650,7 +654,7 @@
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir)"/>
-      <OtherUnitFiles Value="..\src\Others;..\src\Asn1;..\src\Math\EC\Custom\Sec;..\src\Math;..\src\Security;..\src\Utils;..\src\Crypto;..\src\Math\EC;..\src\Math\EC\Rfc7748;..\src\Math\EC\Rfc8032;..\src;..\src\Asn1\X509;..\src\X509;..\src\Asn1\Pkcs;..\src\Utils\Pem;..\src\Utils\Net;..\src\OpenSsl;..\src\Utils\NumberUtilities;..\src\Pkcs"/>
+      <OtherUnitFiles Value="..\src\Others;..\src\Asn1;..\src\Math\EC\Custom\Sec;..\src\Math;..\src\Security;..\src\Utils;..\src\Crypto;..\src\Math\EC;..\src\Math\EC\Rfc7748;..\src\Math\EC\Rfc8032;..\src;..\src\Misc;..\src\Asn1\X509;..\src\X509;..\src\Asn1\Pkcs;..\src\Utils\Pem;..\src\Utils\Net;..\src\OpenSsl;..\src\Utils\NumberUtilities;..\src\Pkcs"/>
       <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
     </SearchPaths>
     <Other>

--- a/CryptoLib.Tests/FreePascal.Tests/CryptoLibConsole.lpr
+++ b/CryptoLib.Tests/FreePascal.Tests/CryptoLibConsole.lpr
@@ -41,7 +41,7 @@ uses
   BlowfishTests, CcmTests, ChaCha20Poly1305Tests, CMacTests, EaxTests, OcbTests,
   MacTests, Poly1305Tests, AeadTestUtilities, GcmReorderTests, GCMTests,
   GcmSivTests, GMacTests, Pkcs12Tests, Bip327MuSig2Tests, Bip340SchnorrTests,
-  CryptoLibTestBase, PkcsEncryptedPrivateKeyInfoTests,
+  CryptoLibTestBase, SimdSelectSlotTests, PkcsEncryptedPrivateKeyInfoTests,
   Pkcs12StoreTests, OpenSslReaderTests, OpenSslWriterTests, X509CertGenTests,
   X509CertificatePairTests, ClpFixedSecureRandom, ClpShortenedDigest,
   ClpCertTestUtilities, ClpFusedKernelToggle, Int32Tests, Int64Tests,

--- a/CryptoLib.Tests/src/Misc/SimdSelectSlotTests.pas
+++ b/CryptoLib.Tests/src/Misc/SimdSelectSlotTests.pas
@@ -1,0 +1,249 @@
+{ *********************************************************************************** }
+{ *                              CryptoLib Library                                  * }
+{ *                           Author - Ugochukwu Mmaduekwe                          * }
+{ *                 Github Repository <https://github.com/Xor-el>                   * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ *                                                                                 * }
+{ *                              Acknowledgements:                                  * }
+{ *                                                                                 * }
+{ *      Thanks to Sphere 10 Software (http://www.sphere10.com/) for sponsoring     * }
+{ *                         the development of this library                         * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+unit SimdSelectSlotTests;
+
+interface
+
+uses
+  SysUtils,
+{$IFDEF FPC}
+  fpcunit,
+  testregistry,
+{$ELSE}
+  TestFramework,
+{$ENDIF FPC}
+  CryptoLibTestBase,
+  ClpSimdLevels,
+  ClpX86SimdFeatures,
+  ClpArmSimdFeatures;
+
+type
+
+  // Exercises the pure overload of TX86SimdFeatures.SelectSlot, which
+  // takes the active level as a parameter and is therefore fully
+  // deterministic and host-CPU-independent.
+  TTestX86SelectSlot = class(TCryptoLibTestCase)
+  published
+    procedure TestExactMatch;
+    procedure TestStepDownOnUnsupportedTier;
+    procedure TestAllDeclaredTiersAboveActive;
+    procedure TestEmptyTiers;
+    procedure TestTierOrderIndependence;
+    procedure TestScalarHost;
+    procedure TestScalarTierAlwaysReachable;
+  end;
+
+type
+
+  // Symmetric coverage for the ARM surface, since the same SelectSlot
+  // shape lives on TArmSimdFeatures.
+  TTestArmSelectSlot = class(TCryptoLibTestCase)
+  published
+    procedure TestExactMatch;
+    procedure TestStepDownOnUnsupportedTier;
+    procedure TestAllDeclaredTiersAboveActive;
+    procedure TestEmptyTiers;
+    procedure TestTierOrderIndependence;
+    procedure TestScalarHost;
+  end;
+
+implementation
+
+function X86LevelName(ALevel: TX86SimdLevel): string;
+begin
+  case ALevel of
+    TX86SimdLevel.Scalar: Result := 'Scalar';
+    TX86SimdLevel.SSE2:   Result := 'SSE2';
+    TX86SimdLevel.SSE3:   Result := 'SSE3';
+    TX86SimdLevel.SSSE3:  Result := 'SSSE3';
+    TX86SimdLevel.SSE41:  Result := 'SSE41';
+    TX86SimdLevel.SSE42:  Result := 'SSE42';
+    TX86SimdLevel.AVX2:   Result := 'AVX2';
+  else
+    Result := 'Unknown';
+  end;
+end;
+
+function ArmLevelName(ALevel: TArmSimdLevel): string;
+begin
+  case ALevel of
+    TArmSimdLevel.Scalar: Result := 'Scalar';
+    TArmSimdLevel.NEON:   Result := 'NEON';
+    TArmSimdLevel.SVE:    Result := 'SVE';
+    TArmSimdLevel.SVE2:   Result := 'SVE2';
+  else
+    Result := 'Unknown';
+  end;
+end;
+
+{ TTestX86SelectSlot }
+
+procedure TTestX86SelectSlot.TestExactMatch;
+var
+  LResult: TX86SimdLevel;
+begin
+  LResult := TX86SimdFeatures.SelectSlot(TX86SimdLevel.AVX2,
+    [TX86SimdLevel.AVX2, TX86SimdLevel.SSE2]);
+  CheckTrue(LResult = TX86SimdLevel.AVX2,
+    Format('Expected AVX2 but got %s.', [X86LevelName(LResult)]));
+end;
+
+procedure TTestX86SelectSlot.TestStepDownOnUnsupportedTier;
+var
+  LResult: TX86SimdLevel;
+begin
+  LResult := TX86SimdFeatures.SelectSlot(TX86SimdLevel.SSE41,
+    [TX86SimdLevel.AVX2, TX86SimdLevel.SSE2]);
+  CheckTrue(LResult = TX86SimdLevel.SSE2,
+    Format('Expected SSE2 but got %s.', [X86LevelName(LResult)]));
+end;
+
+procedure TTestX86SelectSlot.TestAllDeclaredTiersAboveActive;
+var
+  LResult: TX86SimdLevel;
+begin
+  LResult := TX86SimdFeatures.SelectSlot(TX86SimdLevel.SSE2,
+    [TX86SimdLevel.AVX2]);
+  CheckTrue(LResult = TX86SimdLevel.Scalar,
+    Format('Expected Scalar but got %s.', [X86LevelName(LResult)]));
+end;
+
+procedure TTestX86SelectSlot.TestEmptyTiers;
+var
+  LResult: TX86SimdLevel;
+  LEmpty: array of TX86SimdLevel;
+begin
+  System.SetLength(LEmpty, 0);
+  LResult := TX86SimdFeatures.SelectSlot(TX86SimdLevel.AVX2, LEmpty);
+  CheckTrue(LResult = TX86SimdLevel.Scalar,
+    Format('Expected Scalar but got %s.', [X86LevelName(LResult)]));
+end;
+
+procedure TTestX86SelectSlot.TestTierOrderIndependence;
+var
+  LDescending, LAscending: TX86SimdLevel;
+begin
+  LDescending := TX86SimdFeatures.SelectSlot(TX86SimdLevel.SSE42,
+    [TX86SimdLevel.AVX2, TX86SimdLevel.SSE2]);
+  LAscending := TX86SimdFeatures.SelectSlot(TX86SimdLevel.SSE42,
+    [TX86SimdLevel.SSE2, TX86SimdLevel.AVX2]);
+  CheckTrue(LDescending = LAscending,
+    Format('Order-dependent result: descending=%s ascending=%s.',
+      [X86LevelName(LDescending), X86LevelName(LAscending)]));
+  CheckTrue(LDescending = TX86SimdLevel.SSE2,
+    Format('Expected SSE2 but got %s.', [X86LevelName(LDescending)]));
+end;
+
+procedure TTestX86SelectSlot.TestScalarHost;
+var
+  LResult: TX86SimdLevel;
+begin
+  LResult := TX86SimdFeatures.SelectSlot(TX86SimdLevel.Scalar,
+    [TX86SimdLevel.AVX2, TX86SimdLevel.SSE2]);
+  CheckTrue(LResult = TX86SimdLevel.Scalar,
+    Format('Expected Scalar but got %s.', [X86LevelName(LResult)]));
+end;
+
+procedure TTestX86SelectSlot.TestScalarTierAlwaysReachable;
+var
+  LResult: TX86SimdLevel;
+begin
+  LResult := TX86SimdFeatures.SelectSlot(TX86SimdLevel.Scalar,
+    [TX86SimdLevel.Scalar]);
+  CheckTrue(LResult = TX86SimdLevel.Scalar,
+    Format('Expected Scalar but got %s.', [X86LevelName(LResult)]));
+end;
+
+{ TTestArmSelectSlot }
+
+procedure TTestArmSelectSlot.TestExactMatch;
+var
+  LResult: TArmSimdLevel;
+begin
+  LResult := TArmSimdFeatures.SelectSlot(TArmSimdLevel.SVE2,
+    [TArmSimdLevel.SVE2, TArmSimdLevel.NEON]);
+  CheckTrue(LResult = TArmSimdLevel.SVE2,
+    Format('Expected SVE2 but got %s.', [ArmLevelName(LResult)]));
+end;
+
+procedure TTestArmSelectSlot.TestStepDownOnUnsupportedTier;
+var
+  LResult: TArmSimdLevel;
+begin
+  LResult := TArmSimdFeatures.SelectSlot(TArmSimdLevel.SVE,
+    [TArmSimdLevel.SVE2, TArmSimdLevel.NEON]);
+  CheckTrue(LResult = TArmSimdLevel.NEON,
+    Format('Expected NEON but got %s.', [ArmLevelName(LResult)]));
+end;
+
+procedure TTestArmSelectSlot.TestAllDeclaredTiersAboveActive;
+var
+  LResult: TArmSimdLevel;
+begin
+  LResult := TArmSimdFeatures.SelectSlot(TArmSimdLevel.NEON,
+    [TArmSimdLevel.SVE2]);
+  CheckTrue(LResult = TArmSimdLevel.Scalar,
+    Format('Expected Scalar but got %s.', [ArmLevelName(LResult)]));
+end;
+
+procedure TTestArmSelectSlot.TestEmptyTiers;
+var
+  LResult: TArmSimdLevel;
+  LEmpty: array of TArmSimdLevel;
+begin
+  System.SetLength(LEmpty, 0);
+  LResult := TArmSimdFeatures.SelectSlot(TArmSimdLevel.SVE2, LEmpty);
+  CheckTrue(LResult = TArmSimdLevel.Scalar,
+    Format('Expected Scalar but got %s.', [ArmLevelName(LResult)]));
+end;
+
+procedure TTestArmSelectSlot.TestTierOrderIndependence;
+var
+  LDescending, LAscending: TArmSimdLevel;
+begin
+  LDescending := TArmSimdFeatures.SelectSlot(TArmSimdLevel.SVE,
+    [TArmSimdLevel.SVE2, TArmSimdLevel.NEON]);
+  LAscending := TArmSimdFeatures.SelectSlot(TArmSimdLevel.SVE,
+    [TArmSimdLevel.NEON, TArmSimdLevel.SVE2]);
+  CheckTrue(LDescending = LAscending,
+    Format('Order-dependent result: descending=%s ascending=%s.',
+      [ArmLevelName(LDescending), ArmLevelName(LAscending)]));
+  CheckTrue(LDescending = TArmSimdLevel.NEON,
+    Format('Expected NEON but got %s.', [ArmLevelName(LDescending)]));
+end;
+
+procedure TTestArmSelectSlot.TestScalarHost;
+var
+  LResult: TArmSimdLevel;
+begin
+  LResult := TArmSimdFeatures.SelectSlot(TArmSimdLevel.Scalar,
+    [TArmSimdLevel.SVE2, TArmSimdLevel.NEON]);
+  CheckTrue(LResult = TArmSimdLevel.Scalar,
+    Format('Expected Scalar but got %s.', [ArmLevelName(LResult)]));
+end;
+
+initialization
+
+{$IFDEF FPC}
+  RegisterTest(TTestX86SelectSlot);
+  RegisterTest(TTestArmSelectSlot);
+{$ELSE}
+  RegisterTest(TTestX86SelectSlot.Suite);
+  RegisterTest(TTestArmSelectSlot.Suite);
+{$ENDIF FPC}
+
+end.

--- a/CryptoLib/src/Crypto/Engines/ClpChaCha7539Engine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpChaCha7539Engine.pas
@@ -29,7 +29,8 @@ uses
   ClpChaChaEngine,
   ClpPack,
   ClpCryptoLibTypes,
-  ClpCpuFeatures;
+  ClpCpuFeatures,
+  ClpSimdLevels;
 
 resourcestring
   SInvalidKeySize256 = '%s Requires 256 bit key';
@@ -370,17 +371,19 @@ begin
     raise EMaxBytesExceededCryptoLibException.CreateRes(@SMaxByteExceeded38);
   end;
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  if TCpuFeatures.X86.HasAVX2() then
-  begin
-    ChaCha7539ProcessBlocks2Avx2(FRounds, PByte(@FEngineState[0]), PByte(@AInBytes[AInOff]),
-      PByte(@AOutBytes[AOutOff]));
-    Exit;
-  end;
-  if TCpuFeatures.X86.HasSSE2() then
-  begin
-    ChaCha7539ProcessBlocks2Sse2(FRounds, PByte(@FEngineState[0]), PByte(@AInBytes[AInOff]),
-      PByte(@AOutBytes[AOutOff]));
-    Exit;
+  case TCpuFeatures.X86.SelectSlot([TX86SimdLevel.AVX2, TX86SimdLevel.SSE2]) of
+    TX86SimdLevel.AVX2:
+    begin
+      ChaCha7539ProcessBlocks2Avx2(FRounds, PByte(@FEngineState[0]), PByte(@AInBytes[AInOff]),
+        PByte(@AOutBytes[AOutOff]));
+      Exit;
+    end;
+    TX86SimdLevel.SSE2:
+    begin
+      ChaCha7539ProcessBlocks2Sse2(FRounds, PByte(@FEngineState[0]), PByte(@AInBytes[AInOff]),
+        PByte(@AOutBytes[AOutOff]));
+      Exit;
+    end;
   end;
 {$ENDIF}
   ImplProcessBlock(AInBytes, AInOff, AOutBytes, AOutOff);
@@ -401,15 +404,17 @@ begin
       [AlgorithmName]);
   end;
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  if TCpuFeatures.X86.HasAVX2() then
-  begin
-    if (LimitExceeded(UInt32(256))) then
+  case TCpuFeatures.X86.SelectSlot([TX86SimdLevel.AVX2]) of
+    TX86SimdLevel.AVX2:
     begin
-      raise EMaxBytesExceededCryptoLibException.CreateRes(@SMaxByteExceeded38);
+      if (LimitExceeded(UInt32(256))) then
+      begin
+        raise EMaxBytesExceededCryptoLibException.CreateRes(@SMaxByteExceeded38);
+      end;
+      ChaCha7539ProcessBlocks4Avx2(FRounds, PByte(@FEngineState[0]),
+        PByte(@AInBytes[AInOff]), PByte(@AOutBytes[AOutOff]));
+      Exit;
     end;
-    ChaCha7539ProcessBlocks4Avx2(FRounds, PByte(@FEngineState[0]),
-      PByte(@AInBytes[AInOff]), PByte(@AOutBytes[AOutOff]));
-    Exit;
   end;
 {$ENDIF}
   ProcessBlocks2(AInBytes, AInOff, AOutBytes, AOutOff);

--- a/CryptoLib/src/Crypto/Engines/ClpChaChaEngine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpChaChaEngine.pas
@@ -27,6 +27,7 @@ uses
   ClpSalsa20Engine,
   ClpPack,
   ClpCpuFeatures,
+  ClpSimdLevels,
   ClpCryptoLibTypes;
 
 resourcestring
@@ -136,10 +137,12 @@ begin
     raise EArgumentCryptoLibException.CreateRes(@SRoundsEven);
   end;
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  if TCpuFeatures.X86.HasSSE2() then
-  begin
-    ChaCha20BlockSse2(ARounds, PByte(@AInput[0]), PByte(@AOutput[0]));
-    Exit;
+  case TCpuFeatures.X86.SelectSlot([TX86SimdLevel.SSE2]) of
+    TX86SimdLevel.SSE2:
+    begin
+      ChaCha20BlockSse2(ARounds, PByte(@AInput[0]), PByte(@AOutput[0]));
+      Exit;
+    end;
   end;
 {$ENDIF}
 

--- a/CryptoLib/src/Crypto/Engines/ClpSalsa20Engine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpSalsa20Engine.pas
@@ -31,6 +31,7 @@ uses
   ClpIParametersWithIV,
   ClpPack,
   ClpCpuFeatures,
+  ClpSimdLevels,
   ClpCryptoLibTypes;
 
 resourcestring
@@ -350,10 +351,12 @@ procedure TSalsa20Engine.ProcessBlocks2(
 begin
   AssertInitialisedAndBlockAligned;
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  if TCpuFeatures.X86.HasSSE41() then
-  begin
-    Salsa20ProcessBlocks2Sse41(FRounds, PByte(@FEngineState[0]), PByte(@AInBytes[AInOff]), PByte(@AOutBytes[AOutOff]));
-    Exit;
+  case TCpuFeatures.X86.SelectSlot([TX86SimdLevel.SSE41]) of
+    TX86SimdLevel.SSE41:
+    begin
+      Salsa20ProcessBlocks2Sse41(FRounds, PByte(@FEngineState[0]), PByte(@AInBytes[AInOff]), PByte(@AOutBytes[AOutOff]));
+      Exit;
+    end;
   end;
 {$ENDIF}
   ImplProcessBlock(AInBytes, AInOff, AOutBytes, AOutOff);
@@ -527,10 +530,12 @@ begin
     raise EArgumentCryptoLibException.CreateRes(@SRoundsMustbeEven);
   end;
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  if TCpuFeatures.X86.HasSSE41() then
-  begin
-    Salsa20BlockSse41(ARounds, @AInput[0], @AX[0]);
-    Exit;
+  case TCpuFeatures.X86.SelectSlot([TX86SimdLevel.SSE41]) of
+    TX86SimdLevel.SSE41:
+    begin
+      Salsa20BlockSse41(ARounds, @AInput[0], @AX[0]);
+      Exit;
+    end;
   end;
 {$ENDIF}
 

--- a/CryptoLib/src/Crypto/Macs/ClpPoly1305.pas
+++ b/CryptoLib/src/Crypto/Macs/ClpPoly1305.pas
@@ -35,6 +35,7 @@ uses
   ClpBitOperations,
   ClpArrayUtilities,
   ClpCpuFeatures,
+  ClpSimdLevels,
   ClpCryptoLibTypes;
 
 resourcestring
@@ -481,13 +482,14 @@ begin
   // Pre-build any SIMD-specific lookup tables for this key, and use the
   // (non-)allocation of FPowTable as the dispatch flag for BlockUpdate.
   // Reset to nil first so the scalar path is the postcondition when no
-  // SIMD branch matches. To add a new SIMD variant: add a parallel
-  // `if Has<Feature>()` branch here that delegates to its initializer
-  // (which owns sizing + layout), ordered most-capable first.
+  // SIMD branch matches. To add a new SIMD variant: declare its tier in
+  // SelectSlot and delegate to its initializer (which owns sizing + layout).
   FPowTable := nil;
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  if TCpuFeatures.X86.HasAVX2() then
-    Poly1305Avx2InitPowerTable(FPowTable, FState);
+  case TCpuFeatures.X86.SelectSlot([TX86SimdLevel.AVX2]) of
+    TX86SimdLevel.AVX2:
+      Poly1305Avx2InitPowerTable(FPowTable, FState);
+  end;
 {$ENDIF}
 end;
 
@@ -548,7 +550,7 @@ begin
   begin
     LBulkBytes := LNb shl 4;
   {$IFDEF CRYPTOLIB_X86_SIMD}
-    if (FPowTable <> nil) and TCpuFeatures.X86.HasAVX2() then
+    if FPowTable <> nil then
       Poly1305ProcessBlocksAvx2(FState, PByte(FPowTable), AInput,
         AInOff + LPos, LNb)
     else

--- a/CryptoLib/src/Include/CryptoLib.inc
+++ b/CryptoLib/src/Include/CryptoLib.inc
@@ -166,6 +166,10 @@
 
 {============================ Common SIMD Settings ============================}
 
+{$IF DEFINED(CRYPTOLIB_X86_64) AND NOT DEFINED(CRYPTOLIB_MSWINDOWS)}
+  {$DEFINE CRYPTOLIB_SYSV_X64_ABI}
+{$IFEND}
+
 // Uncomment to force scalar dispatch (available on all platforms):
 // {$DEFINE CRYPTOLIB_FORCE_SCALAR}
 

--- a/CryptoLib/src/Include/Simd/Common/SimdProc1Begin_i386.inc
+++ b/CryptoLib/src/Include/Simd/Common/SimdProc1Begin_i386.inc
@@ -1,23 +1,15 @@
 // Shared SIMD procedure prologue for 1-parameter assembly functions (i386).
 // After inclusion: ebx = param1 (EAX at entry; callee saves EBX).
-// FPC: Windows and Unix i386 use the same single-parameter entry layout
-// (first pointer-sized argument arrives in EAX under FPC's register calling
-// convention for the default visibility of asm-only functions).
+// FPC and Delphi Win32 share the same i386 register convention here.
 // Bodies must end with: pop ebx before the Pascal 'end' (which emits ret).
-// Matches the idiom of SimdProc2Begin_i386.inc / SimdProc3Begin_i386.inc.
 // Usage:
 //   procedure MyProc(P1: Pointer);
 //     {$I ..\..\Include\Simd\Common\SimdProc1Begin_i386.inc}
 //     // ... SIMD instructions using ebx ...
-//     // pop ebx     // the included kernel body emits this as its epilogue
 //   end;
 {$IFDEF FPC}
   assembler; nostackframe;
-asm
-  push ebx
-  mov ebx, eax
-{$ELSE}
-asm
-  push ebx
-  mov ebx, eax
 {$ENDIF}
+asm
+  push ebx
+  mov ebx, eax

--- a/CryptoLib/src/Include/Simd/Common/SimdProc1Begin_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Common/SimdProc1Begin_x86_64.inc
@@ -1,6 +1,6 @@
 // Shared SIMD/asm procedure prologue (1 parameter, x86-64).
 // After inclusion: rcx = param1 (MS x64 ABI).
-// On FPC non-Windows, remaps rdi -> rcx.
+// When CRYPTOLIB_SYSV_X64_ABI is defined, remaps rdi -> rcx.
 // Usage:
 //   procedure MyProc(P1: Pointer);
 //     {$I ..\..\Include\Simd\Common\SimdProc1Begin_x86_64.inc}
@@ -8,11 +8,11 @@
 //   end;
 {$IFDEF FPC}
   assembler; nostackframe;
+{$ENDIF}
 asm
-  {$IFNDEF MSWINDOWS}
-  mov rcx, rdi
-  {$ENDIF}
-{$ELSE}
-asm
+{$IFNDEF FPC}
   .noframe
+{$ENDIF}
+{$IFDEF CRYPTOLIB_SYSV_X64_ABI}
+  mov rcx, rdi
 {$ENDIF}

--- a/CryptoLib/src/Include/Simd/Common/SimdProc2Begin_i386.inc
+++ b/CryptoLib/src/Include/Simd/Common/SimdProc2Begin_i386.inc
@@ -1,7 +1,6 @@
 // Shared SIMD procedure prologue for 2-parameter assembly functions (i386).
-// After inclusion: ebx = param1, esi = param2 (EAX, EDX at entry; callee saves EBX, ESI).
-// FPC: Windows and Unix i386 use the same parameter entry layout.
-// Bodies must end with: pop esi / pop ebx (reverse of pushes) before return.
+// After inclusion: ebx = param1, esi = param2 (EAX, EDX at entry).
+// Callee-saved EBX, ESI - epilogue must pop ESI, EBX.
 // Usage:
 //   procedure MyProc(P1, P2: Pointer);
 //     {$I ..\..\Include\Simd\Common\SimdProc2Begin_i386.inc}
@@ -9,15 +8,9 @@
 //   end;
 {$IFDEF FPC}
   assembler; nostackframe;
-asm
-  push ebx
-  push esi
-  mov ebx, eax
-  mov esi, edx
-{$ELSE}
-asm
-  push ebx
-  push esi
-  mov ebx, eax
-  mov esi, edx
 {$ENDIF}
+asm
+  push ebx
+  push esi
+  mov ebx, eax
+  mov esi, edx

--- a/CryptoLib/src/Include/Simd/Common/SimdProc2Begin_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Common/SimdProc2Begin_x86_64.inc
@@ -1,6 +1,6 @@
 // Shared SIMD/asm procedure prologue (2 parameters, x86-64).
 // After inclusion: rcx = param1, rdx = param2 (MS x64 ABI).
-// On FPC non-Windows, remaps rdi, rsi -> rcx, rdx.
+// When CRYPTOLIB_SYSV_X64_ABI is defined, remaps rdi, rsi -> rcx, rdx.
 // Usage:
 //   procedure MyProc(P1, P2: Pointer);
 //     {$I ..\..\Include\Simd\Common\SimdProc2Begin_x86_64.inc}
@@ -8,12 +8,12 @@
 //   end;
 {$IFDEF FPC}
   assembler; nostackframe;
+{$ENDIF}
 asm
-  {$IFNDEF MSWINDOWS}
+{$IFNDEF FPC}
+  .noframe
+{$ENDIF}
+{$IFDEF CRYPTOLIB_SYSV_X64_ABI}
   mov rdx, rsi
   mov rcx, rdi
-  {$ENDIF}
-{$ELSE}
-asm
-  .noframe
 {$ENDIF}

--- a/CryptoLib/src/Include/Simd/Common/SimdProc3Begin_i386.inc
+++ b/CryptoLib/src/Include/Simd/Common/SimdProc3Begin_i386.inc
@@ -1,6 +1,6 @@
 // Shared SIMD procedure prologue for 3-parameter assembly functions (i386).
 // After inclusion: ebx = param1, esi = param2, edi = param3 (EAX, EDX, ECX at entry).
-// FPC: Windows and Unix i386 use the same parameter entry layout.
+// Callee-saved EBX, ESI, EDI - epilogue must pop EDI, ESI, EBX.
 // Usage:
 //   procedure MyProc(P1, P2, P3: Pointer);
 //     {$I ..\..\Include\Simd\Common\SimdProc3Begin_i386.inc}
@@ -8,19 +8,11 @@
 //   end;
 {$IFDEF FPC}
   assembler; nostackframe;
-asm
-  push ebx
-  push esi
-  push edi
-  mov ebx, eax
-  mov esi, edx
-  mov edi, ecx
-{$ELSE}
-asm
-  push ebx
-  push esi
-  push edi
-  mov ebx, eax
-  mov esi, edx
-  mov edi, ecx
 {$ENDIF}
+asm
+  push ebx
+  push esi
+  push edi
+  mov ebx, eax
+  mov esi, edx
+  mov edi, ecx

--- a/CryptoLib/src/Include/Simd/Common/SimdProc3Begin_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Common/SimdProc3Begin_x86_64.inc
@@ -1,20 +1,21 @@
 // Shared SIMD/asm procedure prologue (3 parameters, x86-64).
 // After inclusion: rcx = param1, rdx = param2, r8 = param3 (MS x64 ABI).
-// On FPC non-Windows, remaps rdi, rsi, rdx -> rcx, rdx, r8 (rdx saved before overwrite).
+// When CRYPTOLIB_SYSV_X64_ABI is defined, remaps rdi, rsi, rdx -> rcx, rdx, r8.
+// Move order avoids register clobbering: save rdx before overwriting.
 // Usage:
-//   procedure MyProc(P1, P2, P3: Pointer);  // or mixed Pointer/Integer types
+//   procedure MyProc(P1, P2, P3: Pointer);
 //     {$I ..\..\Include\Simd\Common\SimdProc3Begin_x86_64.inc}
 //     // ... instructions using rcx, rdx, r8 ...
 //   end;
 {$IFDEF FPC}
   assembler; nostackframe;
+{$ENDIF}
 asm
-  {$IFNDEF MSWINDOWS}
+{$IFNDEF FPC}
+  .noframe
+{$ENDIF}
+{$IFDEF CRYPTOLIB_SYSV_X64_ABI}
   mov r8, rdx
   mov rdx, rsi
   mov rcx, rdi
-  {$ENDIF}
-{$ELSE}
-asm
-  .noframe
 {$ENDIF}

--- a/CryptoLib/src/Include/Simd/Common/SimdProc4Begin_i386.inc
+++ b/CryptoLib/src/Include/Simd/Common/SimdProc4Begin_i386.inc
@@ -1,8 +1,10 @@
 // Shared SIMD procedure prologue for 4-parameter assembly functions (i386).
 // After inclusion: ebx = param1, esi = param2, edi = param3, eax = param4
-//   (first three in EAX, EDX, ECX at entry; param4 from stack after callee saves).
-// FPC: Windows and Unix i386 use the same stack tail layout; see asm for ESP offsets.
-// Delphi Win32: param4 at dword ptr [ebp + 8].
+//   (first three in EAX, EDX, ECX at entry; param4 from stack).
+// Callee-saved EBX, ESI, EDI - epilogue must pop EDI, ESI, EBX.
+// Delphi i386 only ships on Windows; param4 lives at [ebp + 8].
+// FPC i386 has no stack frame; param4 lives at [esp + 8] when read after
+// the EBX push but before the ESI / EDI pushes (see asm).
 // Usage:
 //   procedure MyProc(P1, P2, P3: Pointer; P4: Int32);
 //     {$I ..\..\Include\Simd\Common\SimdProc4Begin_i386.inc}
@@ -20,7 +22,6 @@ asm
   mov edi, ecx
 {$ELSE}
 asm
-  {$IFDEF MSWINDOWS}
   push ebx
   mov ebx, eax
   mov eax, dword ptr [ebp + 8]
@@ -28,13 +29,4 @@ asm
   mov esi, edx
   push edi
   mov edi, ecx
-  {$ELSE}
-  push ebx
-  push esi
-  push edi
-  mov ebx, dword ptr [ebp + 8]
-  mov esi, dword ptr [ebp + 12]
-  mov edi, dword ptr [ebp + 16]
-  mov eax, dword ptr [ebp + 20]
-  {$ENDIF}
 {$ENDIF}

--- a/CryptoLib/src/Include/Simd/Common/SimdProc4Begin_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Common/SimdProc4Begin_x86_64.inc
@@ -1,21 +1,23 @@
 // Shared SIMD/asm procedure prologue (4 parameters, x86-64).
-// After inclusion: rcx = param1, rdx = param2, r8 = param3, r9 = param4 (MS x64 ABI).
-// On FPC non-Windows, remaps rdi, rsi, rdx, rcx -> rcx, rdx, r8, r9.
+// After inclusion: rcx = param1, rdx = param2, r8 = param3, r9 = param4
+// (MS x64 ABI).
+// When CRYPTOLIB_SYSV_X64_ABI is defined, remaps rdi, rsi, rdx, rcx -> rcx, rdx, r8, r9.
+// Move order avoids register clobbering: save rcx and rdx first.
 // Usage:
-//   procedure MyProc(P1, P2, P3, P4: Pointer);
+//   procedure MyProc(P1, P2, P3: Pointer; P4: Int32);
 //     {$I ..\..\Include\Simd\Common\SimdProc4Begin_x86_64.inc}
 //     // ... instructions using rcx, rdx, r8, r9 ...
 //   end;
 {$IFDEF FPC}
   assembler; nostackframe;
+{$ENDIF}
 asm
-  {$IFNDEF MSWINDOWS}
+{$IFNDEF FPC}
+  .noframe
+{$ENDIF}
+{$IFDEF CRYPTOLIB_SYSV_X64_ABI}
   mov r9, rcx
   mov r8, rdx
   mov rdx, rsi
   mov rcx, rdi
-  {$ENDIF}
-{$ELSE}
-asm
-  .noframe
 {$ENDIF}

--- a/CryptoLib/src/Include/Simd/Common/SimdProc5Begin_i386.inc
+++ b/CryptoLib/src/Include/Simd/Common/SimdProc5Begin_i386.inc
@@ -2,8 +2,8 @@
 // After inclusion: ebx = param1, esi = param2, edi = param3, eax = param4, ecx = param5
 //   (i386 register convention).
 // FPC: param4 and param5 are at [esp+20] and [esp+16] after push EBX/ESI/EDI (see asm).
-// Delphi Win32: param4 at dword ptr [ebp + 12], param5 at dword ptr [ebp + 8].
-// Callee-saved EBX, ESI, EDI — epilogue must pop EDI, ESI, EBX.
+// Delphi Win32: first 3 params in EAX/EDX/ECX; param4 at [ebp+12], param5 at [ebp+8].
+// Callee-saved EBX, ESI, EDI - epilogue must pop EDI, ESI, EBX.
 // Usage:
 //   procedure MyProc(P1, P2: Pointer; P3, P4: Int32; P5: Pointer);
 //     {$I ..\..\Include\Simd\Common\SimdProc5Begin_i386.inc}
@@ -22,7 +22,6 @@ asm
   mov ecx, dword ptr [esp + 16] // param5
 {$ELSE}
 asm
-  {$IFDEF MSWINDOWS}
   push ebx
   push esi
   push edi
@@ -31,14 +30,4 @@ asm
   mov edi, ecx
   mov eax, dword ptr [ebp + 12] // param4 (first stack param = high address)
   mov ecx, dword ptr [ebp + 8]  // param5 (last stack param)
-  {$ELSE}
-  push ebx
-  push esi
-  push edi
-  mov ebx, dword ptr [ebp + 8]
-  mov esi, dword ptr [ebp + 12]
-  mov edi, dword ptr [ebp + 16]
-  mov eax, dword ptr [ebp + 20]
-  mov ecx, dword ptr [ebp + 24]
-  {$ENDIF}
 {$ENDIF}

--- a/CryptoLib/src/Include/Simd/Common/SimdProc5Begin_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Common/SimdProc5Begin_x86_64.inc
@@ -1,7 +1,8 @@
 // Shared SIMD/asm procedure prologue (5 parameters, x86-64).
-// After inclusion: rcx = param1, rdx = param2, r8 = param3, r9 = param4, r10 = param5 (MS x64 ABI).
-// On FPC non-Windows, remaps rdi, rsi, rdx, rcx, r8 -> rcx, rdx, r8, r9, r10.
-// On MS x64, 5th argument is at [rsp+40] after the call (shadow space + return address).
+// After inclusion: rcx = param1, rdx = param2, r8 = param3, r9 = param4, r10 = param5
+// (MS x64 ABI).
+// When CRYPTOLIB_SYSV_X64_ABI is defined, remaps rdi, rsi, rdx, rcx, r8 -> rcx, rdx, r8, r9, r10.
+// On MS x64, param5 is loaded from [rsp+40] (above 32-byte shadow space + 8-byte return addr).
 // Usage:
 //   procedure MyProc(P1, P2: Pointer; P3, P4: Int32; P5: Pointer);
 //     {$I ..\..\Include\Simd\Common\SimdProc5Begin_x86_64.inc}
@@ -9,18 +10,17 @@
 //   end;
 {$IFDEF FPC}
   assembler; nostackframe;
+{$ENDIF}
 asm
-  {$IFNDEF MSWINDOWS}
+{$IFNDEF FPC}
+  .noframe
+{$ENDIF}
+{$IFDEF CRYPTOLIB_SYSV_X64_ABI}
   mov r10, r8
   mov r9, rcx
   mov r8, rdx
   mov rdx, rsi
   mov rcx, rdi
-  {$ELSE}
-  mov r10, [rsp + 40]
-  {$ENDIF}
 {$ELSE}
-asm
-  .noframe
   mov r10, [rsp + 40]
 {$ENDIF}

--- a/CryptoLib/src/Include/Simd/Common/SimdProc6Begin_i386.inc
+++ b/CryptoLib/src/Include/Simd/Common/SimdProc6Begin_i386.inc
@@ -2,8 +2,9 @@
 // After inclusion: ebx = param1, esi = param2, edi = param3, eax = param4,
 //   ecx = param5 low, edx = param5 high (UInt64 split); param6 is not loaded in this prologue.
 // FPC: param4 at [esp+28]; param5 at [esp+20]/[esp+24]; param6 at [esp+16] after push EBX/ESI/EDI (see asm).
-// Delphi Win32: param4 at [ebp+20], param5 lo/hi at [ebp+12]/[ebp+16], param6 at [ebp+8].
-// Callee-saved EBX, ESI, EDI — epilogue must pop EDI, ESI, EBX; SIMD bodies may adjust ESP for locals.
+// Delphi Win32: first 3 params in EAX/EDX/ECX; param4 at [ebp+20],
+//   param5 at [ebp+12]/[ebp+16], param6 at [ebp+8].
+// Callee-saved EBX, ESI, EDI - epilogue must pop EDI, ESI, EBX; SIMD bodies may adjust ESP for locals.
 // Usage:
 //   procedure MyProc(P1, P2, P3: Pointer; P4: Int32; P5: UInt64; P6: UInt32);
 //     {$I ..\..\Include\Simd\Common\SimdProc6Begin_i386.inc}
@@ -23,7 +24,6 @@ asm
   mov edx, dword ptr [esp + 24] // param5_hi
 {$ELSE}
 asm
-  {$IFDEF MSWINDOWS}
   push ebx
   push esi
   push edi
@@ -33,15 +33,4 @@ asm
   mov eax, dword ptr [ebp + 20] // param4 (first stack param = high address)
   mov ecx, dword ptr [ebp + 12] // param5_lo
   mov edx, dword ptr [ebp + 16] // param5_hi
-  {$ELSE}
-  push ebx
-  push esi
-  push edi
-  mov ebx, eax
-  mov esi, edx
-  mov edi, ecx
-  mov eax, dword ptr [ebp + 20]
-  mov ecx, dword ptr [ebp + 12]
-  mov edx, dword ptr [ebp + 16]
-  {$ENDIF}
 {$ENDIF}

--- a/CryptoLib/src/Include/Simd/Common/SimdProc6Begin_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Common/SimdProc6Begin_x86_64.inc
@@ -1,0 +1,29 @@
+// Shared SIMD procedure prologue for 6-parameter assembly functions (x86-64).
+// After inclusion: rcx = param1, rdx = param2, r8 = param3, r9 = param4,
+//   r10 = param5, r11 = param6 (MS x64 ABI layout).
+// When CRYPTOLIB_SYSV_X64_ABI is defined, remaps rdi, rsi, rdx, rcx, r8, r9 ->
+//   rcx, rdx, r8, r9, r10, r11.
+// On MS x64, param5/6 are loaded from [rsp+40]/[rsp+48] (above shadow space + return addr).
+// Usage:
+//   procedure MyProc(P1, P2, P3: Pointer; P4: Int32; P5: UInt64; P6: UInt32);
+//     {$I ..\..\Include\Simd\Common\SimdProc6Begin_x86_64.inc}
+//     // ... SIMD instructions using rcx, rdx, r8, r9, r10, r11 ...
+//   end;
+{$IFDEF FPC}
+  assembler; nostackframe;
+{$ENDIF}
+asm
+{$IFNDEF FPC}
+  .noframe
+{$ENDIF}
+{$IFDEF CRYPTOLIB_SYSV_X64_ABI}
+  mov r11, r9
+  mov r10, r8
+  mov r9, rcx
+  mov r8, rdx
+  mov rdx, rsi
+  mov rcx, rdi
+{$ELSE}
+  mov r10, [rsp + 40]
+  mov r11, [rsp + 48]
+{$ENDIF}

--- a/CryptoLib/src/Include/Simd/CpuFeatures/CpuIdQuery.inc
+++ b/CryptoLib/src/Include/Simd/CpuFeatures/CpuIdQuery.inc
@@ -1,15 +1,10 @@
-// CPUID query helper (i386 + x86-64).
-// Issues `cpuid` with the caller-supplied leaf / subleaf and writes the
-// returned eax, ebx, ecx, edx quad into a TCpuIdResult record at the
-// supplied pointer.
-//
-// Entry contract (register convention varies by ABI):
-//   i386:             eax = leaf, edx = subleaf, ecx = @TCpuIdResult.
-//   x86-64 MS ABI:    ecx = leaf, edx = subleaf, r8 = @TCpuIdResult.
-//   x86-64 FPC Unix:  rdi = leaf, rsi = subleaf, rdx = @TCpuIdResult
-//                     (remapped internally to eax, ecx, r8).
-// Preserves ebx / rbx around `cpuid` (required by all supported ABIs); on
-// i386 also preserves esi (used to hold the result pointer during `cpuid`).
+// CPUID query: executes CPUID with leaf=ALeaf, subleaf=ASubLeaf,
+// stores EAX/EBX/ECX/EDX into the TCpuIdResult record at AResult.
+// IA-32 fastcall entry: EAX=ALeaf, EDX=ASubLeaf, ECX=AResult.
+// x86-64 entry (per OS ABI):
+//   Windows (MS ABI):   RCX=ALeaf, RDX=ASubLeaf, R8=AResult.
+//   Unix    (SysV ABI): RDI=ALeaf, RSI=ASubLeaf, RDX=AResult.
+// CPUID clobbers EBX, so RBX is preserved across the call.
 {$IFDEF FPC}
   assembler; nostackframe;
 {$ENDIF}
@@ -17,9 +12,9 @@ asm
 {$IFDEF CRYPTOLIB_I386_ASM}
   push ebx
   push esi
-  mov esi, ecx
-  mov ecx, edx
-  cpuid
+  mov esi, ecx       // save AResult (was in ECX) across cpuid
+  mov ecx, edx       // ECX := ASubLeaf
+  cpuid              // EAX already holds ALeaf
   mov [esi], eax
   mov [esi + 4], ebx
   mov [esi + 8], ecx
@@ -27,35 +22,29 @@ asm
   pop esi
   pop ebx
 {$ELSE}
+  // x86-64: normalize to EAX=ALeaf, ECX=ASubLeaf, R8=AResult, then cpuid.
+  // Preserve RBX (CPUID clobbers it).
   {$IFDEF FPC}
   push rbx
-  {$IFDEF MSWINDOWS}
-  mov eax, ecx
-  mov ecx, edx
-  cpuid
-  mov dword ptr [r8], eax
-  mov dword ptr [r8 + 4], ebx
-  mov dword ptr [r8 + 8], ecx
-  mov dword ptr [r8 + 12], edx
-  {$ELSE}
-  mov eax, edi
-  mov ecx, esi
-  mov r8, rdx
-  cpuid
-  mov dword ptr [r8], eax
-  mov dword ptr [r8 + 4], ebx
-  mov dword ptr [r8 + 8], ecx
-  mov dword ptr [r8 + 12], edx
-  {$ENDIF}
-  pop rbx
   {$ELSE}
   .PUSHNV RBX
-  mov eax, ecx
-  mov ecx, edx
+  {$ENDIF}
+  {$IFDEF CRYPTOLIB_SYSV_X64_ABI}
+  // SysV ABI entry: RDI=ALeaf, RSI=ASubLeaf, RDX=AResult.
+  mov eax, edi       // EAX := ALeaf
+  mov ecx, esi       // ECX := ASubLeaf
+  mov r8, rdx        // R8  := AResult
+  {$ELSE}
+  // MS ABI entry: RCX=ALeaf, RDX=ASubLeaf, R8=AResult.
+  mov eax, ecx       // EAX := ALeaf
+  mov ecx, edx       // ECX := ASubLeaf
+  {$ENDIF}
   cpuid
   mov dword ptr [r8], eax
   mov dword ptr [r8 + 4], ebx
   mov dword ptr [r8 + 8], ecx
   mov dword ptr [r8 + 12], edx
+  {$IFDEF FPC}
+  pop rbx
   {$ENDIF}
 {$ENDIF}

--- a/CryptoLib/src/Include/Simd/CpuFeatures/XGetBvQuery.inc
+++ b/CryptoLib/src/Include/Simd/CpuFeatures/XGetBvQuery.inc
@@ -1,42 +1,36 @@
-// XGETBV query helper, ECX = 0 (i386 + x86-64).
-// Issues `xgetbv` with ECX = 0 (reads XCR0) and writes the returned
-// EAX:EDX 64-bit value to the UInt64 at the supplied pointer.
-//
-// Entry contract (register convention varies by ABI):
-//   i386:             eax = @AResult.
-//   x86-64 MS ABI:    rcx = @AResult (remapped internally to r8).
-//   x86-64 FPC Unix:  rdi = @AResult (remapped internally to r8).
-// Preserves ebx on i386. XGETBV is db-encoded for broad assembler
-// compatibility.
+// XGETBV query: executes XGETBV with ECX=0, stores EAX:EDX into the
+// UInt64 at AResult.
+// IA-32 fastcall entry: EAX=AResult.
+// x86-64 entry (per OS ABI):
+//   Windows (MS ABI):   RCX=AResult.
+//   Unix    (SysV ABI): RDI=AResult.
+// XGETBV does not clobber RBX, so no preservation is needed on x86-64.
 {$IFDEF FPC}
   assembler; nostackframe;
 {$ENDIF}
 asm
 {$IFDEF CRYPTOLIB_I386_ASM}
   push ebx
-  mov ebx, eax
-  xor ecx, ecx
-  db $0F, $01, $D0 // xgetbv
+  mov ebx, eax       // save AResult (was in EAX) across xgetbv
+  xor ecx, ecx       // XCR index 0
+  db $0F, $01, $D0   // xgetbv -> EDX:EAX
   mov [ebx], eax
   mov [ebx + 4], edx
   pop ebx
 {$ELSE}
-  {$IFDEF FPC}
-  {$IFDEF MSWINDOWS}
-  mov r8, rcx
-  {$ELSE}
-  mov r8, rdi
-  {$ENDIF}
-  xor ecx, ecx
-  db $0F, $01, $D0 // xgetbv
-  mov dword ptr [r8], eax
-  mov dword ptr [r8 + 4], edx
-  {$ELSE}
+  // x86-64: normalize to R8=AResult, then xgetbv.
+  {$IFNDEF FPC}
   .noframe
-  mov r8, rcx
-  xor ecx, ecx
-  db $0F, $01, $D0 // xgetbv
+  {$ENDIF}
+  {$IFDEF CRYPTOLIB_SYSV_X64_ABI}
+  // SysV ABI entry: RDI=AResult.
+  mov r8, rdi        // R8 := AResult
+  {$ELSE}
+  // MS ABI entry: RCX=AResult.
+  mov r8, rcx        // R8 := AResult
+  {$ENDIF}
+  xor ecx, ecx       // XCR index 0
+  db $0F, $01, $D0   // xgetbv -> EDX:EAX
   mov dword ptr [r8], eax
   mov dword ptr [r8 + 4], edx
-  {$ENDIF}
 {$ENDIF}

--- a/CryptoLib/src/Misc/ClpArmSimdFeatures.pas
+++ b/CryptoLib/src/Misc/ClpArmSimdFeatures.pas
@@ -71,6 +71,18 @@ type
     class function HasSHA3(): Boolean; static;
     class function HasCRC32(): Boolean; static;
     class function HasPMULL(): Boolean; static;
+
+    // Picks the highest declared tier in ATiers that is <= the cached
+    // FActiveSimdLevel. Falls back to TArmSimdLevel.Scalar when no tier
+    // matches or ATiers is empty. Dispatch units use this overload.
+    class function SelectSlot(const ATiers: array of TArmSimdLevel)
+      : TArmSimdLevel; overload; static;
+
+    // Pure overload: reasons over any caller-supplied active level.
+    // Used by tests to deterministically exercise fallback semantics
+    // without depending on the host CPU.
+    class function SelectSlot(AActiveLevel: TArmSimdLevel;
+      const ATiers: array of TArmSimdLevel): TArmSimdLevel; overload; static;
   end;
 
 implementation
@@ -478,6 +490,39 @@ end;
 class function TArmSimdFeatures.HasPMULL(): Boolean;
 begin
   Result := FHasPMULL;
+end;
+
+class function TArmSimdFeatures.SelectSlot(const ATiers
+  : array of TArmSimdLevel): TArmSimdLevel;
+begin
+  Result := SelectSlot(FActiveSimdLevel, ATiers);
+end;
+
+class function TArmSimdFeatures.SelectSlot(AActiveLevel: TArmSimdLevel;
+  const ATiers: array of TArmSimdLevel): TArmSimdLevel;
+var
+  I: Integer;
+  LTier, LBest: TArmSimdLevel;
+  LFound: Boolean;
+begin
+  // Walk all declared tiers, keep the highest one that is <= AActiveLevel.
+  // Order of ATiers is irrelevant. Empty ATiers or no matching tier yields
+  // TArmSimdLevel.Scalar so dispatch units cleanly fall through to scalar.
+  LBest := TArmSimdLevel.Scalar;
+  LFound := False;
+  for I := 0 to System.Length(ATiers) - 1 do
+  begin
+    LTier := ATiers[I];
+    if (LTier <= AActiveLevel) and ((not LFound) or (LTier > LBest)) then
+    begin
+      LBest := LTier;
+      LFound := True;
+    end;
+  end;
+  if LFound then
+    Result := LBest
+  else
+    Result := TArmSimdLevel.Scalar;
 end;
 
 initialization

--- a/CryptoLib/src/Misc/ClpX86SimdFeatures.pas
+++ b/CryptoLib/src/Misc/ClpX86SimdFeatures.pas
@@ -66,6 +66,18 @@ type
     class function HasPCLMULQDQ(): Boolean; static;
     class function HasVPCLMULQDQ(): Boolean; static;
     class function HasAESNI(): Boolean; static;
+
+    // Picks the highest declared tier in ATiers that is <= the cached
+    // FActiveSimdLevel. Falls back to TX86SimdLevel.Scalar when no tier
+    // matches or ATiers is empty. Dispatch units use this overload.
+    class function SelectSlot(const ATiers: array of TX86SimdLevel)
+      : TX86SimdLevel; overload; static;
+
+    // Pure overload: reasons over any caller-supplied active level.
+    // Used by tests to deterministically exercise fallback semantics
+    // without depending on the host CPU.
+    class function SelectSlot(AActiveLevel: TX86SimdLevel;
+      const ATiers: array of TX86SimdLevel): TX86SimdLevel; overload; static;
   end;
 
 implementation
@@ -376,6 +388,39 @@ end;
 class function TX86SimdFeatures.HasAESNI(): Boolean;
 begin
   Result := FHasAESNI;
+end;
+
+class function TX86SimdFeatures.SelectSlot(const ATiers
+  : array of TX86SimdLevel): TX86SimdLevel;
+begin
+  Result := SelectSlot(FActiveSimdLevel, ATiers);
+end;
+
+class function TX86SimdFeatures.SelectSlot(AActiveLevel: TX86SimdLevel;
+  const ATiers: array of TX86SimdLevel): TX86SimdLevel;
+var
+  I: Integer;
+  LTier, LBest: TX86SimdLevel;
+  LFound: Boolean;
+begin
+  // Walk all declared tiers, keep the highest one that is <= AActiveLevel.
+  // Order of ATiers is irrelevant. Empty ATiers or no matching tier yields
+  // TX86SimdLevel.Scalar so dispatch units cleanly fall through to scalar.
+  LBest := TX86SimdLevel.Scalar;
+  LFound := False;
+  for I := 0 to System.Length(ATiers) - 1 do
+  begin
+    LTier := ATiers[I];
+    if (LTier <= AActiveLevel) and ((not LFound) or (LTier > LBest)) then
+    begin
+      LBest := LTier;
+      LFound := True;
+    end;
+  end;
+  if LFound then
+    Result := LBest
+  else
+    Result := TX86SimdLevel.Scalar;
 end;
 
 initialization

--- a/CryptoLib/src/Misc/ClpX86SimdFeatures.pas
+++ b/CryptoLib/src/Misc/ClpX86SimdFeatures.pas
@@ -26,12 +26,6 @@ uses
 type
   TX86SimdFeatures = class sealed
   strict private
-  type
-    TCpuIdResult = record
-      RegEAX, RegEBX, RegECX, RegEDX: UInt32;
-    end;
-
-  strict private
   class var
     FActiveSimdLevel: TX86SimdLevel;
     FHasSHANI: Boolean;
@@ -50,6 +44,11 @@ type
     class function CPUHasPCLMULQDQ(): Boolean; static;
     class function CPUHasVPCLMULQDQ(): Boolean; static;
     class function CPUHasAESNI(): Boolean; static;
+
+    // Clears all the "extra" CPU feature flags (SHA-NI, PCLMULQDQ,
+    // VPCLMULQDQ, AES-NI). Used by ApplyBuildOverrides to give every
+    // CRYPTOLIB_FORCE_* branch a uniform "no accelerated extras" baseline.
+    class procedure DisableAllExtraFeatures(); static;
 
   private
     class procedure ProbeHardwareAndCache(); static;
@@ -71,13 +70,18 @@ type
 
 implementation
 
+type
+  TCpuIdResult = record
+    RegEAX, RegEBX, RegECX, RegEDX: UInt32;
+  end;
+
 {$IFDEF CRYPTOLIB_X86_SIMD}
 
-procedure CpuIdQuery(ALeaf, ASubLeaf: UInt32; AResult: Pointer);
+procedure CpuIdQuery(ALeaf, ASubLeaf: UInt32; out AResult: TCpuIdResult);
   {$I ..\Include\Simd\CpuFeatures\CpuIdQuery.inc}
 end;
 
-procedure XGetBvQuery(AResult: Pointer);
+procedure XGetBvQuery(out AResult: UInt64);
   {$I ..\Include\Simd\CpuFeatures\XGetBvQuery.inc}
 end;
 
@@ -92,7 +96,7 @@ var
 {$ENDIF}
 begin
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  CpuIdQuery(1, 0, @LCpuId);
+  CpuIdQuery(1, 0, LCpuId);
   Result := (LCpuId.RegEDX and (1 shl 26)) <> 0;
 {$ELSE}
   Result := False;
@@ -106,7 +110,7 @@ var
 {$ENDIF}
 begin
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  CpuIdQuery(1, 0, @LCpuId);
+  CpuIdQuery(1, 0, LCpuId);
   // SSSE3: ECX bit 9
   Result := (LCpuId.RegECX and (1 shl 9)) <> 0;
 {$ELSE}
@@ -121,7 +125,7 @@ var
 {$ENDIF}
 begin
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  CpuIdQuery(1, 0, @LCpuId);
+  CpuIdQuery(1, 0, LCpuId);
   // SSE3: ECX bit 0
   Result := (LCpuId.RegECX and (1 shl 0)) <> 0;
 {$ELSE}
@@ -136,7 +140,7 @@ var
 {$ENDIF}
 begin
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  CpuIdQuery(1, 0, @LCpuId);
+  CpuIdQuery(1, 0, LCpuId);
   // SSE4.1: ECX bit 19
   Result := (LCpuId.RegECX and (1 shl 19)) <> 0;
 {$ELSE}
@@ -151,7 +155,7 @@ var
 {$ENDIF}
 begin
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  CpuIdQuery(1, 0, @LCpuId);
+  CpuIdQuery(1, 0, LCpuId);
   // SSE4.2: ECX bit 20
   Result := (LCpuId.RegECX and (1 shl 20)) <> 0;
 {$ELSE}
@@ -167,7 +171,7 @@ var
 {$ENDIF}
 begin
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  CpuIdQuery(1, 0, @LCpuId);
+  CpuIdQuery(1, 0, LCpuId);
 
   // OSXSAVE: ECX bit 27 (required for OS AVX state saving)
   if (LCpuId.RegECX and (1 shl 27)) = 0 then
@@ -175,11 +179,11 @@ begin
 
   // XCR0 bits 1 and 2 must be set for AVX state support
   LXcr0 := 0;
-  XGetBvQuery(@LXcr0);
+  XGetBvQuery(LXcr0);
   if (UInt32(LXcr0) and $06) <> $06 then
     Exit(False);
 
-  CpuIdQuery(7, 0, @LCpuId);
+  CpuIdQuery(7, 0, LCpuId);
 
   // AVX2: EBX bit 5
   Result := (LCpuId.RegEBX and (1 shl 5)) <> 0;
@@ -195,7 +199,7 @@ var
 {$ENDIF}
 begin
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  CpuIdQuery(7, 0, @LCpuId);
+  CpuIdQuery(7, 0, LCpuId);
   // SHA-NI: EBX bit 29
   Result := (LCpuId.RegEBX and (1 shl 29)) <> 0;
 {$ELSE}
@@ -210,7 +214,7 @@ var
 {$ENDIF}
 begin
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  CpuIdQuery(1, 0, @LCpuId);
+  CpuIdQuery(1, 0, LCpuId);
   // PCLMULQDQ: ECX bit 1
   Result := (LCpuId.RegECX and (1 shl 1)) <> 0;
 {$ELSE}
@@ -225,7 +229,7 @@ var
 {$ENDIF}
 begin
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  CpuIdQuery(7, 0, @LCpuId);
+  CpuIdQuery(7, 0, LCpuId);
   // VPCLMULQDQ: ECX bit 10
   Result := (LCpuId.RegECX and (1 shl 10)) <> 0;
 {$ELSE}
@@ -240,12 +244,20 @@ var
 {$ENDIF}
 begin
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  CpuIdQuery(1, 0, @LCpuId);
+  CpuIdQuery(1, 0, LCpuId);
   // AES-NI: ECX bit 25
   Result := (LCpuId.RegECX and (1 shl 25)) <> 0;
 {$ELSE}
   Result := False;
 {$ENDIF}
+end;
+
+class procedure TX86SimdFeatures.DisableAllExtraFeatures();
+begin
+  FHasSHANI := False;
+  FHasPCLMULQDQ := False;
+  FHasVPCLMULQDQ := False;
+  FHasAESNI := False;
 end;
 
 class procedure TX86SimdFeatures.ProbeHardwareAndCache();
@@ -287,45 +299,27 @@ class procedure TX86SimdFeatures.ApplyBuildOverrides();
 begin
 {$IF DEFINED(CRYPTOLIB_FORCE_SCALAR)}
   FActiveSimdLevel := TX86SimdLevel.Scalar;
-  FHasSHANI := False;
-  FHasPCLMULQDQ := False;
-  FHasVPCLMULQDQ := False;
-  FHasAESNI := False;
+  DisableAllExtraFeatures;
 {$ELSEIF DEFINED(CRYPTOLIB_FORCE_SSE2)}
   if FActiveSimdLevel > TX86SimdLevel.SSE2 then
     FActiveSimdLevel := TX86SimdLevel.SSE2;
-  FHasSHANI := False;
-  FHasPCLMULQDQ := False;
-  FHasVPCLMULQDQ := False;
-  FHasAESNI := False;
+  DisableAllExtraFeatures;
 {$ELSEIF DEFINED(CRYPTOLIB_FORCE_SSE3)}
   if FActiveSimdLevel > TX86SimdLevel.SSE3 then
     FActiveSimdLevel := TX86SimdLevel.SSE3;
-  FHasSHANI := False;
-  FHasPCLMULQDQ := False;
-  FHasVPCLMULQDQ := False;
-  FHasAESNI := False;
+  DisableAllExtraFeatures;
 {$ELSEIF DEFINED(CRYPTOLIB_FORCE_SSSE3)}
   if FActiveSimdLevel > TX86SimdLevel.SSSE3 then
     FActiveSimdLevel := TX86SimdLevel.SSSE3;
-  FHasSHANI := False;
-  FHasPCLMULQDQ := False;
-  FHasVPCLMULQDQ := False;
-  FHasAESNI := False;
+  DisableAllExtraFeatures;
 {$ELSEIF DEFINED(CRYPTOLIB_FORCE_SSE41)}
   if FActiveSimdLevel > TX86SimdLevel.SSE41 then
     FActiveSimdLevel := TX86SimdLevel.SSE41;
-  FHasSHANI := False;
-  FHasPCLMULQDQ := False;
-  FHasVPCLMULQDQ := False;
-  FHasAESNI := False;
+  DisableAllExtraFeatures;
 {$ELSEIF DEFINED(CRYPTOLIB_FORCE_SSE42)}
   if FActiveSimdLevel > TX86SimdLevel.SSE42 then
     FActiveSimdLevel := TX86SimdLevel.SSE42;
-  FHasSHANI := False;
-  FHasPCLMULQDQ := False;
-  FHasVPCLMULQDQ := False;
-  FHasAESNI := False;
+  DisableAllExtraFeatures;
 {$IFEND}
 end;
 


### PR DESCRIPTION
## SelectSlot for SIMD dispatch

Adds `TX86SimdFeatures.SelectSlot` and `TArmSimdFeatures.SelectSlot` —
a small declarative API for picking the highest available SIMD tier
from a caller-supplied list, with scalar fallback. Replaces the
`if HasAVX2 ... else if HasSSE2 ... else scalar` chains in
`TChaCha7539Engine`, `TChaChaEngine`, `TSalsa20Engine`, and `TPoly1305`.
A pure overload taking an explicit active level enables host-CPU-
independent tests. New `SimdSelectSlotTests` covers exact-match,
step-down, empty list, scalar host, and order independence for both
the X86 and ARM surfaces.

## ABI plumbing

Centralizes the x86-64 ABI decision behind `CRYPTOLIB_SYSV_X64_ABI`
(defined when `CRYPTOLIB_X86_64 AND NOT CRYPTOLIB_MSWINDOWS`). All
SIMD prologues (`SimdProc{1..6}Begin_x86_64.inc`) and CPU-feature
shims (`CpuIdQuery.inc`, `XGetBvQuery.inc`) now key on this single
symbol rather than re-deriving from `FPC AND NOT MSWINDOWS`. 
Prologues collapse to two flat axes (frame directive, ABI) instead of 
nested compiler/OS branches; MS-ABI stack-load lines in files 5/6 are now 
written once. i386 prologues collapse identical FPC and Delphi-Win32 
branches (files 1–3) and drop dead Delphi-non-Windows branches (files 4–6). 
`TCpuIdResult` moved to implementation-section type; `CpuIdQuery` / `XGetBvQuery` 
take typed `out` parameters; six identical kill-blocks in `ApplyBuildOverrides`
factored into `DisableAllExtraFeatures`. New `SimdProc6Begin_x86_64.inc`
added for symmetry with the i386 counterpart.

## What didn't change

- No instruction sequences in any SIMD body modified.
- Byte-identical output across every dispatch path and SIMD tier.
- `Has<Feature>` predicates remain available alongside `SelectSlot`.
- No new conditional defines required from callers.