### PR TITLE
Harden CMS AES-ICVlen parsing against out-of-Int32 INTEGER

### DIFF
--- a/CryptoLib.Tests/src/Asn1/Cms/CcmParametersTests.pas
+++ b/CryptoLib.Tests/src/Asn1/Cms/CcmParametersTests.pas
@@ -48,6 +48,7 @@ type
     procedure TestDefaultIcvLen;
     procedure TestInvalidIcvLen;
     procedure TestValidIcvLen;
+    procedure TestIcvLenOutsideInt32Range;
   end;
 
 implementation
@@ -115,6 +116,27 @@ begin
   begin
     CheckEquals(ValidIcvLens[LI], TCcmParameters.GetInstance(Seq(ValidIcvLens[LI])).IcvLen);
     CheckEquals(ValidIcvLens[LI], (TCcmParameters.Create(Nonce12, ValidIcvLens[LI]) as ICcmParameters).IcvLen);
+  end;
+end;
+
+procedure TCcmParametersTest.TestIcvLenOutsideInt32Range;
+var
+  LSeq: IAsn1Encodable;
+begin
+  // An ICVlen INTEGER wider than Int32 must surface as a controlled argument
+  // error, not an arithmetic exception leaking from integer extraction.
+  LSeq := TDerSequence.Create([
+    TDerOctetString.FromContents(Nonce12),
+    TDerInteger.ValueOf(Int64($100000000))
+  ]);
+  try
+    TCcmParameters.GetInstance(LSeq);
+    Fail('out-of-Int32 ICV length not rejected on parse');
+  except
+    on E: EArgumentCryptoLibException do
+    begin
+      // expected
+    end;
   end;
 end;
 

--- a/CryptoLib.Tests/src/Asn1/Cms/GcmParametersTests.pas
+++ b/CryptoLib.Tests/src/Asn1/Cms/GcmParametersTests.pas
@@ -48,6 +48,7 @@ type
     procedure TestDefaultIcvLen;
     procedure TestInvalidIcvLen;
     procedure TestValidIcvLen;
+    procedure TestIcvLenOutsideInt32Range;
   end;
 
 implementation
@@ -115,6 +116,27 @@ begin
   begin
     CheckEquals(ValidIcvLens[LI], TGcmParameters.GetInstance(Seq(ValidIcvLens[LI])).IcvLen);
     CheckEquals(ValidIcvLens[LI], (TGcmParameters.Create(Nonce12, ValidIcvLens[LI]) as IGcmParameters).IcvLen);
+  end;
+end;
+
+procedure TGcmParametersTest.TestIcvLenOutsideInt32Range;
+var
+  LSeq: IAsn1Encodable;
+begin
+  // An ICVlen INTEGER wider than Int32 must surface as a controlled argument
+  // error, not an arithmetic exception leaking from integer extraction.
+  LSeq := TDerSequence.Create([
+    TDerOctetString.FromContents(Nonce12),
+    TDerInteger.ValueOf(Int64($100000000))
+  ]);
+  try
+    TGcmParameters.GetInstance(LSeq);
+    Fail('out-of-Int32 ICV length not rejected on parse');
+  except
+    on E: EArgumentCryptoLibException do
+    begin
+      // expected
+    end;
   end;
 end;
 

--- a/CryptoLib/src/Asn1/Cms/ClpCmsAsn1Objects.pas
+++ b/CryptoLib/src/Asn1/Cms/ClpCmsAsn1Objects.pas
@@ -54,7 +54,8 @@ resourcestring
   SCmsBinaryTimeOutOfDateTimeRange = 'BinaryTime out of DateTime range';
   SCmsNoContentFound = 'No content found.';
   SCmsMalformedContent = 'Malformed content.';
-  SCmsInvalidIcvLen = 'Invalid ICV length: %d';
+  SCmsInvalidIcvLen = 'Invalid ''aes-ICVlen'': %d';
+  SCmsIcvLenNotInt32 = 'Invalid ''aes-ICVlen'' (outside Int32 range)';
 
 
 type
@@ -143,7 +144,8 @@ type
     FNonce: IAsn1OctetString;
     FIcvLen: Int32;
 
-    class function ValidateIcvLen(AIcvLen: Int32): Int32; static;
+    class function ValidateIcvLen(const AIcvLen: IDerInteger): Int32; static;
+    class function ValidateIcvLenValue(AIcvLen: Int32): Int32; static;
 
   strict protected
     function GetNonce: TCryptoLibByteArray;
@@ -179,7 +181,8 @@ type
     FNonce: IAsn1OctetString;
     FIcvLen: Int32;
 
-    class function ValidateIcvLen(AIcvLen: Int32): Int32; static;
+    class function ValidateIcvLen(const AIcvLen: IDerInteger): Int32; static;
+    class function ValidateIcvLenValue(AIcvLen: Int32): Int32; static;
 
   strict protected
     function GetNonce: TCryptoLibByteArray;
@@ -1255,7 +1258,18 @@ end;
 
 { TCcmParameters }
 
-class function TCcmParameters.ValidateIcvLen(AIcvLen: Int32): Int32;
+class function TCcmParameters.ValidateIcvLen(const AIcvLen: IDerInteger): Int32;
+var
+  LValue: Int32;
+begin
+  if AIcvLen = nil then
+    Exit(DefaultIcvLen);
+  if not AIcvLen.TryGetIntValueExact(LValue) then
+    raise EArgumentCryptoLibException.CreateRes(@SCmsIcvLenNotInt32);
+  Result := ValidateIcvLenValue(LValue);
+end;
+
+class function TCcmParameters.ValidateIcvLenValue(AIcvLen: Int32): Int32;
 begin
   if (AIcvLen < 4) or (AIcvLen > 16) or ((AIcvLen and 1) <> 0) then
     raise EArgumentCryptoLibException.CreateResFmt(@SCmsInvalidIcvLen, [AIcvLen]);
@@ -1310,17 +1324,14 @@ begin
   LIcvLen := TAsn1Utilities.ReadOptional<IDerInteger>(ASeq, LPos, TDerInteger.GetOptional);
   TAsn1Utilities.RequireEndOfSequence(ASeq, LPos);
 
-  if LIcvLen = nil then
-    FIcvLen := ValidateIcvLen(DefaultIcvLen)
-  else
-    FIcvLen := ValidateIcvLen(LIcvLen.IntValueExact);
+  FIcvLen := ValidateIcvLen(LIcvLen);
 end;
 
 constructor TCcmParameters.Create(const ANonce: TCryptoLibByteArray; AIcvLen: Int32);
 begin
   inherited Create();
   FNonce := TDerOctetString.FromContents(ANonce);
-  FIcvLen := ValidateIcvLen(AIcvLen);
+  FIcvLen := ValidateIcvLenValue(AIcvLen);
 end;
 
 function TCcmParameters.GetNonce: TCryptoLibByteArray;
@@ -1344,7 +1355,18 @@ end;
 
 { TGcmParameters }
 
-class function TGcmParameters.ValidateIcvLen(AIcvLen: Int32): Int32;
+class function TGcmParameters.ValidateIcvLen(const AIcvLen: IDerInteger): Int32;
+var
+  LValue: Int32;
+begin
+  if AIcvLen = nil then
+    Exit(DefaultIcvLen);
+  if not AIcvLen.TryGetIntValueExact(LValue) then
+    raise EArgumentCryptoLibException.CreateRes(@SCmsIcvLenNotInt32);
+  Result := ValidateIcvLenValue(LValue);
+end;
+
+class function TGcmParameters.ValidateIcvLenValue(AIcvLen: Int32): Int32;
 begin
   if (AIcvLen < 12) or (AIcvLen > 16) then
     raise EArgumentCryptoLibException.CreateResFmt(@SCmsInvalidIcvLen, [AIcvLen]);
@@ -1399,17 +1421,14 @@ begin
   LIcvLen := TAsn1Utilities.ReadOptional<IDerInteger>(ASeq, LPos, TDerInteger.GetOptional);
   TAsn1Utilities.RequireEndOfSequence(ASeq, LPos);
 
-  if LIcvLen = nil then
-    FIcvLen := ValidateIcvLen(DefaultIcvLen)
-  else
-    FIcvLen := ValidateIcvLen(LIcvLen.IntValueExact);
+  FIcvLen := ValidateIcvLen(LIcvLen);
 end;
 
 constructor TGcmParameters.Create(const ANonce: TCryptoLibByteArray; AIcvLen: Int32);
 begin
   inherited Create();
   FNonce := TDerOctetString.FromContents(ANonce);
-  FIcvLen := ValidateIcvLen(AIcvLen);
+  FIcvLen := ValidateIcvLenValue(AIcvLen);
 end;
 
 function TGcmParameters.GetNonce: TCryptoLibByteArray;


### PR DESCRIPTION
TCcmParameters and TGcmParameters extracted the AES-ICVlen from the DER INTEGER with the throwing IntValueExact property inside their sequence constructors, so an INTEGER wider than Int32 raised EArithmeticCryptoLibException - an internal arithmetic error leaking out of the ASN.1 parser on attacker-controlled input.

Extract via the non-throwing TryGetIntValueExact and raise a controlled EArgumentCryptoLibException instead:

- Add ValidateIcvLen(const AIcvLen: IDerInteger): nil yields the default, a value outside Int32 range raises EArgumentCryptoLibException, and an in-range value is forwarded to the bounds check.
- Rename the existing int validator to ValidateIcvLenValue (bounds unchanged: Ccm 4..16 even, Gcm 12..16).
- Sequence constructors now call the safe DerInteger overload; value constructors call ValidateIcvLenValue.
- Reword SCmsInvalidIcvLen to reference 'aes-ICVlen' and add SCmsIcvLenNotInt32 for the out-of-range case.

Add TestIcvLenOutsideInt32Range to the Ccm and Gcm parameter suites: a SEQUENCE whose ICVlen INTEGER exceeds Int32 must raise EArgumentCryptoLibException, not EArithmeticCryptoLibException.