### PR TITLE
Reject empty extension sequences and generalize input-stream limit detection

### DIFF
--- a/CryptoLib.Tests/src/Asn1/InputStreamTests.pas
+++ b/CryptoLib.Tests/src/Asn1/InputStreamTests.pas
@@ -35,6 +35,7 @@ uses
   ClpIAsn1Objects,
   ClpIAsn1Core,
   ClpAsn1Streams,
+  ClpStreams,
   ClpEncoders,
   ClpCryptoLibTypes,
   CryptoLibTestBase;
@@ -42,12 +43,13 @@ uses
 type
 
   /// <summary>
-  /// Stream type not handled specially by <c>FindLimit</c> (exercises fallback limit).
+  /// Non-seekable input stream (CanSeek = False, inherited from
+  /// TBaseInputStream): <c>FindLimit</c> cannot infer a bound from it, so it
+  /// exercises the configured fallback limit.
   /// </summary>
-  TDummyStreamWithoutKnownLimit = class(TStream)
+  TDummyStreamWithoutKnownLimit = class(TBaseInputStream)
   public
-    function Read(var Buffer; Count: LongInt): LongInt; override;
-    function Write(const Buffer; Count: LongInt): LongInt; override;
+    function ReadByte: Int32; override;
     function Seek(const Offset: Int64; Origin: TSeekOrigin): Int64; override;
   end;
 
@@ -75,19 +77,17 @@ implementation
 
 { TDummyStreamWithoutKnownLimit }
 
-function TDummyStreamWithoutKnownLimit.Read(var Buffer; Count: LongInt): LongInt;
+function TDummyStreamWithoutKnownLimit.ReadByte: Int32;
 begin
-  Result := 0;
-end;
-
-function TDummyStreamWithoutKnownLimit.Write(const Buffer; Count: LongInt): LongInt;
-begin
-  Result := 0;
+  Result := -1; // always at EOF; this stream exists only to be non-seekable
 end;
 
 function TDummyStreamWithoutKnownLimit.Seek(const Offset: Int64; Origin: TSeekOrigin): Int64;
 begin
-  Result := 0;
+  Result := 0; // unreachable; the raise below never returns
+  // CanSeek is already False, so callers should not reach here; a genuine
+  // non-seekable stream raises if seeked anyway.
+  raise ENotSupportedCryptoLibException.Create('stream is not seekable');
 end;
 
 { TInputStreamTest }
@@ -249,16 +249,16 @@ end;
 procedure TInputStreamTest.TestNegativeMaxLimitClampsFindLimit;
 var
   LSaved: Int32;
-  LMs: TMemoryStream;
+  LDummy: TDummyStreamWithoutKnownLimit;
 begin
   LSaved := TAsn1InputStream.MaxLimitForUnknownStream;
   try
     TAsn1InputStream.MaxLimitForUnknownStream := -10;
-    LMs := TMemoryStream.Create();
+    LDummy := TDummyStreamWithoutKnownLimit.Create();
     try
-      CheckEquals(0, TAsn1InputStream.FindLimit(LMs));
+      CheckEquals(0, TAsn1InputStream.FindLimit(LDummy));
     finally
-      LMs.Free;
+      LDummy.Free;
     end;
   finally
     TAsn1InputStream.MaxLimitForUnknownStream := LSaved;

--- a/CryptoLib.Tests/src/Asn1/X509/X509ExtensionsTests.pas
+++ b/CryptoLib.Tests/src/Asn1/X509/X509ExtensionsTests.pas
@@ -62,6 +62,8 @@ type
     procedure TestExtensionRoundTrip;
     procedure TestExtensionsBridge;
     procedure TestExtensionsGeneratorIExtension;
+    procedure TestCrlDistPointRejectsEmptySequence;
+    procedure TestExtendedKeyUsageRejectsEmptySequence;
 
   end;
 
@@ -319,6 +321,40 @@ begin
   LExtGen.AddExtensions(TExtensions.Create(LExtension) as IExtensions);
   LExts := LExtGen.Generate();
   CheckNotNull(LExts.GetExtension(FOid1), 'added via IExtensions');
+end;
+
+procedure TX509ExtensionsTest.TestCrlDistPointRejectsEmptySequence;
+var
+  LEmpty: IAsn1Sequence;
+  LResult: ICrlDistPoint;
+  LRaised: Boolean;
+begin
+  LEmpty := TDerSequence.Empty;
+  LRaised := False;
+  try
+    LResult := TCrlDistPoint.Create(LEmpty);
+  except
+    on E: EArgumentCryptoLibException do
+      LRaised := True;
+  end;
+  CheckTrue(LRaised, 'CrlDistPoint must reject an empty sequence');
+end;
+
+procedure TX509ExtensionsTest.TestExtendedKeyUsageRejectsEmptySequence;
+var
+  LEmpty: IAsn1Sequence;
+  LResult: IExtendedKeyUsage;
+  LRaised: Boolean;
+begin
+  LEmpty := TDerSequence.Empty;
+  LRaised := False;
+  try
+    LResult := TExtendedKeyUsage.Create(LEmpty);
+  except
+    on E: EArgumentCryptoLibException do
+      LRaised := True;
+  end;
+  CheckTrue(LRaised, 'ExtendedKeyUsage must reject an empty sequence');
 end;
 
 initialization

--- a/CryptoLib/src/Asn1/ClpAsn1Streams.pas
+++ b/CryptoLib/src/Asn1/ClpAsn1Streams.pas
@@ -544,12 +544,6 @@ type
     class function FindLimit(const AInput: TStream): Int32; static;
 
     /// <summary>
-    /// Get fixed buffer stream limit.
-    /// </summary>
-    class function GetFixedBufferStreamLimit(const AInput: TFixedBufferStream): Int32;
-      static;
-
-    /// <summary>
     /// Read tag number from stream.
     /// </summary>
     class function ReadTagNumber(const AInput: TStream; ATagHdr: Int32): Int32;
@@ -1677,7 +1671,7 @@ class function TAsn1InputStream.FindLimit(const AInput: TStream): Int32;
 var
   LAsn1LimitedInputStream: TAsn1LimitedInputStream;
   LAsn1InputStream: TAsn1InputStream;
-  LFixedBufferStream: TFixedBufferStream;
+  LAvailable: Int64;
 begin
   if AInput is TAsn1LimitedInputStream then
   begin
@@ -1693,10 +1687,12 @@ begin
     Exit;
   end;
 
-  if AInput is TFixedBufferStream then
+  if TStreamUtilities.TryGetAvailable(AInput, LAvailable) then
   begin
-    LFixedBufferStream := AInput as TFixedBufferStream;
-    Result := GetFixedBufferStreamLimit(LFixedBufferStream);
+    if LAvailable > Int32.MaxValue then
+      Result := Int32.MaxValue
+    else
+      Result := Int32(LAvailable);
     Exit;
   end;
 
@@ -1704,12 +1700,6 @@ begin
     Result := Max(0, FMaxLimitForUnknownStream)
   else
     Result := Int32.MaxValue;
-end;
-
-class function TAsn1InputStream.GetFixedBufferStreamLimit(const AInput
-  : TFixedBufferStream): Int32;
-begin
-  Result := Int32(AInput.Size - AInput.Position);
 end;
 
 class function TAsn1InputStream.ReadTagNumber(const AInput: TStream;

--- a/CryptoLib/src/Asn1/X509/ClpX509Asn1Objects.pas
+++ b/CryptoLib/src/Asn1/X509/ClpX509Asn1Objects.pas
@@ -5282,6 +5282,7 @@ var
   LOid: IDerObjectIdentifier;
 begin
   inherited Create();
+  TAsn1Utilities.CheckSequenceSize(ASeq, 1, Int32.MaxValue);
   FSeq := ASeq;
   FUsageTable := TDictionary<IDerObjectIdentifier, Boolean>.Create(TAsn1Comparers.OidEqualityComparer);
 
@@ -5310,6 +5311,7 @@ begin
   end;
 
   FSeq := TDerSequence.Create(LV);
+  TAsn1Utilities.CheckSequenceSize(FSeq, 1, Int32.MaxValue);
 end;
 
 constructor TExtendedKeyUsage.Create(const AUsages: array of IKeyPurposeId);
@@ -5332,6 +5334,8 @@ begin
   begin
     FUsageTable.Add(AUsages[LI], True);
   end;
+
+  TAsn1Utilities.CheckSequenceSize(FSeq, 1, Int32.MaxValue);
 end;
 
 destructor TExtendedKeyUsage.Destroy;
@@ -9564,6 +9568,7 @@ end;
 constructor TCrlDistPoint.Create(const ASeq: IAsn1Sequence);
 begin
   inherited Create();
+  TAsn1Utilities.CheckSequenceSize(ASeq, 1, Int32.MaxValue);
   FSeq := ASeq;
 end;
 
@@ -9579,6 +9584,7 @@ begin
     LV.Add(APoints[LI]);
   end;
   FSeq := TDerSequence.Create(LV);
+  TAsn1Utilities.CheckSequenceSize(FSeq, 1, Int32.MaxValue);
 end;
 
 function TCrlDistPoint.GetDistributionPoints: TCryptoLibGenericArray<IDistributionPoint>;

--- a/CryptoLib/src/IO/ClpStreamUtilities.pas
+++ b/CryptoLib/src/IO/ClpStreamUtilities.pas
@@ -78,6 +78,10 @@ type
     class function WriteBufTo(const ABuf: TMemoryStream;
       const AOutput: TCryptoLibByteArray; AOffset: Int32): Int32; static;
 
+    // best-effort: bytes remaining in a seekable stream (Size - Position)
+    class function TryGetAvailable(const AStream: TStream;
+      out AAvailable: Int64): Boolean; static;
+
   end;
 
 type
@@ -253,6 +257,29 @@ begin
 
   // Copy directly from stream buffer into the byte array
   Move(PByte(ABuf.Memory)^, AOutput[AOffset], Result);
+end;
+
+class function TStreamUtilities.TryGetAvailable(const AStream: TStream;
+  out AAvailable: Int64): Boolean;
+var
+  LRemaining: Int64;
+begin
+  AAvailable := 0;
+  Result := False;
+  try
+    if AStream.CanSeek then
+    begin
+      LRemaining := AStream.Size - AStream.Position;
+      if LRemaining < 0 then
+        LRemaining := 0;
+      AAvailable := LRemaining;
+      Result := True;
+    end;
+  except
+    // ignore; this method is best-effort only
+    AAvailable := 0;
+    Result := False;
+  end;
 end;
 
 { TStreamHelper }


### PR DESCRIPTION
Two independent ASN.1 hardening changes.

1. Minimum sequence-size restriction on X.509 extensions TCrlDistPoint and TExtendedKeyUsage now reject an empty sequence (< 1 element) in both their decode (IAsn1Sequence) and array constructors, via TAsn1Utilities.CheckSequenceSize(seq, 1, Int32.MaxValue). A malformed extension with no elements now raises EArgumentCryptoLibException instead of constructing a degenerate object. Both classes already stored the sequence and mapped on demand, so no storage change was needed. Adds TestCrlDistPointRejectsEmptySequence and TestExtendedKeyUsageRejectsEmptySequence to X509ExtensionsTests.

2. TStreamUtilities.TryGetAvailable and use in FindLimit Add TryGetAvailable(stream, out available): best-effort remaining bytes for a seekable stream (Max(0, Size - Position)), guarded so a stream that throws is treated as unavailable. TAsn1InputStream.FindLimit now uses it, replacing the TFixedBufferStream-specific branch (GetFixedBufferStreamLimit removed): any seekable stream gets an available-based limit, not just the fixed buffer. TFixedBufferStream is seekable, so its limit is unchanged; byte-array input still yields a tight bound.

   Corrects the InputStreamTests dummy: it modelled "unknown/non-seekable" but its Seek was a no-op returning 0, making it look like a seekable empty stream. It now inherits TBaseInputStream (CanSeek = False) with a raising Seek, so it honestly exercises FindLimit's fallback; TestNegativeMaxLimitClampsFindLimit uses it to actually reach the clamp path.