### PR TITLE
Use typed TArrayUtilities.Fill overloads for byte/word fills

### DIFF
--- a/CryptoLib/src/Crypto/Bip327/ClpBip327MuSig2.pas
+++ b/CryptoLib/src/Crypto/Bip327/ClpBip327MuSig2.pas
@@ -410,7 +410,7 @@ begin
   LK2Orig := TBigInteger.Create(1, System.Copy(ASecNonce, 32, 32));
   LK1 := LK1Orig;
   LK2 := LK2Orig;
-  TArrayUtilities.Fill<Byte>(ASecNonce, 0, 64, Byte(0));
+  TArrayUtilities.Fill(ASecNonce, 0, 64, Byte(0));
   if (LK1.SignValue <= 0) or (LK1.CompareTo(LN) >= 0) then
     Exit;
   if (LK2.SignValue <= 0) or (LK2.CompareTo(LN) >= 0) then

--- a/CryptoLib/src/Crypto/Bip327/ClpBip327MuSig2KeyAggregation.pas
+++ b/CryptoLib/src/Crypto/Bip327/ClpBip327MuSig2KeyAggregation.pas
@@ -317,7 +317,7 @@ begin
       Exit;
     end;
   System.SetLength(Result, TBip327MuSig2Utilities.BIP327_PLAIN_PUBKEY_SIZE);
-  TArrayUtilities.Fill<Byte>(Result, 0, System.Length(Result), Byte(0));
+  TArrayUtilities.Fill(Result, 0, System.Length(Result), Byte(0));
 end;
 
 class function TBip327MuSig2KeyAggregation.KeyAggCoeffInternal(const APubKeys: TCryptoLibGenericArray<TCryptoLibByteArray>;

--- a/CryptoLib/src/Crypto/Bip340/ClpBip340SchnorrBatchVerifier.pas
+++ b/CryptoLib/src/Crypto/Bip340/ClpBip340SchnorrBatchVerifier.pas
@@ -194,13 +194,13 @@ begin
   if (LU > 1) then
   begin
     System.SetLength(LZeroIV, 12);
-    TArrayUtilities.Fill<Byte>(LZeroIV, 0, 12, Byte(0));
+    TArrayUtilities.Fill(LZeroIV, 0, 12, Byte(0));
     LKeyParam := TKeyParameter.Create(LSeed);
     LParams := TParametersWithIV.Create(LKeyParam, LZeroIV);
     LCipher := TCipherUtilities.GetCipher('CHACHA7539');
     LCipher.Init(True, LParams);
     System.SetLength(LZeros, 32);
-    TArrayUtilities.Fill<Byte>(LZeros, 0, 32, Byte(0));
+    TArrayUtilities.Fill(LZeros, 0, 32, Byte(0));
     System.SetLength(LBlock, 32);
     LJ := 0;
     while LJ < (LU - 1) do

--- a/CryptoLib/src/Crypto/ClpBufferedAsymmetricBlockCipher.pas
+++ b/CryptoLib/src/Crypto/ClpBufferedAsymmetricBlockCipher.pas
@@ -232,7 +232,7 @@ procedure TBufferedAsymmetricBlockCipher.Reset;
 begin
   if FBuffer <> nil then
   begin
-    TArrayUtilities.Fill<Byte>(FBuffer, 0, System.Length(FBuffer), Byte(0));
+    TArrayUtilities.Fill(FBuffer, 0, System.Length(FBuffer), Byte(0));
     FBufOff := 0;
   end;
 end;

--- a/CryptoLib/src/Crypto/ClpBufferedBlockCipher.pas
+++ b/CryptoLib/src/Crypto/ClpBufferedBlockCipher.pas
@@ -587,7 +587,7 @@ end;
 
 procedure TBufferedBlockCipher.Reset;
 begin
-  TArrayUtilities.Fill<Byte>(FBuf, 0, System.Length(FBuf), Byte(0));
+  TArrayUtilities.Fill(FBuf, 0, System.Length(FBuf), Byte(0));
   FBufOff := 0;
 
   FCipherMode.Reset();

--- a/CryptoLib/src/Crypto/ClpLib25519.pas
+++ b/CryptoLib/src/Crypto/ClpLib25519.pas
@@ -229,7 +229,7 @@ begin
   if not FEd25519.Verify(ASignedMsg, ASignedMsgOff, APk, APkOff,
     ASignedMsg, ASignedMsgOff + SignBytes, LMlen) then
   begin
-    TArrayUtilities.Fill<Byte>(AM, AMOff, AMOff + ASignedMsgLen, 0);
+    TArrayUtilities.Fill(AM, AMOff, AMOff + ASignedMsgLen, 0);
     AMlen := -1;
     Exit(False);
   end;

--- a/CryptoLib/src/Crypto/ClpPbeUtilities.pas
+++ b/CryptoLib/src/Crypto/ClpPbeUtilities.pas
@@ -722,7 +722,7 @@ begin
     LParameters := LGenerator.GenerateDerivedMacParameters(LBitLen);
   end;
 
-  TArrayUtilities.Fill<Byte>(LKeyBytes, 0, System.Length(LKeyBytes), Byte(0));
+  TArrayUtilities.Fill(LKeyBytes, 0, System.Length(LKeyBytes), Byte(0));
   Result := LParameters;
 end;
 

--- a/CryptoLib/src/Crypto/Encodings/ClpOaepEncoding.pas
+++ b/CryptoLib/src/Crypto/Encodings/ClpOaepEncoding.pas
@@ -242,7 +242,7 @@ begin
     LCopyLen := System.Length(LBlock);
 
   System.Move(LData[0], LBlock[System.Length(LBlock) - LCopyLen], LCopyLen);
-  TArrayUtilities.Fill<Byte>(LData, 0, System.Length(LData), Byte(0));
+  TArrayUtilities.Fill(LData, 0, System.Length(LData), Byte(0));
 
   FMgf1Hash.Reset();
 
@@ -271,7 +271,7 @@ begin
 
   if LWrongMask <> 0 then
   begin
-    TArrayUtilities.Fill<Byte>(LBlock, 0, System.Length(LBlock), Byte(0));
+    TArrayUtilities.Fill(LBlock, 0, System.Length(LBlock), Byte(0));
     raise EInvalidCipherTextCryptoLibException.CreateRes(@SDataWrong);
   end;
 
@@ -279,7 +279,7 @@ begin
 
   SetLength(Result, System.Length(LBlock) - LStart);
   System.Move(LBlock[LStart], Result[0], System.Length(Result));
-  TArrayUtilities.Fill<Byte>(LBlock, 0, System.Length(LBlock), Byte(0));
+  TArrayUtilities.Fill(LBlock, 0, System.Length(LBlock), Byte(0));
 end;
 
 procedure TOaepEncoding.MaskGeneratorFunction(

--- a/CryptoLib/src/Crypto/Encodings/ClpPkcs1Encoding.pas
+++ b/CryptoLib/src/Crypto/Encodings/ClpPkcs1Encoding.pas
@@ -387,7 +387,7 @@ begin
   end;
 
   // Clear sensitive data
-  TArrayUtilities.Fill<Byte>(LBlock, 0, System.Length(LBlock), Byte(0));
+  TArrayUtilities.Fill(LBlock, 0, System.Length(LBlock), Byte(0));
 end;
 
 function TPkcs1Encoding.DecodeBlock(const AInput: TCryptoLibByteArray;
@@ -435,8 +435,8 @@ begin
     System.Move(LData[System.Length(LData) - LPlaintextLength], Result[0], LPlaintextLength);
   finally
     // Clear sensitive data
-    TArrayUtilities.Fill<Byte>(LBlock, 0, System.Length(LBlock), Byte(0));
-    TArrayUtilities.Fill<Byte>(FBlockBuffer, 0, Math.Max(0, System.Length(FBlockBuffer) - System.Length(LBlock)), Byte(0));
+    TArrayUtilities.Fill(LBlock, 0, System.Length(LBlock), Byte(0));
+    TArrayUtilities.Fill(FBlockBuffer, 0, Math.Max(0, System.Length(FBlockBuffer) - System.Length(LBlock)), Byte(0));
   end;
 end;
 

--- a/CryptoLib/src/Crypto/Engines/ClpAesEngine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpAesEngine.pas
@@ -508,7 +508,7 @@ begin
   LKeyLen := System.Length(AKey);
   if ((LKeyLen < 16) or (LKeyLen > 32) or ((LKeyLen and 7) <> 0)) then
   begin
-    TArrayUtilities.Fill<Byte>(AKey, 0, System.Length(AKey), Byte(0));
+    TArrayUtilities.Fill(AKey, 0, System.Length(AKey), Byte(0));
     raise EArgumentCryptoLibException.CreateRes(@SInvalidKeyLength);
   end;
 
@@ -684,7 +684,7 @@ begin
       end
   else
     begin
-      TArrayUtilities.Fill<Byte>(AKey, 0, System.Length(AKey), Byte(0));
+      TArrayUtilities.Fill(AKey, 0, System.Length(AKey), Byte(0));
       raise EInvalidOperationCryptoLibException.CreateRes(@SInvalidOperation);
     end;
   end;
@@ -703,7 +703,7 @@ begin
 
   Result := LBigW;
 
-  TArrayUtilities.Fill<Byte>(AKey, 0, System.Length(AKey), Byte(0));
+  TArrayUtilities.Fill(AKey, 0, System.Length(AKey), Byte(0));
 end;
 
 function TAesEngine.GetAlgorithmName: String;

--- a/CryptoLib/src/Crypto/Engines/ClpAesEngineX86.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpAesEngineX86.pas
@@ -865,7 +865,7 @@ begin
   LKeyLen := System.Length(AKey);
   if ((LKeyLen < 16) or (LKeyLen > 32) or ((LKeyLen and 7) <> 0)) then
   begin
-    TArrayUtilities.Fill<Byte>(AKey, 0, LKeyLen, Byte(0));
+    TArrayUtilities.Fill(AKey, 0, LKeyLen, Byte(0));
     raise EArgumentCryptoLibException.CreateRes(@SInvalidKeyLength);
   end;
 
@@ -888,7 +888,7 @@ begin
         AesNiExpandRoundKeys256(@AKey[0], LK);
       end;
   else
-    TArrayUtilities.Fill<Byte>(AKey, 0, LKeyLen, Byte(0));
+    TArrayUtilities.Fill(AKey, 0, LKeyLen, Byte(0));
     raise EArgumentCryptoLibException.CreateRes(@SInvalidKeyLength);
   end;
 
@@ -1014,7 +1014,7 @@ begin
     CreateRoundKeys(AForEncryption, LKeyCopy);
     BindCipherPointers;
   finally
-    TArrayUtilities.Fill<Byte>(LKeyCopy, 0, System.Length(LKeyCopy), Byte(0));
+    TArrayUtilities.Fill(LKeyCopy, 0, System.Length(LKeyCopy), Byte(0));
   end;
 end;
 

--- a/CryptoLib/src/Crypto/Engines/ClpAesLightEngine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpAesLightEngine.pas
@@ -421,7 +421,7 @@ begin
   LKeyLen := System.Length(AKey);
   if ((LKeyLen < 16) or (LKeyLen > 32) or ((LKeyLen and 7) <> 0)) then
   begin
-    TArrayUtilities.Fill<Byte>(AKey, 0, System.Length(AKey), Byte(0));
+    TArrayUtilities.Fill(AKey, 0, System.Length(AKey), Byte(0));
     raise EArgumentCryptoLibException.CreateRes(@SInvalidKeyLength);
   end;
 
@@ -597,7 +597,7 @@ begin
       end
   else
     begin
-      TArrayUtilities.Fill<Byte>(AKey, 0, System.Length(AKey), Byte(0));
+      TArrayUtilities.Fill(AKey, 0, System.Length(AKey), Byte(0));
       raise EInvalidOperationCryptoLibException.CreateRes(@SInvalidOperation);
     end;
   end;
@@ -616,7 +616,7 @@ begin
 
   Result := LBigW;
 
-  TArrayUtilities.Fill<Byte>(AKey, 0, System.Length(AKey), Byte(0));
+  TArrayUtilities.Fill(AKey, 0, System.Length(AKey), Byte(0));
 end;
 
 function TAesLightEngine.GetAlgorithmName: String;

--- a/CryptoLib/src/Crypto/Engines/ClpBlowfishEngine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpBlowfishEngine.pas
@@ -322,7 +322,7 @@ begin
   if ((LKeyLength < 4) or (LKeyLength > 56) or (((LKeyLength * 8) and 7) <> 0))
   then
   begin
-    TArrayUtilities.Fill<Byte>(AKey, 0, System.Length(AKey), Byte(0));
+    TArrayUtilities.Fill(AKey, 0, System.Length(AKey), Byte(0));
     raise EArgumentCryptoLibException.CreateRes(@SInvalidKeyLength);
   end;
 
@@ -408,7 +408,7 @@ begin
   ProcessTable(FS1[SBOX_SK - 2], FS1[SBOX_SK - 1], FS2);
   ProcessTable(FS2[SBOX_SK - 2], FS2[SBOX_SK - 1], FS3);
 
-  TArrayUtilities.Fill<Byte>(AKey, 0, System.Length(AKey), Byte(0));
+  TArrayUtilities.Fill(AKey, 0, System.Length(AKey), Byte(0));
 end;
 
 procedure TBlowfishEngine.EncryptBlock(const ASrc: TCryptoLibByteArray;

--- a/CryptoLib/src/Crypto/Engines/ClpIesEngine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpIesEngine.pas
@@ -597,7 +597,7 @@ begin
   if (System.Length(FV) <> 0) then
   begin
     VZ := TArrayUtilities.Concatenate<Byte>([FV, BigZ]);
-    TArrayUtilities.Fill<Byte>(BigZ, 0, System.Length(BigZ), Byte(0));
+    TArrayUtilities.Fill(BigZ, 0, System.Length(BigZ), Byte(0));
     BigZ := VZ;
   end;
 
@@ -618,7 +618,7 @@ begin
     end;
 
   finally
-    TArrayUtilities.Fill<Byte>(BigZ, 0, System.Length(BigZ), Byte(0));
+    TArrayUtilities.Fill(BigZ, 0, System.Length(BigZ), Byte(0));
   end;
 end;
 

--- a/CryptoLib/src/Crypto/Engines/ClpPascalCoinIesEngine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpPascalCoinIesEngine.pas
@@ -311,7 +311,7 @@ begin
     end;
 
   finally
-    TArrayUtilities.Fill<Byte>(LBigZ, 0, System.Length(LBigZ), Byte(0));
+    TArrayUtilities.Fill(LBigZ, 0, System.Length(LBigZ), Byte(0));
   end;
 end;
 

--- a/CryptoLib/src/Crypto/Engines/ClpRfc3211WrapEngine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpRfc3211WrapEngine.pas
@@ -224,7 +224,7 @@ begin
     LNonEqual := LNonEqual or (LCheck xor LCekBlock[4 + LI]);
   end;
 
-  TArrayUtilities.Fill<Byte>(LCekBlock, 0, System.Length(LCekBlock), Byte(0));
+  TArrayUtilities.Fill(LCekBlock, 0, System.Length(LCekBlock), Byte(0));
 
   if (LNonEqual <> 0) or LInvalidLength then
     raise EInvalidCipherTextCryptoLibException.CreateRes(@SWrappedKeyCorrupted);

--- a/CryptoLib/src/Crypto/Engines/ClpRijndaelEngine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpRijndaelEngine.pas
@@ -543,7 +543,7 @@ begin
       LKc := 8
   else
     begin
-      TArrayUtilities.Fill<Byte>(AKey, 0, System.Length(AKey), Byte(0));
+      TArrayUtilities.Fill(AKey, 0, System.Length(AKey), Byte(0));
       raise EArgumentCryptoLibException.CreateRes(@SInvalidKeyLength);
     end;
   end;
@@ -653,7 +653,7 @@ begin
   end;
   Result := LW;
 
-  TArrayUtilities.Fill<Byte>(AKey, 0, System.Length(AKey), Byte(0));
+  TArrayUtilities.Fill(AKey, 0, System.Length(AKey), Byte(0));
 end;
 
 procedure TRijndaelEngine.PackBlock(const ABytes: TCryptoLibByteArray;

--- a/CryptoLib/src/Crypto/Engines/ClpSpeckEngine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpSpeckEngine.pas
@@ -791,7 +791,7 @@ begin
 
   end;
 
-  TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+  TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
 end;
 
 { TSpeckUInt64Engine }
@@ -954,7 +954,7 @@ begin
 
   end;
 
-  TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+  TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
 end;
 
 { TSpeck32Engine }
@@ -976,7 +976,7 @@ begin
   LKeyBytesSize := System.Length(AKeyBytes);
   if (LKeyBytesSize <> 8) then
   begin
-    TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+    TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
     raise EArgumentCryptoLibException.CreateResFmt(@SSpeckInvalidKeySize,
       ['32', '64 bits', LKeyBytesSize * 8]);
   end;
@@ -1001,7 +1001,7 @@ begin
   LKeyBytesSize := System.Length(AKeyBytes);
   if not(LKeyBytesSize in [9, 12]) then
   begin
-    TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+    TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
     raise EArgumentCryptoLibException.CreateResFmt(@SSpeckInvalidKeySize,
       ['48', '72 or 96 bits', LKeyBytesSize * 8]);
   end;
@@ -1026,7 +1026,7 @@ begin
   LKeyBytesSize := System.Length(AKeyBytes);
   if not(LKeyBytesSize in [12, 16]) then
   begin
-    TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+    TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
     raise EArgumentCryptoLibException.CreateResFmt(@SSpeckInvalidKeySize,
       ['64', '96 or 128 bits', LKeyBytesSize * 8]);
   end;
@@ -1051,7 +1051,7 @@ begin
   LKeyBytesSize := System.Length(AKeyBytes);
   if not(LKeyBytesSize in [12, 18]) then
   begin
-    TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+    TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
     raise EArgumentCryptoLibException.CreateResFmt(@SSpeckInvalidKeySize,
       ['96', '96 or 144 bits', LKeyBytesSize * 8]);
   end;
@@ -1076,7 +1076,7 @@ begin
   LKeyBytesSize := System.Length(AKeyBytes);
   if not(LKeyBytesSize in [16, 24, 32]) then
   begin
-    TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+    TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
     raise EArgumentCryptoLibException.CreateResFmt(@SSpeckInvalidKeySize,
       ['128', '128, 192 or 256 bits', LKeyBytesSize * 8]);
   end;

--- a/CryptoLib/src/Crypto/Engines/ClpSpeckLegacyEngine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpSpeckLegacyEngine.pas
@@ -791,7 +791,7 @@ begin
 
   end;
 
-  TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+  TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
 end;
 
 { TSpeckUInt64LegacyEngine }
@@ -958,7 +958,7 @@ begin
 
   end;
 
-  TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+  TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
 end;
 
 { TSpeck32LegacyEngine }
@@ -981,7 +981,7 @@ begin
   LKeyBytesSize := System.Length(AKeyBytes);
   if (LKeyBytesSize <> 8) then
   begin
-    TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+    TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
     raise EArgumentCryptoLibException.CreateResFmt
       (@SSpeckLegacyInvalidKeySize, ['32', '64 bits', LKeyBytesSize * 8]);
   end;
@@ -1007,7 +1007,7 @@ begin
   LKeyBytesSize := System.Length(AKeyBytes);
   if not(LKeyBytesSize in [9, 12]) then
   begin
-    TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+    TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
     raise EArgumentCryptoLibException.CreateResFmt
       (@SSpeckLegacyInvalidKeySize, ['48', '72 or 96 bits', LKeyBytesSize * 8]);
   end;
@@ -1033,7 +1033,7 @@ begin
   LKeyBytesSize := System.Length(AKeyBytes);
   if not(LKeyBytesSize in [12, 16]) then
   begin
-    TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+    TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
     raise EArgumentCryptoLibException.CreateResFmt
       (@SSpeckLegacyInvalidKeySize, ['64', '96 or 128 bits', LKeyBytesSize * 8]);
   end;
@@ -1059,7 +1059,7 @@ begin
   LKeyBytesSize := System.Length(AKeyBytes);
   if not(LKeyBytesSize in [12, 18]) then
   begin
-    TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+    TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
     raise EArgumentCryptoLibException.CreateResFmt
       (@SSpeckLegacyInvalidKeySize, ['96', '96 or 144 bits', LKeyBytesSize * 8]);
   end;
@@ -1085,7 +1085,7 @@ begin
   LKeyBytesSize := System.Length(AKeyBytes);
   if not(LKeyBytesSize in [16, 24, 32]) then
   begin
-    TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+    TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
     raise EArgumentCryptoLibException.CreateResFmt
       (@SSpeckLegacyInvalidKeySize, ['128', '128, 192 or 256 bits',
       LKeyBytesSize * 8]);

--- a/CryptoLib/src/Crypto/Engines/ClpXChaCha20Engine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpXChaCha20Engine.pas
@@ -99,18 +99,18 @@ begin
   try
     TChaChaEngine.HChaCha20(AKeyBytes, LNoncePrefix, LSubKey, 0);
   finally
-    TArrayUtilities.Fill<Byte>(LNoncePrefix, 0, System.Length(LNoncePrefix), Byte(0));
+    TArrayUtilities.Fill(LNoncePrefix, 0, System.Length(LNoncePrefix), Byte(0));
   end;
 
   System.SetLength(LInnerIv, 12);
-  TArrayUtilities.Fill<Byte>(LInnerIv, 0, 4, Byte(0));
+  TArrayUtilities.Fill(LInnerIv, 0, 4, Byte(0));
   System.Move(AIvBytes[16], LInnerIv[4], 8);
 
   try
     inherited SetKey(LSubKey, LInnerIv);
   finally
-    TArrayUtilities.Fill<Byte>(LSubKey, 0, 32, Byte(0));
-    TArrayUtilities.Fill<Byte>(LInnerIv, 0, 12, Byte(0));
+    TArrayUtilities.Fill(LSubKey, 0, 32, Byte(0));
+    TArrayUtilities.Fill(LInnerIv, 0, 12, Byte(0));
   end;
 end;
 

--- a/CryptoLib/src/Crypto/Engines/ClpXSalsa20Engine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpXSalsa20Engine.pas
@@ -79,8 +79,8 @@ begin
 
   if (System.Length(AKeyBytes) <> 32) then
   begin
-    TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
-    TArrayUtilities.Fill<Byte>(AIvBytes, 0, System.Length(AIvBytes), Byte(0));
+    TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+    TArrayUtilities.Fill(AIvBytes, 0, System.Length(AIvBytes), Byte(0));
     raise EArgumentCryptoLibException.CreateResFmt(@SInvalidKeySize,
       [AlgorithmName]);
   end;
@@ -109,8 +109,8 @@ begin
   // Last 64 bits of input IV
   TPack.LE_To_UInt32(AIvBytes, 16, FEngineState, 6, 2);
 
-  TArrayUtilities.Fill<Byte>(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
-  TArrayUtilities.Fill<Byte>(AIvBytes, 0, System.Length(AIvBytes), Byte(0));
+  TArrayUtilities.Fill(AKeyBytes, 0, System.Length(AKeyBytes), Byte(0));
+  TArrayUtilities.Fill(AIvBytes, 0, System.Length(AIvBytes), Byte(0));
 end;
 
 end.

--- a/CryptoLib/src/Crypto/Generators/ClpPbeParametersGenerator.pas
+++ b/CryptoLib/src/Crypto/Generators/ClpPbeParametersGenerator.pas
@@ -184,12 +184,12 @@ procedure TPbeParametersGenerator.Clear;
 begin
   if FPassword <> nil then
   begin
-    TArrayUtilities.Fill<Byte>(FPassword, 0, System.Length(FPassword), Byte(0));
+    TArrayUtilities.Fill(FPassword, 0, System.Length(FPassword), Byte(0));
     FPassword := nil;
   end;
   if FSalt <> nil then
   begin
-    TArrayUtilities.Fill<Byte>(FSalt, 0, System.Length(FSalt), Byte(0));
+    TArrayUtilities.Fill(FSalt, 0, System.Length(FSalt), Byte(0));
     FSalt := nil;
   end;
   FIterationCount := 0;
@@ -238,7 +238,7 @@ begin
     if AWrongPkcs12Zero then
     begin
       System.SetLength(Result, 2);
-      TArrayUtilities.Fill<Byte>(Result, 0, System.Length(Result), Byte(0));
+      TArrayUtilities.Fill(Result, 0, System.Length(Result), Byte(0));
     end
     else
       Result := nil;

--- a/CryptoLib/src/Crypto/Generators/ClpPkcs12ParametersGenerator.pas
+++ b/CryptoLib/src/Crypto/Generators/ClpPkcs12ParametersGenerator.pas
@@ -119,7 +119,7 @@ var
   LSaltEmpty, LPasswordEmpty: Boolean;
 begin
   System.SetLength(LD, FV);
-  TArrayUtilities.Fill<Byte>(LD, 0, System.Length(LD), Byte(AIdByte));
+  TArrayUtilities.Fill(LD, 0, System.Length(LD), Byte(AIdByte));
 
   LSaltEmpty := (FSalt = nil) or (System.Length(FSalt) = 0);
   LS := nil;

--- a/CryptoLib/src/Crypto/IO/ClpCipherStream.pas
+++ b/CryptoLib/src/Crypto/IO/ClpCipherStream.pas
@@ -202,7 +202,7 @@ begin
       try
         FStream.Write(LOutput[0], LLength);
       finally
-        TArrayUtilities.Fill<Byte>(LOutput, 0, System.Length(LOutput), Byte(0));
+        TArrayUtilities.Fill(LOutput, 0, System.Length(LOutput), Byte(0));
       end;
     end;
   end;
@@ -226,7 +226,7 @@ begin
     try
       FStream.Write(LOutput[0], System.Length(LOutput));
     finally
-      TArrayUtilities.Fill<Byte>(LOutput, 0, System.Length(LOutput), Byte(0));
+      TArrayUtilities.Fill(LOutput, 0, System.Length(LOutput), Byte(0));
     end;
   end;
 end;
@@ -258,7 +258,7 @@ begin
     LLen := FWriteCipher.DoFinal(LOutput, 0);
     if LLen > 0 then
       FStream.Write(LOutput[0], LLen);
-    TArrayUtilities.Fill<Byte>(LOutput, 0, System.Length(LOutput), Byte(0));
+    TArrayUtilities.Fill(LOutput, 0, System.Length(LOutput), Byte(0));
   end;
   if not FLeaveOpen then
     FStream.Free;

--- a/CryptoLib/src/Crypto/Macs/ClpCMac.pas
+++ b/CryptoLib/src/Crypto/Macs/ClpCMac.pas
@@ -257,7 +257,7 @@ end;
 
 procedure TCMac.Reset();
 begin
-  TArrayUtilities.Fill<Byte>(FBuf, 0, System.Length(FBuf), Byte(0));
+  TArrayUtilities.Fill(FBuf, 0, System.Length(FBuf), Byte(0));
   FBufOff := 0;
   FCipherMode.Reset();
 end;

--- a/CryptoLib/src/Crypto/Macs/ClpCbcBlockCipherMac.pas
+++ b/CryptoLib/src/Crypto/Macs/ClpCbcBlockCipherMac.pas
@@ -197,7 +197,7 @@ end;
 
 procedure TCbcBlockCipherMac.Reset();
 begin
-  TArrayUtilities.Fill<Byte>(FBuf, 0, System.Length(FBuf), Byte(0));
+  TArrayUtilities.Fill(FBuf, 0, System.Length(FBuf), Byte(0));
   FBufOff := 0;
   FCipherMode.Reset();
 end;

--- a/CryptoLib/src/Crypto/Macs/ClpCfbBlockCipherMac.pas
+++ b/CryptoLib/src/Crypto/Macs/ClpCfbBlockCipherMac.pas
@@ -166,7 +166,7 @@ begin
     if LIvLen < System.Length(FIV) then
     begin
       LOffset := System.Length(FIV) - LIvLen;
-      TArrayUtilities.Fill<Byte>(FIV, 0, LOffset, Byte(0));
+      TArrayUtilities.Fill(FIV, 0, LOffset, Byte(0));
       System.Move(LIv[0], FIV[LOffset], LIvLen * System.SizeOf(Byte));
     end
     else
@@ -352,7 +352,7 @@ end;
 
 procedure TCfbBlockCipherMac.Reset;
 begin
-  TArrayUtilities.Fill<Byte>(FBuf, 0, System.Length(FBuf), Byte(0));
+  TArrayUtilities.Fill(FBuf, 0, System.Length(FBuf), Byte(0));
   FBufOff := 0;
   FCipher.Reset();
 end;

--- a/CryptoLib/src/Crypto/Macs/ClpPoly1305.pas
+++ b/CryptoLib/src/Crypto/Macs/ClpPoly1305.pas
@@ -432,7 +432,7 @@ end;
 procedure TPoly1305.Reset();
 begin
   FCurrentBlockOffset := 0;
-  TArrayUtilities.Fill<Byte>(FCurrentBlock, 0, System.Length(FCurrentBlock), Byte(0));
+  TArrayUtilities.Fill(FCurrentBlock, 0, System.Length(FCurrentBlock), Byte(0));
   Poly1305StateReset(FState);
 end;
 

--- a/CryptoLib/src/Crypto/Modes/ClpCbcBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpCbcBlockCipher.pas
@@ -289,7 +289,7 @@ end;
 procedure TCbcBlockCipher.Reset;
 begin
   System.Move(FIV[0], FCbcV[0], System.Length(FIV));
-  TArrayUtilities.Fill<Byte>(FCbcNextV, 0, System.Length(FCbcNextV), Byte(0));
+  TArrayUtilities.Fill(FCbcNextV, 0, System.Length(FCbcNextV), Byte(0));
 end;
 
 function TCbcBlockCipher.GetAlgorithmName: String;

--- a/CryptoLib/src/Crypto/Modes/ClpCcmBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpCcmBlockCipher.pas
@@ -652,7 +652,7 @@ begin
     end;
   end;
 
-  System.FillChar(AMacState[0], BlockSize, 0);
+  TArrayUtilities.Fill(AMacState, 0, BlockSize, Byte(0));
   System.SetLength(LBlock, BlockSize);
   LOffset := 0;
   while LOffset < LHeaderLen do
@@ -789,7 +789,7 @@ begin
     PByte(@ACtx.Dest[ACtx.DestOff + LBulkBlocks * BlockSize]));
 
   // Zero-pad plaintext tail and fold one last CBC step.
-  System.FillChar(LTailBlock[0], BlockSize, 0);
+  TArrayUtilities.Fill(LTailBlock, 0, BlockSize, Byte(0));
   for LI := 0 to LTailLen - 1 do
     LTailBlock[LI] := ACtx.Dest[ACtx.DestOff + LBulkBlocks * BlockSize + LI];
   TByteUtilities.XorTo(BlockSize, PByte(@LTailBlock[0]), PByte(@LMacState[0]));

--- a/CryptoLib/src/Crypto/Modes/ClpCfbBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpCfbBlockCipher.pas
@@ -232,7 +232,7 @@ begin
     LIv := LIvParam.GetIV();
     LDiff := System.Length(FIV) - System.Length(LIv);
     System.Move(LIv[0], FIV[LDiff], System.Length(LIv) * System.SizeOf(Byte));
-    TArrayUtilities.Fill<Byte>(FIV, 0, LDiff, Byte(0));
+    TArrayUtilities.Fill(FIV, 0, LDiff, Byte(0));
     LParameters := LIvParam.Parameters;
   end;
 

--- a/CryptoLib/src/Crypto/Modes/ClpChaCha20Poly1305.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpChaCha20Poly1305.pas
@@ -545,7 +545,7 @@ begin
 
   CheckData();
 
-  TArrayUtilities.Fill<Byte>(FMac, 0, MacSize, Byte(0));
+  TArrayUtilities.Fill(FMac, 0, MacSize, Byte(0));
 
   case FState of
     TState.DecData:
@@ -676,7 +676,7 @@ begin
     FChaCha20.ProcessBytes(LFirstBlock, 0, 64, LFirstBlock, 0);
     FPoly1305.Init(TKeyParameter.Create(LFirstBlock, 0, 32) as IKeyParameter);
   finally
-    TArrayUtilities.Fill<Byte>(LFirstBlock, 0, 64, Byte(0));
+    TArrayUtilities.Fill(LFirstBlock, 0, 64, Byte(0));
   end;
 end;
 
@@ -733,11 +733,11 @@ end;
 
 procedure TChaCha20Poly1305.Reset(AClearMac, AResetCipher: Boolean);
 begin
-  TArrayUtilities.Fill<Byte>(FBuf, 0, System.Length(FBuf), Byte(0));
+  TArrayUtilities.Fill(FBuf, 0, System.Length(FBuf), Byte(0));
 
   if AClearMac then
   begin
-    TArrayUtilities.Fill<Byte>(FMac, 0, System.Length(FMac), Byte(0));
+    TArrayUtilities.Fill(FMac, 0, System.Length(FMac), Byte(0));
   end;
 
   FAadCount := UInt64(0);

--- a/CryptoLib/src/Crypto/Modes/ClpCipherModeParameterUtilities.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpCipherModeParameterUtilities.pas
@@ -124,7 +124,7 @@ begin
       LPrefix := System.Length(AIvTarget) - System.Length(LIv);
       System.Move(LIv[0], AIvTarget[LPrefix],
         System.Length(LIv) * System.SizeOf(Byte));
-      TArrayUtilities.Fill<Byte>(AIvTarget, 0, LPrefix, Byte(0));
+      TArrayUtilities.Fill(AIvTarget, 0, LPrefix, Byte(0));
     end
     else
     begin

--- a/CryptoLib/src/Crypto/Modes/ClpEaxBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpEaxBlockCipher.pas
@@ -557,11 +557,11 @@ begin
   FMac.Reset();
 
   FBufOff := 0;
-  TArrayUtilities.Fill<Byte>(FBufBlock, 0, System.Length(FBufBlock), Byte(0));
+  TArrayUtilities.Fill(FBufBlock, 0, System.Length(FBufBlock), Byte(0));
 
   if AClearMac then
   begin
-    TArrayUtilities.Fill<Byte>(FMacBlock, 0, System.Length(FMacBlock), Byte(0));
+    TArrayUtilities.Fill(FMacBlock, 0, System.Length(FMacBlock), Byte(0));
   end;
 
   System.SetLength(LTag, FBlockSize);
@@ -573,8 +573,8 @@ begin
   if FUseFusedBody then
   begin
     System.Move(FNonceMac[0], FCtrBlock[0], FBlockSize);
-    TArrayUtilities.Fill<Byte>(FOmacState, 0, FBlockSize, Byte(0));
-    TArrayUtilities.Fill<Byte>(FOmacLookahead, 0, FBlockSize, Byte(0));
+    TArrayUtilities.Fill(FOmacState, 0, FBlockSize, Byte(0));
+    TArrayUtilities.Fill(FOmacLookahead, 0, FBlockSize, Byte(0));
     FHasOmacLookahead := False;
   end;
 

--- a/CryptoLib/src/Crypto/Modes/ClpGcmBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpGcmBlockCipher.pas
@@ -463,9 +463,9 @@ begin
     System.SetLength(FHPow, 128);
     TGcmUtilities.InitEightWayHPowFromH(FH, FHPow);
     System.SetLength(FWorkCtr, 128);
-    TArrayUtilities.Fill<Byte>(FWorkCtr, 0, System.Length(FWorkCtr), Byte(0));
+    TArrayUtilities.Fill(FWorkCtr, 0, System.Length(FWorkCtr), Byte(0));
     System.SetLength(FWorkCtrAhead, 128);
-    TArrayUtilities.Fill<Byte>(FWorkCtrAhead, 0, System.Length(FWorkCtrAhead), Byte(0));
+    TArrayUtilities.Fill(FWorkCtrAhead, 0, System.Length(FWorkCtrAhead), Byte(0));
 
     if TFusedKernelRegistry.TryAcquireGcm(FCipher, TFusedModeDirection.Encrypt,
       @FHPow[0], FGcmKernel) and (FGcmKernel <> nil) then
@@ -1049,10 +1049,10 @@ end;
 
 procedure TGcmBlockCipher.DoReset(AClearMac: Boolean);
 begin
-  TArrayUtilities.Fill<Byte>(FS, 0, System.Length(FS), Byte(0));
-  TArrayUtilities.Fill<Byte>(FS_at, 0, System.Length(FS_at), Byte(0));
-  TArrayUtilities.Fill<Byte>(FS_atPre, 0, System.Length(FS_atPre), Byte(0));
-  TArrayUtilities.Fill<Byte>(FAtBlock, 0, System.Length(FAtBlock), Byte(0));
+  TArrayUtilities.Fill(FS, 0, System.Length(FS), Byte(0));
+  TArrayUtilities.Fill(FS_at, 0, System.Length(FS_at), Byte(0));
+  TArrayUtilities.Fill(FS_atPre, 0, System.Length(FS_atPre), Byte(0));
+  TArrayUtilities.Fill(FAtBlock, 0, System.Length(FAtBlock), Byte(0));
   FAtBlockPos := 0;
   FAtLength := 0;
   FAtLengthPre := 0;
@@ -1063,7 +1063,7 @@ begin
   FTotalLength := 0;
 
   if FBufBlock <> nil then
-    TArrayUtilities.Fill<Byte>(FBufBlock, 0, System.Length(FBufBlock), Byte(0));
+    TArrayUtilities.Fill(FBufBlock, 0, System.Length(FBufBlock), Byte(0));
 
   if AClearMac then
     FMacBlock := nil;

--- a/CryptoLib/src/Crypto/Modes/ClpGcmSivBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpGcmSivBlockCipher.pas
@@ -291,7 +291,7 @@ procedure TGcmSivBlockCipher.TGcmSivHasher.CompleteHash;
 begin
   if FNumActive > 0 then
   begin
-    TArrayUtilities.Fill<Byte>(FParent.FTheReverse, 0, System.Length(FParent.FTheReverse), Byte(0));
+    TArrayUtilities.Fill(FParent.FTheReverse, 0, System.Length(FParent.FTheReverse), Byte(0));
     TGcmSivBlockCipher.FillReverse(FBuffer, 0, FNumActive, FParent.FTheReverse);
 
     FParent.GHASH(FParent.FTheReverse);
@@ -551,8 +551,7 @@ procedure TGcmSivBlockCipher.ResetStreams;
 begin
   // Wipe held/recovered plaintext (FTheEncData holds only ciphertext); reset
   // used lengths but keep the reused buffers' capacity.
-  if FThePlainLen > 0 then
-    System.FillChar(FThePlain[0], FThePlainLen, 0);
+  TArrayUtilities.Fill(FThePlain, 0, FThePlainLen, Byte(0));
   FThePlainLen := 0;
   FTheEncDataLen := 0;
 
@@ -560,7 +559,7 @@ begin
   FTheDataHasher.Reset();
 
   FTheFlags := FTheFlags and (not AEAD_COMPLETE);
-  TArrayUtilities.Fill<Byte>(FTheGHash, 0, System.Length(FTheGHash), Byte(0));
+  TArrayUtilities.Fill(FTheGHash, 0, System.Length(FTheGHash), Byte(0));
 
   if FTheInitialAEAD <> nil then
     FTheAEADHasher.UpdateHash(FTheInitialAEAD, 0, System.Length(FTheInitialAEAD));

--- a/CryptoLib/src/Crypto/Modes/ClpOcbBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpOcbBlockCipher.pas
@@ -301,16 +301,16 @@ begin
     FMacSize := 16;
 
   System.SetLength(FHashBlock, 16);
-  TArrayUtilities.Fill<Byte>(FHashBlock, 0, 16, Byte(0));
+  TArrayUtilities.Fill(FHashBlock, 0, 16, Byte(0));
   if FForEncryption then
   begin
     System.SetLength(FMainBlock, BLOCK_SIZE);
-    TArrayUtilities.Fill<Byte>(FMainBlock, 0, BLOCK_SIZE, Byte(0));
+    TArrayUtilities.Fill(FMainBlock, 0, BLOCK_SIZE, Byte(0));
   end
   else
   begin
     System.SetLength(FMainBlock, BLOCK_SIZE + FMacSize);
-    TArrayUtilities.Fill<Byte>(FMainBlock, 0, BLOCK_SIZE + FMacSize, Byte(0));
+    TArrayUtilities.Fill(FMainBlock, 0, BLOCK_SIZE + FMacSize, Byte(0));
   end;
 
   if (System.Length(LN) > 15) then
@@ -359,7 +359,7 @@ begin
   end;
 
   System.SetLength(FL_Asterisk, 16);
-  TArrayUtilities.Fill<Byte>(FL_Asterisk, 0, 16, Byte(0));
+  TArrayUtilities.Fill(FL_Asterisk, 0, 16, Byte(0));
   FHashCipher.ProcessBlock(FL_Asterisk, 0, FL_Asterisk, 0);
 
   FL_Dollar := OCB_double(FL_Asterisk);
@@ -394,12 +394,12 @@ begin
   FMainBlockCount := 0;
 
   System.SetLength(FOffsetHASH, 16);
-  TArrayUtilities.Fill<Byte>(FOffsetHASH, 0, 16, Byte(0));
+  TArrayUtilities.Fill(FOffsetHASH, 0, 16, Byte(0));
   System.SetLength(FSum, 16);
-  TArrayUtilities.Fill<Byte>(FSum, 0, 16, Byte(0));
+  TArrayUtilities.Fill(FSum, 0, 16, Byte(0));
   System.Move(FOffsetMAIN_0[0], FOffsetMAIN[0], 16);
   System.SetLength(FChecksum, 16);
-  TArrayUtilities.Fill<Byte>(FChecksum, 0, 16, Byte(0));
+  TArrayUtilities.Fill(FChecksum, 0, 16, Byte(0));
 
   if (FInitialAssociatedText <> nil) then
   begin
@@ -857,7 +857,7 @@ procedure TOcbBlockCipher.Clear(const ABs: TCryptoLibByteArray);
 begin
   if (ABs <> nil) then
   begin
-    TArrayUtilities.Fill<Byte>(ABs, 0, System.Length(ABs), Byte(0));
+    TArrayUtilities.Fill(ABs, 0, System.Length(ABs), Byte(0));
   end;
 end;
 

--- a/CryptoLib/src/Crypto/Modes/ClpSicBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpSicBlockCipher.pas
@@ -155,7 +155,7 @@ end;
 
 procedure TSicBlockCipher.Reset;
 begin
-  TArrayUtilities.Fill<Byte>(FCounter, 0, System.Length(FCounter), Byte(0));
+  TArrayUtilities.Fill(FCounter, 0, System.Length(FCounter), Byte(0));
   System.Move(FIV[0], FCounter[0], System.Length(FIV) * System.SizeOf(Byte));
 end;
 

--- a/CryptoLib/src/Crypto/Parameters/ClpKeyParameter.pas
+++ b/CryptoLib/src/Crypto/Parameters/ClpKeyParameter.pas
@@ -70,7 +70,7 @@ end;
 
 procedure TKeyParameter.Clear;
 begin
-  TArrayUtilities.Fill<Byte>(FKey, 0, System.Length(FKey), Byte(0));
+  TArrayUtilities.Fill(FKey, 0, System.Length(FKey), Byte(0));
 end;
 
 constructor TKeyParameter.Create(const AKey: TCryptoLibByteArray;

--- a/CryptoLib/src/Crypto/Parameters/ClpParametersWithContext.pas
+++ b/CryptoLib/src/Crypto/Parameters/ClpParametersWithContext.pas
@@ -88,7 +88,7 @@ end;
 
 destructor TParametersWithContext.Destroy;
 begin
-  TArrayUtilities.Fill<Byte>(FContext, 0, System.Length(FContext), Byte(0));
+  TArrayUtilities.Fill(FContext, 0, System.Length(FContext), Byte(0));
   inherited;
 end;
 

--- a/CryptoLib/src/Crypto/Parameters/ClpParametersWithIV.pas
+++ b/CryptoLib/src/Crypto/Parameters/ClpParametersWithIV.pas
@@ -79,7 +79,7 @@ end;
 
 procedure TParametersWithIV.Clear;
 begin
-  TArrayUtilities.Fill<Byte>(FIv, 0, System.Length(FIv), Byte(0));
+  TArrayUtilities.Fill(FIv, 0, System.Length(FIv), Byte(0));
 end;
 
 constructor TParametersWithIV.Create(const AParameters: ICipherParameters;

--- a/CryptoLib/src/Crypto/Signers/ClpBip340SchnorrSigner.pas
+++ b/CryptoLib/src/Crypto/Signers/ClpBip340SchnorrSigner.pas
@@ -201,7 +201,7 @@ begin
     if (LProvidedRandom <> nil) then
       LProvidedRandom.NextBytes(LAuxRand)
     else
-      TArrayUtilities.Fill<Byte>(LAuxRand, 0, System.Length(LAuxRand), Byte(0));
+      TArrayUtilities.Fill(LAuxRand, 0, System.Length(LAuxRand), Byte(0));
 
     LD := TBigInteger.Create(1, APrivateKey.GetEncoded()).&Mod(LN);
     if (LD.SignValue = 0) then

--- a/CryptoLib/src/Crypto/Signers/ClpPssSigner.pas
+++ b/CryptoLib/src/Crypto/Signers/ClpPssSigner.pas
@@ -291,7 +291,7 @@ end;
 procedure TPssSigner.ClearBlock(const ABlock: TCryptoLibByteArray);
 begin
   if ABlock <> nil then
-    TArrayUtilities.Fill<Byte>(ABlock, 0, System.Length(ABlock), Byte(0));
+    TArrayUtilities.Fill(ABlock, 0, System.Length(ABlock), Byte(0));
 end;
 
 procedure TPssSigner.Update(AInput: Byte);
@@ -320,7 +320,7 @@ begin
   ClearBlock(FBlock);
 
   // PSS requires first 8 bytes of mDash to be zeros (padding1)
-  TArrayUtilities.Fill<Byte>(FMDash, 0, 8, Byte(0));
+  TArrayUtilities.Fill(FMDash, 0, 8, Byte(0));
 
   FContentDigest1.DoFinal(FMDash, System.Length(FMDash) - FHLen - FSLen);
 
@@ -378,13 +378,13 @@ begin
   end;
 
   // PSS requires first 8 bytes of mDash to be zeros (padding1)
-  TArrayUtilities.Fill<Byte>(FMDash, 0, 8, Byte(0));
+  TArrayUtilities.Fill(FMDash, 0, 8, Byte(0));
 
   FContentDigest1.DoFinal(FMDash, System.Length(FMDash) - FHLen - FSLen);
 
   LB := FCipher.ProcessBlock(ASignature, 0, System.Length(ASignature));
   
-  TArrayUtilities.Fill<Byte>(FBlock, 0, System.Length(FBlock) - System.Length(LB), Byte(0));
+  TArrayUtilities.Fill(FBlock, 0, System.Length(FBlock) - System.Length(LB), Byte(0));
   System.Move(LB[0], FBlock[System.Length(FBlock) - System.Length(LB)],
     System.Length(LB));
 

--- a/CryptoLib/src/Crypto/Signers/ClpSlhDsaSigner.pas
+++ b/CryptoLib/src/Crypto/Signers/ClpSlhDsaSigner.pas
@@ -32,6 +32,7 @@ uses
   ClpCryptoServicesRegistrar,
   ClpISecureRandom,
   ClpSecureRandom,
+  ClpArrayUtilities,
   ClpCryptoLibTypes;
 
 resourcestring
@@ -114,8 +115,7 @@ end;
 
 procedure TSlhDsaSignerBuffer.TruncateAndClear(ANewLength: Int32);
 begin
-  if ANewLength < FCount then
-    FillChar(FBuffer[ANewLength], FCount - ANewLength, 0);
+  TArrayUtilities.Fill(FBuffer, ANewLength, FCount, Byte(0));
   FCount := ANewLength;
 end;
 

--- a/CryptoLib/src/Crypto/Signers/ClpX931Signer.pas
+++ b/CryptoLib/src/Crypto/Signers/ClpX931Signer.pas
@@ -178,7 +178,7 @@ begin
 
   LT := TBigInteger.Create(1, FCipher.ProcessBlock(FBlock, 0,
     System.Length(FBlock)));
-  TArrayUtilities.Fill<Byte>(FBlock, 0, System.Length(FBlock), Byte($00));
+  TArrayUtilities.Fill(FBlock, 0, System.Length(FBlock), Byte($00));
 
   LT := LT.Min(FKParam.Modulus.Subtract(LT));
 
@@ -226,8 +226,8 @@ begin
 
   LRv := TArrayUtilities.FixedTimeEquals(FBlock, LFBlock);
 
-  TArrayUtilities.Fill<Byte>(FBlock, 0, System.Length(FBlock), Byte($00));
-  TArrayUtilities.Fill<Byte>(LFBlock, 0, System.Length(LFBlock), Byte($00));
+  TArrayUtilities.Fill(FBlock, 0, System.Length(FBlock), Byte($00));
+  TArrayUtilities.Fill(LFBlock, 0, System.Length(LFBlock), Byte($00));
 
   Result := LRv;
 end;

--- a/CryptoLib/src/Crypto/Signers/MlDsa/ClpMlDsaEngine.pas
+++ b/CryptoLib/src/Crypto/Signers/MlDsa/ClpMlDsaEngine.pas
@@ -32,6 +32,7 @@ uses
   ClpISecureRandom,
   ClpSecureRandom,
   ClpBitOperations,
+  ClpArrayUtilities,
   ClpCryptoLibTypes;
 
 resourcestring
@@ -401,7 +402,7 @@ begin
   if FRandom <> nil then
     LRnd := TSecureRandom.GetNextBytes(FRandom, RndBytes)
   else
-    FillChar(LRnd[0], RndBytes, 0);
+    TArrayUtilities.Fill(LRnd, 0, RndBytes, Byte(0));
   MsgRepEndSignCore(ADigest, ASig, ASigLen, ARho, AK, AT0Enc, AS1Enc, AS2Enc, LRnd);
 end;
 

--- a/CryptoLib/src/Crypto/Signers/SignerCalculators/ClpHMacDsaKCalculator.pas
+++ b/CryptoLib/src/Crypto/Signers/SignerCalculators/ClpHMacDsaKCalculator.pas
@@ -120,8 +120,8 @@ var
   LSize: Int32;
 begin
   FN := AN;
-  TArrayUtilities.Fill<Byte>(FV, 0, System.Length(FV), Byte($01));
-  TArrayUtilities.Fill<Byte>(FK, 0, System.Length(FK), Byte(0));
+  TArrayUtilities.Fill(FV, 0, System.Length(FV), Byte($01));
+  TArrayUtilities.Fill(FK, 0, System.Length(FK), Byte(0));
 
   LSize := TBigIntegerUtilities.GetUnsignedByteLength(AN);
   System.SetLength(LX, LSize);

--- a/CryptoLib/src/Crypto/Signers/SignerEncodings/ClpPlainDsaEncoding.pas
+++ b/CryptoLib/src/Crypto/Signers/SignerEncodings/ClpPlainDsaEncoding.pas
@@ -108,7 +108,7 @@ begin
   LBsOff := Max(0, System.Length(LBs) - ALength);
   LBsLen := System.Length(LBs) - LBsOff;
   LPos := ALength - LBsLen;
-  TArrayUtilities.Fill<Byte>(ABuf, AOff, AOff + LPos, Byte(0));
+  TArrayUtilities.Fill(ABuf, AOff, AOff + LPos, Byte(0));
   System.Move(LBs[LBsOff], ABuf[AOff + LPos], LBsLen * System.SizeOf(Byte));
 end;
 

--- a/CryptoLib/src/Crypto/Signers/SlhDsa/ClpSlhDsaCore.pas
+++ b/CryptoLib/src/Crypto/Signers/SlhDsa/ClpSlhDsaCore.pas
@@ -284,7 +284,7 @@ end;
 procedure TSlhDsaAdrs.SetTypeAndClear(AAdrsType: UInt32);
 begin
   SetType(AAdrsType);
-  FillChar(FValue[SlhDsaAdrsOffsetType + 4], 32 - (SlhDsaAdrsOffsetType + 4), 0);
+  TArrayUtilities.Fill(FValue, SlhDsaAdrsOffsetType + 4, 32, Byte(0));
 end;
 
 { TSlhDsaIndexGenerator }

--- a/CryptoLib/src/GeneralUtilities/ClpArrayUtilities.pas
+++ b/CryptoLib/src/GeneralUtilities/ClpArrayUtilities.pas
@@ -122,6 +122,8 @@ type
       AFiller: UInt32); overload; static; inline;
     class procedure Fill(const ABuf: TCryptoLibUInt64Array; AFrom, ATo: Int32;
       AFiller: UInt64); overload; static; inline;
+    class procedure Fill(const ABuf: TCryptoLibInt32Array; AFrom, ATo: Int32;
+      AFiller: Int32); overload; static; inline;
 
     /// <summary>
     /// Grow ABuf's capacity to at least ANeeded by doubling; never shrinks.
@@ -377,6 +379,18 @@ begin
   System.FillQWord(ABuf[AFrom], ATo - AFrom, AFiller);
 {$ELSE}
   FillCore<UInt64>(ABuf, AFrom, ATo, AFiller);
+{$ENDIF FPC}
+end;
+
+class procedure TArrayUtilities.Fill(const ABuf: TCryptoLibInt32Array;
+  AFrom, ATo: Int32; AFiller: Int32);
+begin
+  if (ABuf = nil) or (ATo <= AFrom) then
+    Exit;
+{$IFDEF FPC}
+  System.FillDWord(ABuf[AFrom], ATo - AFrom, UInt32(AFiller));
+{$ELSE}
+  FillCore<Int32>(ABuf, AFrom, ATo, AFiller);
 {$ENDIF FPC}
 end;
 

--- a/CryptoLib/src/Math/BinPoly/ClpBinPolyMulBase.pas
+++ b/CryptoLib/src/Math/BinPoly/ClpBinPolyMulBase.pas
@@ -114,7 +114,7 @@ begin
     TInterleave.Expand64To128(AX, AXOff, FSize, Ltt, 0);
     FReduce.Reduce(Ltt, 0, AZ, AZOff);
   finally
-    TArrayUtilities.Fill<UInt64>(Ltt, 0, FSizeExt, 0);
+    TArrayUtilities.Fill(Ltt, 0, FSizeExt, 0);
   end;
 end;
 
@@ -138,7 +138,7 @@ begin
       FReduce.Reduce(Ltt, 0, AZ, AZOff);
     end;
   finally
-    TArrayUtilities.Fill<UInt64>(Ltt, 0, FSizeExt, 0);
+    TArrayUtilities.Fill(Ltt, 0, FSizeExt, 0);
   end;
 end;
 

--- a/CryptoLib/src/Math/BinPoly/ClpBinPolyScalarLarge.pas
+++ b/CryptoLib/src/Math/BinPoly/ClpBinPolyScalarLarge.pas
@@ -86,8 +86,8 @@ begin
     ImplKaratsuba(FSize, AX, AXOff, AY, AYOff, Ltt, 0, LScratch, 0);
     FReduce.Reduce(Ltt, 0, AZ, AZOff);
   finally
-    TArrayUtilities.Fill<UInt64>(LScratch, 0, LScratchSize, 0);
-    TArrayUtilities.Fill<UInt64>(Ltt, 0, FSizeExt, 0);
+    TArrayUtilities.Fill(LScratch, 0, LScratchSize, 0);
+    TArrayUtilities.Fill(Ltt, 0, FSizeExt, 0);
   end;
 end;
 

--- a/CryptoLib/src/Math/BinPoly/ClpBinPolyScalarMedium.pas
+++ b/CryptoLib/src/Math/BinPoly/ClpBinPolyScalarMedium.pas
@@ -61,7 +61,7 @@ begin
     TBinPolyScalarKernels.ImplMul(FSize, AX, AXOff, AY, AYOff, Ltt, 0);
     FReduce.Reduce(Ltt, 0, AZ, AZOff);
   finally
-    TArrayUtilities.Fill<UInt64>(Ltt, 0, FSizeExt, 0);
+    TArrayUtilities.Fill(Ltt, 0, FSizeExt, 0);
   end;
 end;
 

--- a/CryptoLib/src/Math/BinPoly/ClpBinPolyX86V128Large.pas
+++ b/CryptoLib/src/Math/BinPoly/ClpBinPolyX86V128Large.pas
@@ -74,8 +74,8 @@ begin
     ImplKaratsuba(FSize, AX, AXOff, AY, AYOff, Ltt, 0, LScratch, 0);
     FReduce.Reduce(Ltt, 0, AZ, AZOff);
   finally
-    TArrayUtilities.Fill<UInt64>(LScratch, 0, LScratchSize, 0);
-    TArrayUtilities.Fill<UInt64>(Ltt, 0, FSizeExt, 0);
+    TArrayUtilities.Fill(LScratch, 0, LScratchSize, 0);
+    TArrayUtilities.Fill(Ltt, 0, FSizeExt, 0);
   end;
 end;
 

--- a/CryptoLib/src/Math/BinPoly/ClpBinPolyX86V128Medium.pas
+++ b/CryptoLib/src/Math/BinPoly/ClpBinPolyX86V128Medium.pas
@@ -73,7 +73,7 @@ begin
     TBinPolyX86V128Kernels.ImplMulEven(FSize, AX, AXOff, AY, AYOff, Ltt, 0);
     FReduce.Reduce(Ltt, 0, AZ, AZOff);
   finally
-    TArrayUtilities.Fill<UInt64>(Ltt, 0, FSizeExt, 0);
+    TArrayUtilities.Fill(Ltt, 0, FSizeExt, 0);
   end;
 end;
 
@@ -98,7 +98,7 @@ begin
     TBinPolyX86V128Kernels.ImplMulOdd(FSize, AX, AXOff, AY, AYOff, Ltt, 0);
     FReduce.Reduce(Ltt, 0, AZ, AZOff);
   finally
-    TArrayUtilities.Fill<UInt64>(Ltt, 0, FSizeExt, 0);
+    TArrayUtilities.Fill(Ltt, 0, FSizeExt, 0);
   end;
 end;
 

--- a/CryptoLib/src/Math/BinPoly/ClpBinPolyX86V128Sizes.pas
+++ b/CryptoLib/src/Math/BinPoly/ClpBinPolyX86V128Sizes.pas
@@ -122,7 +122,7 @@ begin
     TBinPolyX86V128Kernels.ImplMulSmall(ASmallLen, AX, AXOff, AY, AYOff, Ltt, 0);
     AReduce.Reduce(Ltt, 0, AZ, AZOff);
   finally
-    TArrayUtilities.Fill<UInt64>(Ltt, 0, ASizeExt, 0);
+    TArrayUtilities.Fill(Ltt, 0, ASizeExt, 0);
   end;
 end;
 

--- a/CryptoLib/src/Math/BinPoly/ClpBinPolys.pas
+++ b/CryptoLib/src/Math/BinPoly/ClpBinPolys.pas
@@ -210,19 +210,19 @@ end;
 
 class procedure TBinPolys.Zero(ASize: Int32; const AZ: TCryptoLibUInt64Array; AZOff: Int32);
 begin
-  TArrayUtilities.Fill<UInt64>(AZ, AZOff, AZOff + ASize, 0);
+  TArrayUtilities.Fill(AZ, AZOff, AZOff + ASize, 0);
 end;
 
 class procedure TBinPolys.Clear(ASize: Int32; const AZ: TCryptoLibUInt64Array; AZOff: Int32);
 begin
-  TArrayUtilities.Fill<UInt64>(AZ, AZOff, AZOff + ASize, 0);
+  TArrayUtilities.Fill(AZ, AZOff, AZOff + ASize, 0);
 end;
 
 class procedure TBinPolys.One(ASize: Int32; const AZ: TCryptoLibUInt64Array; AZOff: Int32);
 begin
   AZ[AZOff] := 1;
   if ASize > 1 then
-    TArrayUtilities.Fill<UInt64>(AZ, AZOff + 1, AZOff + ASize, 0);
+    TArrayUtilities.Fill(AZ, AZOff + 1, AZOff + ASize, 0);
 end;
 
 class function TBinPolys.EqualTo(ASize: Int32; const AX: TCryptoLibUInt64Array; AXOff: Int32;

--- a/CryptoLib/src/Math/ClpBigInteger.pas
+++ b/CryptoLib/src/Math/ClpBigInteger.pas
@@ -831,7 +831,7 @@ begin
     System.SetLength(LNewMag, LMagLen + LNInts);
     if LMagLen > 0 then
       Move(AMag[0], LNewMag[0], LMagLen * SizeOf(UInt32));
-    TArrayUtilities.Fill<UInt32>(LNewMag, LMagLen, System.Length(LNewMag), UInt32(0));
+    TArrayUtilities.Fill(LNewMag, LMagLen, System.Length(LNewMag), UInt32(0));
   end
   else
   begin
@@ -998,7 +998,7 @@ begin
     begin
       AMag[LI] := AMag[LI - LDelta];
     end;
-    TArrayUtilities.Fill<UInt32>(AMag, AStart, LNInts, UInt32(0));
+    TArrayUtilities.Fill(AMag, AStart, LNInts, UInt32(0));
   end;
   if LNBits <> 0 then
   begin
@@ -1129,7 +1129,7 @@ begin
   if LXYCmp = 0 then
   begin
     LCount := AddMagnitudes(LCount, FOne.FMagnitude);
-    TArrayUtilities.Fill<UInt32>(AX, LXStart, System.Length(AX), UInt32(0));
+    TArrayUtilities.Fill(AX, LXStart, System.Length(AX), UInt32(0));
   end;
   Result := LCount;
 end;
@@ -1234,7 +1234,7 @@ begin
   end;
   if LXYCmp = 0 then
   begin
-    TArrayUtilities.Fill<UInt32>(AX, LXStart, System.Length(AX), UInt32(0));
+    TArrayUtilities.Fill(AX, LXStart, System.Length(AX), UInt32(0));
   end;
   Result := AX;
 end;
@@ -1911,7 +1911,7 @@ begin
   end;
   LResLength := System.Length(FMagnitude) + System.Length(AValue.FMagnitude);
   System.SetLength(LRes, LResLength);
-  TArrayUtilities.Fill<UInt32>(LRes, 0, System.Length(LRes), UInt32(0));
+  TArrayUtilities.Fill(LRes, 0, System.Length(LRes), UInt32(0));
   Multiply(LRes, FMagnitude, AValue.FMagnitude);
   LResSign := FSign xor AValue.FSign xor 1;
   Result := TBigInteger.Create(LResSign, LRes, True);

--- a/CryptoLib/src/Math/ClpBigIntegerUtilities.pas
+++ b/CryptoLib/src/Math/ClpBigIntegerUtilities.pas
@@ -274,7 +274,7 @@ begin
 
   LPadLen := ALength - LBytesLength;
   System.SetLength(Result, ALength);
-  TArrayUtilities.Fill<Byte>(Result, 0, LPadLen, Byte(0));
+  TArrayUtilities.Fill(Result, 0, LPadLen, Byte(0));
   System.Move(LBytes[0], Result[LPadLen], LBytesLength * System.SizeOf(Byte));
 end;
 
@@ -291,7 +291,7 @@ begin
     raise EArgumentCryptoLibException.CreateRes(@SStandardLengthExceeded);
 
   LPadLen := ALen - LBytesLength;
-  TArrayUtilities.Fill<Byte>(ABuf, AOff, AOff + LPadLen, Byte(0));
+  TArrayUtilities.Fill(ABuf, AOff, AOff + LPadLen, Byte(0));
   System.Move(LBytes[0], ABuf[AOff + LPadLen], LBytesLength * System.SizeOf(Byte));
 end;
 

--- a/CryptoLib/src/Math/EC/Multiplier/ClpWNafUtilities.pas
+++ b/CryptoLib/src/Math/EC/Multiplier/ClpWNafUtilities.pas
@@ -529,7 +529,7 @@ begin
   L3k := AK.ShiftLeft(1).Add(AK);
   LDigits := L3k.BitLength - 1;
   System.SetLength(Result, LDigits);
-  TArrayUtilities.Fill<Byte>(Result, 0, LDigits, Byte(0));
+  TArrayUtilities.Fill(Result, 0, LDigits, Byte(0));
   LDiff := L3k.&Xor(AK);
   LI := 1;
   while LI < LDigits do
@@ -570,7 +570,7 @@ begin
   end;
   LResultLength := AK.BitLength + 1;
   System.SetLength(Result, LResultLength);
-  TArrayUtilities.Fill<Byte>(Result, 0, LResultLength, Byte(0));
+  TArrayUtilities.Fill(Result, 0, LResultLength, Byte(0));
   LPow2 := 1 shl AWidth;
   LMask := LPow2 - 1;
   LSign := TBitOperations.Asr32(LPow2, 1);
@@ -612,7 +612,7 @@ var
 begin
   LDigits := Math.Max(AG.BitLength, AH.BitLength) + 1;
   System.SetLength(LJsf, LDigits);
-  TArrayUtilities.Fill<Byte>(LJsf, 0, LDigits, Byte(0));
+  TArrayUtilities.Fill(LJsf, 0, LDigits, Byte(0));
   LK0 := AG;
   LK1 := AH;
   LJ := 0;
@@ -700,7 +700,7 @@ begin
   LBits := L3k.BitLength;
   LResultLength := TBitOperations.Asr32(LBits, 1);
   System.SetLength(Result, LResultLength);
-  TArrayUtilities.Fill<Int32>(Result, 0, LResultLength, Int32(0));
+  TArrayUtilities.Fill(Result, 0, LResultLength, Int32(0));
   LDiff := L3k.&Xor(AK);
   LHighBit := LBits - 1;
   LLength := 0;
@@ -752,7 +752,7 @@ begin
   end;
   LResultLength := AK.BitLength div AWidth + 1;
   System.SetLength(Result, LResultLength);
-  TArrayUtilities.Fill<Int32>(Result, 0, LResultLength, Int32(0));
+  TArrayUtilities.Fill(Result, 0, LResultLength, Int32(0));
   LPow2 := 1 shl AWidth;
   LMask := LPow2 - 1;
   LSign := TBitOperations.Asr32(LPow2, 1);

--- a/CryptoLib/src/Math/EC/Rfc7748/ClpX25519Field.pas
+++ b/CryptoLib/src/Math/EC/Rfc7748/ClpX25519Field.pas
@@ -786,7 +786,7 @@ end;
 class procedure TX25519Field.One(AZ: TCryptoLibInt32Array);
 begin
   AZ[0] := 1;
-  TArrayUtilities.Fill<Int32>(AZ, 1, Size, 0);
+  TArrayUtilities.Fill(AZ, 1, Size, 0);
 end;
 
 class procedure TX25519Field.PowPm5d8(const AX: TCryptoLibInt32Array; const ARx2: TCryptoLibInt32Array;
@@ -1004,7 +1004,7 @@ end;
 
 class procedure TX25519Field.Zero(AZ: TCryptoLibInt32Array);
 begin
-  TArrayUtilities.Fill<Int32>(AZ, 0, Size, 0);
+  TArrayUtilities.Fill(AZ, 0, Size, 0);
 end;
 
 end.

--- a/CryptoLib/src/Math/EC/Rfc7748/ClpX448Field.pas
+++ b/CryptoLib/src/Math/EC/Rfc7748/ClpX448Field.pas
@@ -1127,7 +1127,7 @@ end;
 
 class procedure TX448Field.Zero(AZ: TCryptoLibUInt32Array);
 begin
-  TArrayUtilities.Fill<UInt32>(AZ, 0, Size, 0);
+  TArrayUtilities.Fill(AZ, 0, Size, 0);
 end;
 
 end.

--- a/CryptoLib/src/Math/EC/Rfc8032/ClpEd25519.pas
+++ b/CryptoLib/src/Math/EC/Rfc8032/ClpEd25519.pas
@@ -1894,7 +1894,7 @@ begin
     FOwner.GeneratePrivateKey(ARandom, LSk);
     ExpandPrivateKey(LSk, 0, AXk, AXkOff);
   finally
-    TArrayUtilities.Fill<Byte>(LSk, 0, System.Length(LSk), 0);
+    TArrayUtilities.Fill(LSk, 0, System.Length(LSk), 0);
   end;
 end;
 

--- a/CryptoLib/src/Math/Raw/ClpNat.pas
+++ b/CryptoLib/src/Math/Raw/ClpNat.pas
@@ -3201,7 +3201,7 @@ begin
   end;
   if LI < ALen then
   begin
-    TArrayUtilities.Fill<UInt32>(AZ, LI, ALen, UInt32(0));
+    TArrayUtilities.Fill(AZ, LI, ALen, UInt32(0));
   end;
 end;
 
@@ -3222,7 +3222,7 @@ begin
   end;
   if LI < ALen then
   begin
-    TArrayUtilities.Fill<UInt32>(AZ, AZOff + LI, AZOff + ALen, UInt32(0));
+    TArrayUtilities.Fill(AZ, AZOff + LI, AZOff + ALen, UInt32(0));
   end;
 end;
 
@@ -3243,7 +3243,7 @@ begin
   end;
   if LI < ALen then
   begin
-    TArrayUtilities.Fill<UInt64>(AZ, LI, ALen, UInt64(0));
+    TArrayUtilities.Fill(AZ, LI, ALen, UInt64(0));
   end;
 end;
 
@@ -3264,7 +3264,7 @@ begin
   end;
   if LI < ALen then
   begin
-    TArrayUtilities.Fill<UInt64>(AZ, AZOff + LI, AZOff + ALen, UInt64(0));
+    TArrayUtilities.Fill(AZ, AZOff + LI, AZOff + ALen, UInt64(0));
   end;
 end;
 

--- a/CryptoLib/src/Math/Raw/ClpNat128.pas
+++ b/CryptoLib/src/Math/Raw/ClpNat128.pas
@@ -1106,7 +1106,7 @@ end;
 
 class procedure TNat128.Zero(const AZ: TCryptoLibUInt32Array);
 begin
-  TArrayUtilities.Fill<UInt32>(AZ, 0, 4, UInt32(0));
+  TArrayUtilities.Fill(AZ, 0, 4, UInt32(0));
 end;
 
 end.

--- a/CryptoLib/src/Math/Raw/ClpNat160.pas
+++ b/CryptoLib/src/Math/Raw/ClpNat160.pas
@@ -1134,7 +1134,7 @@ end;
 
 class procedure TNat160.Zero(const AZ: TCryptoLibUInt32Array);
 begin
-  TArrayUtilities.Fill<UInt32>(AZ, 0, 5, UInt32(0));
+  TArrayUtilities.Fill(AZ, 0, 5, UInt32(0));
 end;
 
 end.

--- a/CryptoLib/src/Math/Raw/ClpNat192.pas
+++ b/CryptoLib/src/Math/Raw/ClpNat192.pas
@@ -1245,7 +1245,7 @@ end;
 
 class procedure TNat192.Zero(AZ: TCryptoLibUInt32Array);
 begin
-  TArrayUtilities.Fill<UInt32>(AZ, 0, 6, UInt32(0));
+  TArrayUtilities.Fill(AZ, 0, 6, UInt32(0));
 end;
 
 end.

--- a/CryptoLib/src/Math/Raw/ClpNat224.pas
+++ b/CryptoLib/src/Math/Raw/ClpNat224.pas
@@ -1400,7 +1400,7 @@ end;
 
 class procedure TNat224.Zero(AZ: TCryptoLibUInt32Array);
 begin
-  TArrayUtilities.Fill<UInt32>(AZ, 0, 7, UInt32(0));
+  TArrayUtilities.Fill(AZ, 0, 7, UInt32(0));
 end;
 
 end.

--- a/CryptoLib/src/Math/Raw/ClpNat256.pas
+++ b/CryptoLib/src/Math/Raw/ClpNat256.pas
@@ -1939,22 +1939,22 @@ end;
 
 class procedure TNat256.Zero(AZ: TCryptoLibUInt32Array);
 begin
-  TArrayUtilities.Fill<UInt32>(AZ, 0, 8, UInt32(0));
+  TArrayUtilities.Fill(AZ, 0, 8, UInt32(0));
 end;
 
 class procedure TNat256.Zero(AZ: TCryptoLibUInt32Array; AZOff: Int32);
 begin
-  TArrayUtilities.Fill<UInt32>(AZ, AZOff, AZOff + 8, UInt32(0));
+  TArrayUtilities.Fill(AZ, AZOff, AZOff + 8, UInt32(0));
 end;
 
 class procedure TNat256.Zero64(AZ: TCryptoLibUInt64Array);
 begin
-  TArrayUtilities.Fill<UInt64>(AZ, 0, 4, UInt64(0));
+  TArrayUtilities.Fill(AZ, 0, 4, UInt64(0));
 end;
 
 class procedure TNat256.Zero64(AZ: TCryptoLibUInt64Array; AZOff: Int32);
 begin
-  TArrayUtilities.Fill<UInt64>(AZ, AZOff, AZOff + 4, UInt64(0));
+  TArrayUtilities.Fill(AZ, AZOff, AZOff + 4, UInt64(0));
 end;
 
 end.

--- a/CryptoLib/src/Math/Raw/ClpNat512.pas
+++ b/CryptoLib/src/Math/Raw/ClpNat512.pas
@@ -403,22 +403,22 @@ end;
 
 class procedure TNat512.Zero(AZ: TCryptoLibUInt32Array);
 begin
-  TArrayUtilities.Fill<UInt32>(AZ, 0, 16, UInt32(0));
+  TArrayUtilities.Fill(AZ, 0, 16, UInt32(0));
 end;
 
 class procedure TNat512.Zero(AZ: TCryptoLibUInt32Array; AZOff: Int32);
 begin
-  TArrayUtilities.Fill<UInt32>(AZ, AZOff, AZOff + 16, UInt32(0));
+  TArrayUtilities.Fill(AZ, AZOff, AZOff + 16, UInt32(0));
 end;
 
 class procedure TNat512.Zero64(AZ: TCryptoLibUInt64Array);
 begin
-  TArrayUtilities.Fill<UInt64>(AZ, 0, 8, UInt64(0));
+  TArrayUtilities.Fill(AZ, 0, 8, UInt64(0));
 end;
 
 class procedure TNat512.Zero64(AZ: TCryptoLibUInt64Array; AZOff: Int32);
 begin
-  TArrayUtilities.Fill<UInt64>(AZ, AZOff, AZOff + 8, UInt64(0));
+  TArrayUtilities.Fill(AZ, AZOff, AZOff + 8, UInt64(0));
 end;
 
 end.

--- a/CryptoLib/src/Rngs/Providers/ClpAesRandomProvider.pas
+++ b/CryptoLib/src/Rngs/Providers/ClpAesRandomProvider.pas
@@ -195,8 +195,8 @@ begin
     FCipher.Init(True, TKeyParameter.Create(LNewKey) as IKeyParameter);
     FBytesSinceSeed := 0;
   finally
-    TArrayUtilities.Fill<Byte>(LMix, 0, System.Length(LMix), Byte(0));
-    TArrayUtilities.Fill<Byte>(LNewKey, 0, System.Length(LNewKey), Byte(0));
+    TArrayUtilities.Fill(LMix, 0, System.Length(LMix), Byte(0));
+    TArrayUtilities.Fill(LNewKey, 0, System.Length(LNewKey), Byte(0));
   end;
 end;
 
@@ -223,7 +223,7 @@ begin
   FCipher.Init(True, TKeyParameter.Create(LAesRngSeed) as IKeyParameter);
   FBytesSinceSeed := 0;
 
-  TArrayUtilities.Fill<Byte>(LAesRngSeed, 0, System.Length(LAesRngSeed), Byte(0));
+  TArrayUtilities.Fill(LAesRngSeed, 0, System.Length(LAesRngSeed), Byte(0));
 end;
 
 constructor TAesRandomProvider.Create(AAesRngSeedLength,
@@ -236,7 +236,7 @@ begin
     GetRawEntropy(LSeed); // pure entropy from OS
     Create(LSeed, AReseedAfterBytes);
   finally
-    TArrayUtilities.Fill<Byte>(LSeed, 0, System.Length(LSeed), Byte(0));
+    TArrayUtilities.Fill(LSeed, 0, System.Length(LSeed), Byte(0));
   end;
 end;
 
@@ -268,7 +268,7 @@ begin
         GetRawEntropy(LSeed);
         DoSeedLocked(LSeed);
       finally
-        TArrayUtilities.Fill<Byte>(LSeed, 0, System.Length(LSeed), Byte(0));
+        TArrayUtilities.Fill(LSeed, 0, System.Length(LSeed), Byte(0));
       end;
     end;
 
@@ -294,10 +294,10 @@ begin
         System.Inc(FBytesSinceSeed, LDataLength);
         // Zero the bytes we did NOT consume so they cannot be read from the
         // heap after LResult is released.
-        TArrayUtilities.Fill<Byte>(LResult, LDataLength,
+        TArrayUtilities.Fill(LResult, LDataLength,
           System.Length(LResult) - LDataLength, Byte(0));
       finally
-        TArrayUtilities.Fill<Byte>(LResult, 0,
+        TArrayUtilities.Fill(LResult, 0,
           System.Length(LResult), Byte(0));
       end;
     end;


### PR DESCRIPTION
Add a Fill(TCryptoLibInt32Array) overload beside the existing Byte / UInt32 / UInt64 ones, then switch every TArrayUtilities.Fill<T> call in the library to the matching non-generic overload. These map to FillChar / FillDWord / FillQWord (memset) instead of the generic per-element loop and are correct for any filler value, including negative Int32.

Also replace the six FillChar calls that wipe dynamic byte arrays with TArrayUtilities.Fill; the remaining FillChar uses (pointer derefs and fixed arrays/records, which Fill can't take) are left as-is. The generic Fill<T> stays as the fallback for other element types.