### PR TITLE
Stop overriding default ASN.1 stream limits in X509 parsers and Asn1Dumper

### DIFF
--- a/CryptoLib/src/Asn1/ClpAsn1Dumper.pas
+++ b/CryptoLib/src/Asn1/ClpAsn1Dumper.pas
@@ -389,7 +389,7 @@ var
   LAsn1In: TAsn1InputStream;
   LAsn1Object: IAsn1Object;
 begin
-  LAsn1In := TAsn1InputStream.Create(AInput, MaxInt, True);
+  LAsn1In := TAsn1InputStream.Create(AInput, True);
   try
     LAsn1Object := LAsn1In.ReadObject();
     while LAsn1Object <> nil do

--- a/CryptoLib/src/X509/ClpX509AttrCertParser.pas
+++ b/CryptoLib/src/X509/ClpX509AttrCertParser.pas
@@ -220,7 +220,7 @@ function TX509AttrCertParser.ReadAttrCert(const AInStream: TStream): IX509V2Attr
   var
     LAsn1In: TAsn1InputStream;
   begin
-    LAsn1In := TAsn1InputStream.Create(AStream, Int32.MaxValue, True);
+    LAsn1In := TAsn1InputStream.Create(AStream, True);
     try
       Result := ReadDerCertificate(LAsn1In);
     finally

--- a/CryptoLib/src/X509/ClpX509CertificatePairParser.pas
+++ b/CryptoLib/src/X509/ClpX509CertificatePairParser.pas
@@ -81,7 +81,7 @@ var
   LObj: IAsn1Object;
   LPair: ICertificatePair;
 begin
-  LAsn1In := TAsn1InputStream.Create(AInStream, Int32.MaxValue, True);
+  LAsn1In := TAsn1InputStream.Create(AInStream, True);
   try
     LObj := LAsn1In.ReadObject();
     if LObj = nil then

--- a/CryptoLib/src/X509/ClpX509CertificateParser.pas
+++ b/CryptoLib/src/X509/ClpX509CertificateParser.pas
@@ -207,7 +207,7 @@ function TX509CertificateParser.ReadCertificate(const AInStream: TStream): IX509
   var
     LAsn1In: TAsn1InputStream;
   begin
-    LAsn1In := TAsn1InputStream.Create(AStream, Int32.MaxValue, True);
+    LAsn1In := TAsn1InputStream.Create(AStream, True);
     try
       Result := ReadDerCertificate(LAsn1In);
     finally

--- a/CryptoLib/src/X509/ClpX509CrlParser.pas
+++ b/CryptoLib/src/X509/ClpX509CrlParser.pas
@@ -195,7 +195,7 @@ function TX509CrlParser.ReadCrl(const AInStream: TStream): IX509Crl;
   var
     LAsn1In: TAsn1InputStream;
   begin
-    LAsn1In := TAsn1InputStream.Create(AStream, Int32.MaxValue, True);
+    LAsn1In := TAsn1InputStream.Create(AStream, True);
     try
       Result := ReadDerCrl(LAsn1In);
     finally


### PR DESCRIPTION
- Use TAsn1InputStream.Create(stream, leaveOpen) instead of passing MaxInt, so consumers respect FindLimit and MaxLimitForUnknownStream rather than bypassing them.