### PR TITLE
Remove HashLib IHash leak from public IDigest

### DIFF
--- a/CryptoLib.Benchmark/Delphi/CryptoLib.BenchmarkConsole.dpr
+++ b/CryptoLib.Benchmark/Delphi/CryptoLib.BenchmarkConsole.dpr
@@ -182,6 +182,7 @@ uses
   ClpIDHBasicAgreement in '..\..\CryptoLib\src\Interfaces\Crypto\Agreements\ClpIDHBasicAgreement.pas',
   ClpIDHGenerators in '..\..\CryptoLib\src\Interfaces\Crypto\Generators\ClpIDHGenerators.pas',
   ClpIDHParameters in '..\..\CryptoLib\src\Interfaces\Crypto\Parameters\ClpIDHParameters.pas',
+  ClpIBackingHashProvider in '..\..\CryptoLib\src\Interfaces\Crypto\Digests\ClpIBackingHashProvider.pas',
   ClpIDigest in '..\..\CryptoLib\src\Interfaces\Crypto\Digests\ClpIDigest.pas',
   ClpIDigestFactory in '..\..\CryptoLib\src\Interfaces\Crypto\Operators\ClpIDigestFactory.pas',
   ClpIDigestRandomGenerator in '..\..\CryptoLib\src\Interfaces\Rngs\ClpIDigestRandomGenerator.pas',

--- a/CryptoLib.Examples/Delphi.Examples/CryptoLib.Examples.dpr
+++ b/CryptoLib.Examples/Delphi.Examples/CryptoLib.Examples.dpr
@@ -198,6 +198,7 @@ uses
   ClpIDHBasicAgreement in '..\..\CryptoLib\src\Interfaces\Crypto\Agreements\ClpIDHBasicAgreement.pas',
   ClpIDHGenerators in '..\..\CryptoLib\src\Interfaces\Crypto\Generators\ClpIDHGenerators.pas',
   ClpIDHParameters in '..\..\CryptoLib\src\Interfaces\Crypto\Parameters\ClpIDHParameters.pas',
+  ClpIBackingHashProvider in '..\..\CryptoLib\src\Interfaces\Crypto\Digests\ClpIBackingHashProvider.pas',
   ClpIDigest in '..\..\CryptoLib\src\Interfaces\Crypto\Digests\ClpIDigest.pas',
   ClpIDigestFactory in '..\..\CryptoLib\src\Interfaces\Crypto\Operators\ClpIDigestFactory.pas',
   ClpIDigestRandomGenerator in '..\..\CryptoLib\src\Interfaces\Rngs\ClpIDigestRandomGenerator.pas',

--- a/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.Mobile.dpr
+++ b/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.Mobile.dpr
@@ -179,6 +179,7 @@ uses
   ClpIDHBasicAgreement in '..\..\CryptoLib\src\Interfaces\Crypto\Agreements\ClpIDHBasicAgreement.pas',
   ClpIDHGenerators in '..\..\CryptoLib\src\Interfaces\Crypto\Generators\ClpIDHGenerators.pas',
   ClpIDHParameters in '..\..\CryptoLib\src\Interfaces\Crypto\Parameters\ClpIDHParameters.pas',
+  ClpIBackingHashProvider in '..\..\CryptoLib\src\Interfaces\Crypto\Digests\ClpIBackingHashProvider.pas',
   ClpIDigest in '..\..\CryptoLib\src\Interfaces\Crypto\Digests\ClpIDigest.pas',
   ClpIDigestFactory in '..\..\CryptoLib\src\Interfaces\Crypto\Operators\ClpIDigestFactory.pas',
   ClpIDigestRandomGenerator in '..\..\CryptoLib\src\Interfaces\Rngs\ClpIDigestRandomGenerator.pas',

--- a/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.Mobile.dproj
+++ b/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.Mobile.dproj
@@ -522,6 +522,7 @@
         <DCCReference Include="..\..\CryptoLib\src\Interfaces\Crypto\Agreements\ClpIDHBasicAgreement.pas"/>
         <DCCReference Include="..\..\CryptoLib\src\Interfaces\Crypto\Generators\ClpIDHGenerators.pas"/>
         <DCCReference Include="..\..\CryptoLib\src\Interfaces\Crypto\Parameters\ClpIDHParameters.pas"/>
+        <DCCReference Include="..\..\CryptoLib\src\Interfaces\Crypto\Digests\ClpIBackingHashProvider.pas"/>
         <DCCReference Include="..\..\CryptoLib\src\Interfaces\Crypto\Digests\ClpIDigest.pas"/>
         <DCCReference Include="..\..\CryptoLib\src\Interfaces\Crypto\Operators\ClpIDigestFactory.pas"/>
         <DCCReference Include="..\..\CryptoLib\src\Interfaces\Rngs\ClpIDigestRandomGenerator.pas"/>

--- a/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.dpr
+++ b/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.dpr
@@ -198,6 +198,7 @@ uses
   ClpIDHBasicAgreement in '..\..\CryptoLib\src\Interfaces\Crypto\Agreements\ClpIDHBasicAgreement.pas',
   ClpIDHGenerators in '..\..\CryptoLib\src\Interfaces\Crypto\Generators\ClpIDHGenerators.pas',
   ClpIDHParameters in '..\..\CryptoLib\src\Interfaces\Crypto\Parameters\ClpIDHParameters.pas',
+  ClpIBackingHashProvider in '..\..\CryptoLib\src\Interfaces\Crypto\Digests\ClpIBackingHashProvider.pas',
   ClpIDigest in '..\..\CryptoLib\src\Interfaces\Crypto\Digests\ClpIDigest.pas',
   ClpIDigestFactory in '..\..\CryptoLib\src\Interfaces\Crypto\Operators\ClpIDigestFactory.pas',
   ClpIDigestRandomGenerator in '..\..\CryptoLib\src\Interfaces\Rngs\ClpIDigestRandomGenerator.pas',

--- a/CryptoLib.Tests/src/Utils/ShortenedDigest.pas
+++ b/CryptoLib.Tests/src/Utils/ShortenedDigest.pas
@@ -27,6 +27,7 @@ uses
   HlpIHash,
   ClpDigest,
   ClpIDigest,
+  ClpIBackingHashProvider,
   ClpCryptoLibTypes;
 
 resourcestring
@@ -52,7 +53,7 @@ type
 
    strict protected
     function GetAlgorithmName: string; override;
-    function GetUnderlyingHasher: IHash; override;
+    function GetBackingHash: IHash; override;
 
   public
 
@@ -129,9 +130,14 @@ begin
   Result := FLength;
 end;
 
-function TShortenedDigest.GetUnderlyingHasher: IHash;
+function TShortenedDigest.GetBackingHash: IHash;
+var
+  LProvider: IBackingHashProvider;
 begin
-  Result := FBaseDigest.UnderlyingHasher;
+  if Supports(FBaseDigest, IBackingHashProvider, LProvider) then
+    Result := LProvider.BackingHash
+  else
+    Result := nil;
 end;
 
 procedure TShortenedDigest.Update(AInput: Byte);

--- a/CryptoLib/src/Crypto/Digests/ClpDigest.pas
+++ b/CryptoLib/src/Crypto/Digests/ClpDigest.pas
@@ -25,6 +25,7 @@ uses
   Generics.Collections,
   HlpIHash,
   ClpIDigest,
+  ClpIBackingHashProvider,
   ClpCryptoLibTypes;
 
 resourcestring
@@ -34,7 +35,7 @@ type
   /// <summary>
   /// Hash Wrapper For the Proper Implementation in HashLib4Pascal
   /// </summary>
-  TDigest = class(TInterfacedObject, IDigest)
+  TDigest = class(TInterfacedObject, IDigest, IBackingHashProvider)
 
   strict private
 
@@ -50,9 +51,9 @@ type
 
     function GetAlgorithmName: string; virtual;
     /// <summary>
-    /// Gets the Underlying <b>IHash</b> Instance
+    /// Gets the backing HashLib <b>IHash</b> instance (IBackingHashProvider).
     /// </summary>
-    function GetUnderlyingHasher: IHash; virtual;
+    function GetBackingHash: IHash; virtual;
 
   public
     class constructor Create; overload;
@@ -119,7 +120,7 @@ type
     /// </summary>
     property AlgorithmName: String read GetAlgorithmName;
 
-    property UnderlyingHasher: IHash read GetUnderlyingHasher;
+    property BackingHash: IHash read GetBackingHash;
 
   end;
 
@@ -233,7 +234,7 @@ begin
   Result := FHash.HashSize;
 end;
 
-function TDigest.GetUnderlyingHasher: IHash;
+function TDigest.GetBackingHash: IHash;
 begin
   Result := FHash;
 end;

--- a/CryptoLib/src/Crypto/Digests/ClpPrehash.pas
+++ b/CryptoLib/src/Crypto/Digests/ClpPrehash.pas
@@ -49,9 +49,9 @@ type
     strict protected
     function GetAlgorithmName: String; override;
     /// <summary>
-    /// Gets the Underlying <b>IHash</b> Instance
+    /// Prehash has no backing HashLib IHash; returns nil (IBackingHashProvider).
     /// </summary>
-    function GetUnderlyingHasher: IHash; override;
+    function GetBackingHash: IHash; override;
 
   public
     class function ForDigest(const ADigest: IDigest): IPrehash; static;
@@ -72,7 +72,7 @@ type
     function Clone: IDigest; override;
 
     property AlgorithmName: String read GetAlgorithmName;
-    property UnderlyingHasher: IHash read GetUnderlyingHasher;
+    property BackingHash: IHash read GetBackingHash;
 
   end;
 
@@ -110,9 +110,9 @@ begin
   Result := FAlgorithmName;
 end;
 
-function TPrehash.GetUnderlyingHasher: IHash;
+function TPrehash.GetBackingHash: IHash;
 begin
-  // Prehash doesn't have an underlying IHash
+  // Prehash doesn't have a backing IHash
   Result := nil;
 end;
 

--- a/CryptoLib/src/Crypto/Generators/ClpDsaGenerators.pas
+++ b/CryptoLib/src/Crypto/Generators/ClpDsaGenerators.pas
@@ -23,7 +23,6 @@ interface
 uses
   Math,
   SysUtils,
-  HlpSHA1,
   ClpIDigest,
   ClpISecureRandom,
   ClpDsaParameters,
@@ -375,7 +374,7 @@ begin
   LN := (FL - 1) div 160;
   System.SetLength(LW, FL div 8);
 
-  if (not (FDigest.UnderlyingHasher is TSHA1)) then
+  if (FDigest.AlgorithmName <> 'SHA-1') then
   begin
     raise EInvalidParameterCryptoLibException.CreateRes(@SUnsupportedDigest);
   end;

--- a/CryptoLib/src/Crypto/Generators/ClpPkcs5S2ParametersGenerator.pas
+++ b/CryptoLib/src/Crypto/Generators/ClpPkcs5S2ParametersGenerator.pas
@@ -21,9 +21,12 @@ unit ClpPkcs5S2ParametersGenerator;
 interface
 
 uses
+  SysUtils,
+  HlpIHash,
   HlpIHashInfo,
   HlpHashFactory,
   ClpIDigest,
+  ClpIBackingHashProvider,
   ClpICipherParameters,
   ClpIPkcs5S2ParametersGenerator,
   ClpKeyParameter,
@@ -33,6 +36,10 @@ uses
   ClpPbeParametersGenerator,
   ClpDigestUtilities,
   ClpCryptoLibTypes;
+
+resourcestring
+  SDigestNoBackingHash =
+    'digest does not provide a backing hash (required for PBKDF2)';
 
 type
   /// <summary>
@@ -194,9 +201,17 @@ end;
 
 procedure TPkcs5S2ParametersGenerator.Init(const APassword, ASalt: TCryptoLibByteArray;
   AIterationCount: Int32);
+var
+  LProvider: IBackingHashProvider;
+  LHash: IHash;
 begin
   inherited Init(APassword, ASalt, AIterationCount);
-  FPBKDF2_HMAC := TKDF.TPBKDF2_HMAC.CreatePBKDF2_HMAC(FDigest.UnderlyingHasher, FPassword, FSalt, AIterationCount);
+  if not Supports(FDigest, IBackingHashProvider, LProvider) then
+    raise EArgumentCryptoLibException.CreateRes(@SDigestNoBackingHash);
+  LHash := LProvider.BackingHash;
+  if LHash = nil then
+    raise EArgumentCryptoLibException.CreateRes(@SDigestNoBackingHash);
+  FPBKDF2_HMAC := TKDF.TPBKDF2_HMAC.CreatePBKDF2_HMAC(LHash, FPassword, FSalt, AIterationCount);
 end;
 
 end.

--- a/CryptoLib/src/Crypto/Macs/ClpHMac.pas
+++ b/CryptoLib/src/Crypto/Macs/ClpHMac.pas
@@ -22,12 +22,14 @@ interface
 
 uses
   SysUtils,
+  HlpIHash,
   HlpIHashInfo,
   HlpHashFactory,
   ClpIMac,
   ClpIHMac,
   ClpMac,
   ClpIDigest,
+  ClpIBackingHashProvider,
   ClpIKeyParameter,
   ClpICipherParameters,
   ClpCryptoLibTypes;
@@ -35,6 +37,8 @@ uses
 resourcestring
   SOutputBufferTooShort = 'output buffer too short';
   SInvalidParameterHMac = 'HMAC requires KeyParameter';
+  SDigestNoBackingHash =
+    'digest does not provide a backing hash (required for HMAC)';
 
 type
   /// <summary>
@@ -103,10 +107,18 @@ begin
 end;
 
 constructor THMac.Create(const ADigest: IDigest);
+var
+  LProvider: IBackingHashProvider;
+  LHash: IHash;
 begin
   Inherited Create();
   FDigest := ADigest;
-  FHMAC := THashFactory.THMac.CreateHMAC(FDigest.UnderlyingHasher);
+  if not Supports(FDigest, IBackingHashProvider, LProvider) then
+    raise EArgumentCryptoLibException.CreateRes(@SDigestNoBackingHash);
+  LHash := LProvider.BackingHash;
+  if LHash = nil then
+    raise EArgumentCryptoLibException.CreateRes(@SDigestNoBackingHash);
+  FHMAC := THashFactory.THMac.CreateHMAC(LHash);
 end;
 
 destructor THMac.Destroy;

--- a/CryptoLib/src/Interfaces/Crypto/Digests/ClpIBackingHashProvider.pas
+++ b/CryptoLib/src/Interfaces/Crypto/Digests/ClpIBackingHashProvider.pas
@@ -1,0 +1,47 @@
+{ *********************************************************************************** }
+{ *                              CryptoLib Library                                  * }
+{ *                           Author - Ugochukwu Mmaduekwe                          * }
+{ *                 Github Repository <https://github.com/Xor-el>                   * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ *                                                                                 * }
+{ *                              Acknowledgements:                                  * }
+{ *                                                                                 * }
+{ *      Thanks to Sphere 10 Software (http://www.sphere10.com/) for sponsoring     * }
+{ *                         the development of this library                         * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+unit ClpIBackingHashProvider;
+
+{$I ..\..\..\Include\CryptoLib.inc}
+
+interface
+
+uses
+  HlpIHash;
+
+type
+  /// <summary>
+  /// Internal capability interface exposing the HashLib4Pascal <c>IHash</c> that
+  /// backs a digest. This is an implementation detail of the HashLib-backed
+  /// digests (TDigest and its descendants) and is deliberately NOT part of the
+  /// public <c>IDigest</c> contract; only the in-tree HMAC / PBKDF2 bridges query
+  /// it (via <c>Supports</c>) because HashLib's own HMAC / PBKDF2 constructors
+  /// require an <c>IHash</c>. Digests without a backing hash (e.g. a prehash
+  /// digest) return nil, and callers must treat that as "not backing-hash
+  /// capable".
+  /// </summary>
+  IBackingHashProvider = interface(IInterface)
+    ['{2A9F7C64-4B1E-4D0A-9E3C-7F5B8D2A1C60}']
+
+    function GetBackingHash: IHash;
+
+    property BackingHash: IHash read GetBackingHash;
+  end;
+
+implementation
+
+end.

--- a/CryptoLib/src/Interfaces/Crypto/Digests/ClpIDigest.pas
+++ b/CryptoLib/src/Interfaces/Crypto/Digests/ClpIDigest.pas
@@ -21,7 +21,6 @@ unit ClpIDigest;
 interface
 
 uses
-  HlpIHash,
   ClpCryptoLibTypes;
 
 type
@@ -32,16 +31,9 @@ type
     function GetAlgorithmName: string;
 
     /// <summary>
-    /// Gets the Underlying <b>IHash</b> Instance
-    /// </summary>
-    function GetUnderlyingHasher: IHash;
-
-    /// <summary>
     /// the algorithm name
     /// </summary>
     property AlgorithmName: String read GetAlgorithmName;
-
-    property UnderlyingHasher: IHash read GetUnderlyingHasher;
 
     /// <summary>
     /// the size, in bytes, of the digest produced by this message digest.

--- a/CryptoLib/src/Packages/Delphi/CryptoLib4PascalPackage.dpk
+++ b/CryptoLib/src/Packages/Delphi/CryptoLib4PascalPackage.dpk
@@ -193,6 +193,7 @@ contains
   ClpIDHBasicAgreement in '..\..\Interfaces\Crypto\Agreements\ClpIDHBasicAgreement.pas',
   ClpIDHGenerators in '..\..\Interfaces\Crypto\Generators\ClpIDHGenerators.pas',
   ClpIDHParameters in '..\..\Interfaces\Crypto\Parameters\ClpIDHParameters.pas',
+  ClpIBackingHashProvider in '..\..\Interfaces\Crypto\Digests\ClpIBackingHashProvider.pas',
   ClpIDigest in '..\..\Interfaces\Crypto\Digests\ClpIDigest.pas',
   ClpIDigestFactory in '..\..\Interfaces\Crypto\Operators\ClpIDigestFactory.pas',
   ClpIDigestRandomGenerator in '..\..\Interfaces\Rngs\ClpIDigestRandomGenerator.pas',

--- a/CryptoLib/src/Packages/FPC/CryptoLib4PascalPackage.lpk
+++ b/CryptoLib/src/Packages/FPC/CryptoLib4PascalPackage.lpk
@@ -31,7 +31,7 @@
  Acknowledgements: 
 Thanks to Sphere 10 Software (http://www.sphere10.com/) for sponsoring the development of this library "/>
     <Version Major="3" Minor="3"/>
-    <Files Count="774">
+    <Files Count="775">
       <Item1>
         <Filename Value="..\..\Asn1\ClpOidTokenizer.pas"/>
         <UnitName Value="ClpOidTokenizer"/>
@@ -3129,6 +3129,10 @@ Thanks to Sphere 10 Software (http://www.sphere10.com/) for sponsoring the devel
         <Filename Value="..\..\Interfaces\Crypto\Engines\ClpIAesHardwareEngine.pas"/>
         <UnitName Value="ClpIAesHardwareEngine"/>
       </Item774>
+      <Item775>
+        <Filename Value="..\..\Interfaces\Crypto\Digests\ClpIBackingHashProvider.pas"/>
+        <UnitName Value="ClpIBackingHashProvider"/>
+      </Item775>
     </Files>
     <CompatibilityMode Value="True"/>
     <RequiredPkgs Count="3">

--- a/CryptoLib/src/Packages/FPC/CryptoLib4PascalPackage.pas
+++ b/CryptoLib/src/Packages/FPC/CryptoLib4PascalPackage.pas
@@ -251,7 +251,8 @@ uses
   ClpHMacSP800Drbg, ClpCtrSP800Drbg, ClpSP800SecureRandom, 
   ClpISP800SecureRandomBuilder, ClpSP800SecureRandomBuilder, 
   ClpECDHRawAgreement, ClpECDHCRawAgreement, ClpIECDHRawAgreement, 
-  ClpIECDHCRawAgreement, ClpGF256Aes, ClpIAesHardwareEngine;
+  ClpIECDHCRawAgreement, ClpGF256Aes, ClpIAesHardwareEngine, 
+  ClpIBackingHashProvider;
 
 implementation
 


### PR DESCRIPTION
IDigest is an adapter over HashLib4Pascal's IHash, but it re-exposed that IHash on its public contract via GetUnderlyingHasher/UnderlyingHasher. That baked HashLib into the public digest API (ClpIDigest.pas itself used HlpIHash) and advertised a capability not every digest has - TPrehash returned nil, so building an HMAC from a prehash digest passed nil into HashLib and crashed cryptically.

Move the raw-hash access off IDigest onto a small internal capability interface, IBackingHashProvider (property BackingHash), implemented by TDigest. The public IDigest is now HashLib-free.

- New ClpIBackingHashProvider.pas; IDigest drops GetUnderlyingHasher and its HlpIHash dependency.
- TDigest implements IBackingHashProvider (GetUnderlyingHasher -> GetBackingHash); TPrehash's override still returns nil.
- THMac and TPkcs5S2ParametersGenerator obtain the hash via Supports(digest, IBackingHashProvider, p) then p.BackingHash, raising a clear "digest does not provide a backing hash" error when it is nil/absent (fixes the prehash nil footgun).
- TDsaParametersGenerator replaces the `hasher is TSHA1` type check with AlgorithmName = 'SHA-1', dropping the HlpSHA1 import.