### PR TITLE
use FPC LEtoN/BEtoN intrinsics for wire-to-native reads

### DIFF
--- a/CryptoLib/src/Misc/ClpBinaryPrimitives.pas
+++ b/CryptoLib/src/Misc/ClpBinaryPrimitives.pas
@@ -161,56 +161,80 @@ end;
 
 class function TBinaryPrimitives.LeToNativeUInt16(AValue: UInt16): UInt16;
 begin
-{$IFDEF CRYPTOLIB_LITTLE_ENDIAN}
-  Result := AValue;
+{$IFDEF FPC}
+  Result := LEtoN(AValue);
 {$ELSE}
+  {$IFDEF CRYPTOLIB_LITTLE_ENDIAN}
+  Result := AValue;
+  {$ELSE}
   Result := TBitOperations.ReverseBytesUInt16(AValue);
-{$ENDIF}
+  {$ENDIF CRYPTOLIB_LITTLE_ENDIAN}
+{$ENDIF FPC}
 end;
 
 class function TBinaryPrimitives.LeToNativeUInt32(AValue: UInt32): UInt32;
 begin
-{$IFDEF CRYPTOLIB_LITTLE_ENDIAN}
-  Result := AValue;
+{$IFDEF FPC}
+  Result := LEtoN(AValue);
 {$ELSE}
+  {$IFDEF CRYPTOLIB_LITTLE_ENDIAN}
+  Result := AValue;
+  {$ELSE}
   Result := TBitOperations.ReverseBytesUInt32(AValue);
-{$ENDIF}
+  {$ENDIF CRYPTOLIB_LITTLE_ENDIAN}
+{$ENDIF FPC}
 end;
 
 class function TBinaryPrimitives.LeToNativeUInt64(AValue: UInt64): UInt64;
 begin
-{$IFDEF CRYPTOLIB_LITTLE_ENDIAN}
-  Result := AValue;
+{$IFDEF FPC}
+  Result := LEtoN(AValue);
 {$ELSE}
+  {$IFDEF CRYPTOLIB_LITTLE_ENDIAN}
+  Result := AValue;
+  {$ELSE}
   Result := TBitOperations.ReverseBytesUInt64(AValue);
-{$ENDIF}
+  {$ENDIF CRYPTOLIB_LITTLE_ENDIAN}
+{$ENDIF FPC}
 end;
 
 class function TBinaryPrimitives.BeToNativeUInt16(AValue: UInt16): UInt16;
 begin
-{$IFDEF CRYPTOLIB_LITTLE_ENDIAN}
-  Result := TBitOperations.ReverseBytesUInt16(AValue);
+{$IFDEF FPC}
+  Result := BEtoN(AValue);
 {$ELSE}
+  {$IFDEF CRYPTOLIB_LITTLE_ENDIAN}
+  Result := TBitOperations.ReverseBytesUInt16(AValue);
+  {$ELSE}
   Result := AValue;
-{$ENDIF}
+  {$ENDIF CRYPTOLIB_LITTLE_ENDIAN}
+{$ENDIF FPC}
 end;
 
 class function TBinaryPrimitives.BeToNativeUInt32(AValue: UInt32): UInt32;
 begin
-{$IFDEF CRYPTOLIB_LITTLE_ENDIAN}
-  Result := TBitOperations.ReverseBytesUInt32(AValue);
+{$IFDEF FPC}
+  Result := BEtoN(AValue);
 {$ELSE}
+  {$IFDEF CRYPTOLIB_LITTLE_ENDIAN}
+  Result := TBitOperations.ReverseBytesUInt32(AValue);
+  {$ELSE}
   Result := AValue;
-{$ENDIF}
+  {$ENDIF CRYPTOLIB_LITTLE_ENDIAN}
+{$ENDIF FPC}
 end;
 
 class function TBinaryPrimitives.BeToNativeUInt64(AValue: UInt64): UInt64;
 begin
-{$IFDEF CRYPTOLIB_LITTLE_ENDIAN}
-  Result := TBitOperations.ReverseBytesUInt64(AValue);
+{$IFDEF FPC}
+  Result := BEtoN(AValue);
 {$ELSE}
+  {$IFDEF CRYPTOLIB_LITTLE_ENDIAN}
+  Result := TBitOperations.ReverseBytesUInt64(AValue);
+  {$ELSE}
   Result := AValue;
-{$ENDIF}
+  {$ENDIF CRYPTOLIB_LITTLE_ENDIAN}
+{$ENDIF FPC}
 end;
 
 // ============================================================================


### PR DESCRIPTION
Replace the hand-rolled {$IFDEF CRYPTOLIB_LITTLE_ENDIAN} branches in the six private read-side helpers with FPC's dedicated, self-endian-aware RTL intrinsics:

  LeToNativeUInt16/32/64 -> LEtoN
  BeToNativeUInt16/32/64 -> BEtoN

The intrinsic is used on FPC; Delphi keeps the existing fallback verbatim via {$ELSE}. Generated little-endian code is unchanged (LEtoN/BEtoN are the identity on LE hosts, a bswap on BE) -- this is an idiomatic/clarity change that drops these functions' reliance on the CRYPTOLIB_LITTLE_ENDIAN define and defers the endianness decision to the RTL. All Read* overloads route through these helpers, so the whole read path is covered transitively.