### PR TITLE
Refactor PackTauOrSigma and ChaCha callers

### DIFF
--- a/CryptoLib/src/Crypto/Engines/ClpChaCha7539Engine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpChaCha7539Engine.pas
@@ -164,7 +164,7 @@ begin
         [AlgorithmName]);
     end;
 
-    PackTauOrSigma(System.Length(AKeyBytes), FEngineState, 0);
+    PackTauOrSigma(32, FEngineState);
 
     // Key
     TPack.LE_To_UInt32(AKeyBytes, 0, FEngineState, 4, 8);

--- a/CryptoLib/src/Crypto/Engines/ClpChaChaEngine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpChaChaEngine.pas
@@ -296,7 +296,7 @@ begin
         [AlgorithmName]);
     end;
 
-    PackTauOrSigma(System.Length(AKeyBytes), FEngineState, 0);
+    PackTauOrSigma(System.Length(AKeyBytes), FEngineState);
 
     // Key
     TPack.LE_To_UInt32(AKeyBytes, 0, FEngineState, 4, 4);
@@ -339,7 +339,7 @@ begin
   end;
 
   System.SetLength(LState, 16);
-  PackTauOrSigma(32, LState, 0);
+  PackTauOrSigma(32, LState);
   TPack.LE_To_UInt32(AKey256, 0, LState, 4, 8);
   TPack.LE_To_UInt32(ANonce128, 0, LState, 12, 4);
 

--- a/CryptoLib/src/Crypto/Engines/ClpSalsa20Engine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpSalsa20Engine.pas
@@ -113,7 +113,7 @@ type
     /// </returns>
     class function R(AX: UInt32; AY: Int32): UInt32; static; inline;
     class procedure PackTauOrSigma(AKeyLength: Int32;
-      const AState: TCryptoLibUInt32Array; AStateOffset: Int32); static;
+      const AState: TCryptoLibUInt32Array); static;
     class procedure SalsaCore(ARounds: Int32;
       const AInput, AX: TCryptoLibUInt32Array); static;
 
@@ -364,15 +364,15 @@ begin
 end;
 
 class procedure TSalsa20Engine.PackTauOrSigma(AKeyLength: Int32;
-  const AState: TCryptoLibUInt32Array; AStateOffset: Int32);
+  const AState: TCryptoLibUInt32Array);
 var
   LTsOff: Int32;
 begin
-  LTsOff := (AKeyLength - 16) div 4;
-  AState[AStateOffset] := TAU_SIGMA[LTsOff];
-  AState[AStateOffset + 1] := TAU_SIGMA[LTsOff + 1];
-  AState[AStateOffset + 2] := TAU_SIGMA[LTsOff + 2];
-  AState[AStateOffset + 3] := TAU_SIGMA[LTsOff + 3];
+  LTsOff := AKeyLength div 4 - 4;
+  AState[0] := TAU_SIGMA[LTsOff];
+  AState[1] := TAU_SIGMA[LTsOff + 1];
+  AState[2] := TAU_SIGMA[LTsOff + 2];
+  AState[3] := TAU_SIGMA[LTsOff + 3];
 end;
 
 procedure TSalsa20Engine.ProcessBytes(const AInBytes: TCryptoLibByteArray;

--- a/CryptoLib/src/Crypto/Engines/ClpSalsa20Engine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpSalsa20Engine.pas
@@ -368,7 +368,7 @@ class procedure TSalsa20Engine.PackTauOrSigma(AKeyLength: Int32;
 var
   LTsOff: Int32;
 begin
-  LTsOff := AKeyLength div 4 - 4;
+  LTsOff := (AKeyLength div 4) - 4;
   AState[0] := TAU_SIGMA[LTsOff];
   AState[1] := TAU_SIGMA[LTsOff + 1];
   AState[2] := TAU_SIGMA[LTsOff + 2];


### PR DESCRIPTION
- Simplify TSalsa20Engine.PackTauOrSigma to write state[0..3] directly
- Drop unused stateOffset parameter from the helper signature
- Use keyLength div 4 - 4 for tau/sigma index selection (equivalent for 128/256-bit keys)
- Update ChaChaEngine and ChaCha7539Engine call sites; use literal 32 in ChaCha7539 SetKey Behavior-preserving refactor; no API or test changes required.