### PR TITLE
Standardize SIMD kernel header comments

### DIFF
--- a/CryptoLib/src/Include/Simd/Aes/AesNiEightCipher_i386.inc
+++ b/CryptoLib/src/Include/Simd/Aes/AesNiEightCipher_i386.inc
@@ -18,6 +18,10 @@
 // Variant selection (forwarded to the rounds-only include):
 //   CRYPTOLIB_AESNI_DECRYPT  -> decrypt; else encrypt.
 //   Exactly one of CRYPTOLIB_AESNI_KEY128 / KEY192 / KEY256 selects N_R.
+//
+// Reference: Shay Gueron, "Intel AES New Instructions" whitepaper - the
+// multi-block-interleaved AES-NI technique implemented by the round chain
+// that this file wraps (AesNiEightRoundsOnly_i386.inc).
   movdqu    xmm0, [ebx + 0]
   movdqu    xmm1, [ebx + 16]
   movdqu    xmm2, [ebx + 32]

--- a/CryptoLib/src/Include/Simd/Aes/AesNiEightCipher_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Aes/AesNiEightCipher_x86_64.inc
@@ -16,6 +16,10 @@
 // Variant selection (forwarded to the rounds-only include):
 //   CRYPTOLIB_AESNI_DECRYPT  -> decrypt; else encrypt.
 //   Exactly one of CRYPTOLIB_AESNI_KEY128 / KEY192 / KEY256 selects N_R.
+//
+// Reference: Shay Gueron, "Intel AES New Instructions" whitepaper - the
+// multi-block-interleaved AES-NI technique implemented by the round chain
+// that this file wraps (AesNiEightRoundsOnly_x86_64.inc).
 {$I ..\..\Include\Simd\Common\ClpSimdNonVolatileSave_x86_64.inc}
   movdqu    xmm0, [rcx]
   movdqu    xmm1, [rcx + 16]

--- a/CryptoLib/src/Include/Simd/Aes/AesNiFourCipher_i386.inc
+++ b/CryptoLib/src/Include/Simd/Aes/AesNiFourCipher_i386.inc
@@ -18,6 +18,10 @@
 // Variant selection (forwarded to the rounds-only include):
 //   CRYPTOLIB_AESNI_DECRYPT  -> decrypt; else encrypt.
 //   Exactly one of CRYPTOLIB_AESNI_KEY128 / KEY192 / KEY256 selects N_R.
+//
+// Reference: Shay Gueron, "Intel AES New Instructions" whitepaper - the
+// multi-block-interleaved AES-NI technique implemented by the round chain
+// that this file wraps (AesNiFourRoundsOnly_i386.inc).
   movdqu    xmm0, [ebx + 0]
   movdqu    xmm1, [ebx + 16]
   movdqu    xmm2, [ebx + 32]

--- a/CryptoLib/src/Include/Simd/Aes/AesNiFourCipher_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Aes/AesNiFourCipher_x86_64.inc
@@ -16,6 +16,10 @@
 // Variant selection (forwarded to the rounds-only include):
 //   CRYPTOLIB_AESNI_DECRYPT  -> decrypt; else encrypt.
 //   Exactly one of CRYPTOLIB_AESNI_KEY128 / KEY192 / KEY256 selects N_R.
+//
+// Reference: Shay Gueron, "Intel AES New Instructions" whitepaper - the
+// multi-block-interleaved AES-NI technique implemented by the round chain
+// that this file wraps (AesNiFourRoundsOnly_x86_64.inc).
   movdqu    xmm0, [rcx]
   movdqu    xmm1, [rcx + 16]
   movdqu    xmm2, [rcx + 32]

--- a/CryptoLib/src/Include/Simd/Aes/AesNiOneCipher_i386.inc
+++ b/CryptoLib/src/Include/Simd/Aes/AesNiOneCipher_i386.inc
@@ -18,6 +18,10 @@
 // Variant selection (forwarded to the rounds-only include):
 //   CRYPTOLIB_AESNI_DECRYPT  -> decrypt; else encrypt.
 //   Exactly one of CRYPTOLIB_AESNI_KEY128 / KEY192 / KEY256 selects N_R.
+//
+// Reference: Shay Gueron, "Intel AES New Instructions" whitepaper - the
+// multi-block-interleaved AES-NI technique implemented by the round chain
+// that this file wraps (AesNiOneRoundsOnly_i386.inc).
   movdqu    xmm0, [ebx + 0]
 {$IFNDEF CRYPTOLIB_AESNI_INOUT}
   push      edi

--- a/CryptoLib/src/Include/Simd/Aes/AesNiOneCipher_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Aes/AesNiOneCipher_x86_64.inc
@@ -16,6 +16,10 @@
 // Variant selection (forwarded to the rounds-only include):
 //   CRYPTOLIB_AESNI_DECRYPT  -> decrypt; else encrypt.
 //   Exactly one of CRYPTOLIB_AESNI_KEY128 / KEY192 / KEY256 selects N_R.
+//
+// Reference: Shay Gueron, "Intel AES New Instructions" whitepaper - the
+// multi-block-interleaved AES-NI technique implemented by the round chain
+// that this file wraps (AesNiOneRoundsOnly_x86_64.inc).
   movdqu    xmm0, [rcx]
 {$IFNDEF CRYPTOLIB_AESNI_INOUT}
   mov       r8, rdx

--- a/CryptoLib/src/Include/Simd/Aes/Ccm/AesCcmFusedCtrCbcMacTwo_i386.inc
+++ b/CryptoLib/src/Include/Simd/Aes/Ccm/AesCcmFusedCtrCbcMacTwo_i386.inc
@@ -1,6 +1,6 @@
 // CCM fused AES-NI CTR+CBC-MAC kernel (i386).
 // -------------------------------------------------------------------
-// Technique: Shay Gueron, "Intel AES New Instructions" Rev 3.01.
+// Technique: Shay Gueron, "Intel AES New Instructions" whitepaper.
 // Inspired by OpenSSL aesni_ccm64_{encrypt,decrypt}_blocks
 // (crypto/aes/asm/aesni-x86_64.pl, Andy Polyakov / @dot-asm).
 //

--- a/CryptoLib/src/Include/Simd/Aes/Ccm/AesCcmFusedCtrCbcMacTwo_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Aes/Ccm/AesCcmFusedCtrCbcMacTwo_x86_64.inc
@@ -1,6 +1,6 @@
 // CCM fused AES-NI CTR+CBC-MAC kernel (x86-64).
 // -------------------------------------------------------------------
-// Technique: Shay Gueron, "Intel AES New Instructions" Rev 3.01.
+// Technique: Shay Gueron, "Intel AES New Instructions" whitepaper.
 // Inspired by OpenSSL aesni_ccm64_{encrypt,decrypt}_blocks
 // (crypto/aes/asm/aesni-x86_64.pl, Andy Polyakov / @dot-asm).
 //

--- a/CryptoLib/src/Include/Simd/Aes/Eax/AesEaxFusedCtrOmacTwo_i386.inc
+++ b/CryptoLib/src/Include/Simd/Aes/Eax/AesEaxFusedCtrOmacTwo_i386.inc
@@ -4,7 +4,7 @@
 // OpenSSL, BoringSSL, AWS-LC or Botan (all ship scalar EAX). Technique
 // derived from Bogdanov-Lauridsen-Tischhauser "Comb to Pipeline" (FSE
 // 2016, eprint 2016/047) and the AES-NI AEAD pattern shared with CCM
-// (Shay Gueron, "Intel AES New Instructions" Rev 3.01).
+// (Shay Gueron, "Intel AES New Instructions" whitepaper).
 //
 // Two lanes (CTR / MAC) share each round-key broadcast: the second
 // aesenc fills a pipeline slot that would otherwise idle. EAX is

--- a/CryptoLib/src/Include/Simd/Aes/Eax/AesEaxFusedCtrOmacTwo_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Aes/Eax/AesEaxFusedCtrOmacTwo_x86_64.inc
@@ -4,7 +4,7 @@
 // OpenSSL, BoringSSL, AWS-LC or Botan (all ship scalar EAX). Technique
 // derived from Bogdanov-Lauridsen-Tischhauser "Comb to Pipeline" (FSE
 // 2016, eprint 2016/047) and the AES-NI AEAD pattern shared with CCM
-// (Shay Gueron, "Intel AES New Instructions" Rev 3.01).
+// (Shay Gueron, "Intel AES New Instructions" whitepaper).
 //
 // Two lanes (CTR / MAC) share each round-key broadcast: the second
 // aesenc fills a pipeline slot that would otherwise idle. EAX is

--- a/CryptoLib/src/Include/Simd/Aes/Gcm/AesGcmFusedCtrGhashEight_i386.inc
+++ b/CryptoLib/src/Include/Simd/Aes/Gcm/AesGcmFusedCtrGhashEight_i386.inc
@@ -1,6 +1,6 @@
 // Fused AES-NI CTR keystream + 8-way GHASH kernel (i386).
 // -------------------------------------------------------------------
-// Technique: Shay Gueron, "Intel AES New Instructions" Rev 3.01 - AES
+// Technique: Shay Gueron, "Intel AES New Instructions" whitepaper - AES
 // and PCLMULQDQ instructions are interleaved so the AES port and the
 // carry-less-multiply port operate in parallel, hiding GHASH latency
 // inside the AES critical path.

--- a/CryptoLib/src/Include/Simd/Aes/Gcm/AesGcmFusedCtrGhashEight_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Aes/Gcm/AesGcmFusedCtrGhashEight_x86_64.inc
@@ -1,6 +1,6 @@
 // Fused AES-NI CTR keystream + 8-way GHASH kernel (x86-64).
 // -------------------------------------------------------------------
-// Technique: Shay Gueron, "Intel AES New Instructions" Rev 3.01 - AES
+// Technique: Shay Gueron, "Intel AES New Instructions" whitepaper - AES
 // and PCLMULQDQ instructions are interleaved so the AES port and the
 // carry-less-multiply port operate in parallel, hiding GHASH latency
 // inside the AES critical path.

--- a/CryptoLib/src/Include/Simd/Aes/Ocb/AesOcbFusedWide_i386.inc
+++ b/CryptoLib/src/Include/Simd/Aes/Ocb/AesOcbFusedWide_i386.inc
@@ -39,6 +39,11 @@
 //   [esp + 208..223]  checksum spill during the round chain
 //
 // AES-NI instructions are db-encoded for broad assembler compatibility.
+//
+// Reference: the round-interleaved ladder structure was informed by
+// OpenSSL's aesni_ocb_encrypt/aesni_ocb_decrypt (crypto/aes/asm/
+// aesni-x86_64.pl, Andy Polyakov) - the encoding, register allocation
+// and ping-pong bank staging here are original.
 // -------------------------------------------------------------------
 
   push      edi

--- a/CryptoLib/src/Include/Simd/Aes/Ocb/AesOcbFusedWide_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Aes/Ocb/AesOcbFusedWide_x86_64.inc
@@ -32,6 +32,11 @@
 //
 // AES-NI instructions and forms touching xmm8..xmm15 are db-encoded for
 // broad assembler compatibility.
+//
+// Reference: the round-interleaved ladder structure was informed by
+// OpenSSL's aesni_ocb_encrypt/aesni_ocb_decrypt (crypto/aes/asm/
+// aesni-x86_64.pl, Andy Polyakov) - the encoding, register allocation
+// and ping-pong bank staging here are original.
 // -------------------------------------------------------------------
 
 {$I ..\..\..\Include\Simd\Common\ClpSimdNonVolatileSave_x86_64.inc}

--- a/CryptoLib/src/Include/Simd/BinPoly/BinPolyClmulMul2x2_i386.inc
+++ b/CryptoLib/src/Include/Simd/BinPoly/BinPolyClmulMul2x2_i386.inc
@@ -1,7 +1,20 @@
-// 2x2 carryless Karatsuba multiply (3 PCLMULQDQ).
-// Entry:  xmm0 = X (x0, x1), xmm1 = Y (y0, y1).
-// Exit:   xmm6 = W0, xmm7 = W1 (i386 has xmm0..xmm7 only).
+// 2x2-limb carryless Karatsuba multiply (i386).
+// -------------------------------------------------------------------
+// Multiplies two 2-limb (256-bit) polynomials X=(x0,x1), Y=(y0,y1) over
+// GF(2)[x] using 3 PCLMULQDQ products instead of the schoolbook 4 (x0*y0,
+// x1*y1, and (x0 xor x1)*(y0 xor y1) to recover the cross term), then
+// combines the partials into the 4-limb (512-bit) product W=(W0,W1).
+//
+// On entry: xmm0 = X (x0, x1), xmm1 = Y (y0, y1).
+// On exit:  xmm6 = W0, xmm7 = W1 (i386 has xmm0..xmm7 only).
 // Clobbers: xmm2..xmm5.
+//
+// PCLMULQDQ forms are db-encoded for broad assembler compatibility.
+//
+// Reference: Karatsuba's algorithm applied to carry-less multiplication -
+// the standard 3-multiply reduction described in Shay Gueron / Michael E.
+// Kounavis, "Intel(R) Carry-Less Multiplication Instruction and its Usage
+// for Computing the GCM Mode" (white paper).
   movdqa    xmm2, xmm0
   punpcklqdq xmm2, xmm1
   movdqa    xmm3, xmm0

--- a/CryptoLib/src/Include/Simd/BinPoly/BinPolyClmulMul2x2_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/BinPoly/BinPolyClmulMul2x2_x86_64.inc
@@ -1,7 +1,20 @@
-// 2x2 carryless Karatsuba multiply (3 PCLMULQDQ).
-// Entry:  xmm0 = X (x0, x1), xmm1 = Y (y0, y1).
-// Exit:   xmm8 = W0, xmm9 = W1.
+// 2x2-limb carryless Karatsuba multiply (x86-64).
+// -------------------------------------------------------------------
+// Multiplies two 2-limb (256-bit) polynomials X=(x0,x1), Y=(y0,y1) over
+// GF(2)[x] using 3 PCLMULQDQ products instead of the schoolbook 4 (x0*y0,
+// x1*y1, and (x0 xor x1)*(y0 xor y1) to recover the cross term), then
+// combines the partials into the 4-limb (512-bit) product W=(W0,W1).
+//
+// On entry: xmm0 = X (x0, x1), xmm1 = Y (y0, y1).
+// On exit:  xmm8 = W0, xmm9 = W1.
 // Clobbers: xmm2..xmm7.
+//
+// PCLMULQDQ forms are db-encoded for broad assembler compatibility.
+//
+// Reference: Karatsuba's algorithm applied to carry-less multiplication -
+// the standard 3-multiply reduction described in Shay Gueron / Michael E.
+// Kounavis, "Intel(R) Carry-Less Multiplication Instruction and its Usage
+// for Computing the GCM Mode" (white paper).
   movdqa    xmm2, xmm0
   punpcklqdq xmm2, xmm1
   movdqa    xmm3, xmm0

--- a/CryptoLib/src/Include/Simd/BinPoly/BinPolyPclmulImplMulEven_i386.inc
+++ b/CryptoLib/src/Include/Simd/BinPoly/BinPolyPclmulImplMulEven_i386.inc
@@ -1,7 +1,16 @@
 // V128 BinPoly medium multiply, even limb count (i386).
-// Entry (after ClpSimdProc4Begin_i386.inc):
+// -------------------------------------------------------------------
+// N-limb schoolbook polynomial multiply built on the 2x2 Karatsuba
+// primitive (BinPolyClmulMul2x2_i386.inc); ZZ is addressed as packed
+// V128 slots (16-byte stride).
+//
+// On entry (after ClpSimdProc4Begin_i386.inc):
 //   ebx = ALen (UInt32 limb count, even), esi = PX, edi = PY, eax = PZz.
-// ZZ is addressed as packed V128 slots (16-byte stride).
+//
+// Reference: Shay Gueron / Michael E. Kounavis, "Intel(R) Carry-Less
+// Multiplication Instruction and its Usage for Computing the GCM Mode"
+// (white paper) - the carry-less multiplication technique that this
+// N-limb form generalizes.
 //
 // Local stack layout (after push ebp/push edx/sub esp,24):
 //   [esp +  0] = L

--- a/CryptoLib/src/Include/Simd/BinPoly/BinPolyPclmulImplMulEven_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/BinPoly/BinPolyPclmulImplMulEven_x86_64.inc
@@ -1,7 +1,16 @@
 // V128 BinPoly medium multiply, even limb count (x86-64).
-// Entry (after ClpSimdProc4Begin_x86_64.inc):
+// -------------------------------------------------------------------
+// N-limb schoolbook polynomial multiply built on the 2x2 Karatsuba
+// primitive (BinPolyClmulMul2x2_x86_64.inc); ZZ is addressed as packed
+// V128 slots (16-byte stride).
+//
+// On entry (after ClpSimdProc4Begin_x86_64.inc):
 //   rcx = ALen (UInt64 limb count, even), rdx = PX, r8 = PY, r9 = PZz.
-// ZZ is addressed as packed V128 slots (16-byte stride).
+//
+// Reference: Shay Gueron / Michael E. Kounavis, "Intel(R) Carry-Less
+// Multiplication Instruction and its Usage for Computing the GCM Mode"
+// (white paper) - the carry-less multiplication technique that this
+// N-limb form generalizes.
 
   push      rbx
   push      rbp

--- a/CryptoLib/src/Include/Simd/BinPoly/BinPolyPclmulImplMulOdd_i386.inc
+++ b/CryptoLib/src/Include/Simd/BinPoly/BinPolyPclmulImplMulOdd_i386.inc
@@ -1,7 +1,16 @@
 // V128 BinPoly medium multiply, odd limb count (i386).
-// Entry (after ClpSimdProc4Begin_i386.inc):
+// -------------------------------------------------------------------
+// N-limb schoolbook polynomial multiply built on the 2x2 Karatsuba
+// primitive (BinPolyClmulMul2x2_i386.inc); ZZ is addressed as packed
+// V128 slots (16-byte stride).
+//
+// On entry (after ClpSimdProc4Begin_i386.inc):
 //   ebx = ALen (UInt32 limb count, odd), esi = PX, edi = PY, eax = PZz.
-// ZZ is addressed as packed V128 slots (16-byte stride).
+//
+// Reference: Shay Gueron / Michael E. Kounavis, "Intel(R) Carry-Less
+// Multiplication Instruction and its Usage for Computing the GCM Mode"
+// (white paper) - the carry-less multiplication technique that this
+// N-limb form generalizes.
 //
 // Local stack layout (after push ebp/push edx/sub esp,24):
 //   [esp +  0] = L

--- a/CryptoLib/src/Include/Simd/BinPoly/BinPolyPclmulImplMulOdd_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/BinPoly/BinPolyPclmulImplMulOdd_x86_64.inc
@@ -1,7 +1,16 @@
 // V128 BinPoly medium multiply, odd limb count (x86-64).
-// Entry (after ClpSimdProc4Begin_x86_64.inc):
+// -------------------------------------------------------------------
+// N-limb schoolbook polynomial multiply built on the 2x2 Karatsuba
+// primitive (BinPolyClmulMul2x2_x86_64.inc); ZZ is addressed as packed
+// V128 slots (16-byte stride).
+//
+// On entry (after ClpSimdProc4Begin_x86_64.inc):
 //   rcx = ALen (UInt64 limb count, odd), rdx = PX, r8 = PY, r9 = PZz.
-// ZZ is addressed as packed V128 slots (16-byte stride).
+//
+// Reference: Shay Gueron / Michael E. Kounavis, "Intel(R) Carry-Less
+// Multiplication Instruction and its Usage for Computing the GCM Mode"
+// (white paper) - the carry-less multiplication technique that this
+// N-limb form generalizes.
 
   push      rbx
   push      rbp

--- a/CryptoLib/src/Include/Simd/BinPoly/BinPolyPclmulImplMulSmall_i386.inc
+++ b/CryptoLib/src/Include/Simd/BinPoly/BinPolyPclmulImplMulSmall_i386.inc
@@ -1,8 +1,18 @@
-// x86/V128 BinPoly fixed-size carryless multiply kernels for limb counts 1..10.
-// PCLMULQDQ instruction is db-encoded for broad assembler compatibility.
+// x86/V128 BinPoly fixed-size carryless multiply kernels for limb counts 1..10 (i386).
+// -------------------------------------------------------------------
+// One fully-unrolled case per limb count, avoiding the medium-multiply
+// loop overhead for small operands. ZZ output: V128 lane k at byte offset
+// 16*k in PZz.
+//
 // Included inside BinPolyPclmulImplMulSmall after ClpSimdProc4Begin_i386.inc:
-//   ebx = ALen, esi = PX, edi = PY, eax = PZz
-// ZZ output: V128 lane k at byte offset 16*k in PZz.
+//   ebx = ALen, esi = PX, edi = PY, eax = PZz.
+//
+// PCLMULQDQ instruction is db-encoded for broad assembler compatibility.
+//
+// Reference: Shay Gueron / Michael E. Kounavis, "Intel(R) Carry-Less
+// Multiplication Instruction and its Usage for Computing the GCM Mode"
+// (white paper) - the carry-less multiplication technique that these
+// fixed-size cases implement.
 
   cmp       ebx, 1
   je        @@BinPolySmallSize1

--- a/CryptoLib/src/Include/Simd/BinPoly/BinPolyPclmulImplMulSmall_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/BinPoly/BinPolyPclmulImplMulSmall_x86_64.inc
@@ -1,8 +1,18 @@
-// x86/V128 BinPoly fixed-size carryless multiply kernels for limb counts 1..10.
-// PCLMULQDQ instruction is db-encoded for broad assembler compatibility.
+// x86/V128 BinPoly fixed-size carryless multiply kernels for limb counts 1..10 (x86-64).
+// -------------------------------------------------------------------
+// One fully-unrolled case per limb count, avoiding the medium-multiply
+// loop overhead for small operands. ZZ output: V128 lane k at byte offset
+// 16*k in PZz.
+//
 // Included inside BinPolyPclmulImplMulSmall after ClpSimdProc4Begin_x86_64.inc:
-//   rcx = ALen, rdx = PX, r8 = PY, r9 = PZz
-// ZZ output: V128 lane k at byte offset 16*k in PZz.
+//   rcx = ALen, rdx = PX, r8 = PY, r9 = PZz.
+//
+// PCLMULQDQ instruction is db-encoded for broad assembler compatibility.
+//
+// Reference: Shay Gueron / Michael E. Kounavis, "Intel(R) Carry-Less
+// Multiplication Instruction and its Usage for Computing the GCM Mode"
+// (white paper) - the carry-less multiplication technique that these
+// fixed-size cases implement.
 
   // Each size case reaches @@BinPolySmallXmmDone via `jmp` (not `ret`) so the
   // restore of the registers saved here always runs.

--- a/CryptoLib/src/Include/Simd/ChaCha/ChaCha20BlockSse2_i386.inc
+++ b/CryptoLib/src/Include/Simd/ChaCha/ChaCha20BlockSse2_i386.inc
@@ -1,5 +1,15 @@
-// ChaCha20 one 64B block, SSE2, i386. Keystream only: state in, 64B out to AOut (not ChaCha7539 fused I/O xor). Rounds: ChaChaSse2_DoubleRoundBody.inc.
-// After ClpSimdProc3Begin_i386.inc: ebx=ARounds, esi=AIn, edi=AOut. End: add esp, 64; add esp, eax; pop edi; pop esi; pop ebx
+// ChaCha20 one-block (64B) core, pure SSE2 (i386).
+// -------------------------------------------------------------------
+// Keystream only: state in, 64B out to AOut (not ChaCha7539's fused I/O
+// xor). Rounds: ChaChaSse2_DoubleRoundBody.inc.
+//
+// On entry (after ClpSimdProc3Begin_i386.inc):
+//   ebx = ARounds, esi = AIn, edi = AOut.
+//
+// End: add esp, 64; add esp, eax; pop edi; pop esi; pop ebx.
+//
+// Reference: D.J. Bernstein, "ChaCha, a variant of Salsa20" - the
+// quarter-round arithmetic that this kernel's rounds implement.
   mov     eax, esp
   and     eax, 15
   sub     esp, eax

--- a/CryptoLib/src/Include/Simd/ChaCha/ChaCha20BlockSse2_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/ChaCha/ChaCha20BlockSse2_x86_64.inc
@@ -1,6 +1,14 @@
-// ChaCha20 one 64B block, SSE2, x86-64. Little-endian state in, 64B keystream out to AOut (keystream-only path, not ChaCha7539 fused I/O xor).
-// Rounds: ChaChaSse2_DoubleRoundBody.inc. 64B stack copy of state; add initial state; store block to AOut.
-// After ClpSimdProc3Begin_x86_64.inc: rcx=ARounds, rdx=AIn (16 UInt32 state), r8=AOut (64B output).
+// ChaCha20 one-block (64B) core, pure SSE2 (x86-64).
+// -------------------------------------------------------------------
+// Little-endian state in, 64B keystream out to AOut (keystream-only path,
+// not ChaCha7539's fused I/O xor). Rounds: ChaChaSse2_DoubleRoundBody.inc.
+// 64B stack copy of state; add initial state; store block to AOut.
+//
+// On entry (after ClpSimdProc3Begin_x86_64.inc):
+//   rcx = ARounds, rdx = AIn (16 UInt32 state), r8 = AOut (64B output).
+//
+// Reference: D.J. Bernstein, "ChaCha, a variant of Salsa20" - the
+// quarter-round arithmetic that this kernel's rounds implement.
   sub     rsp, 64
   movdqu  xmm0, [rdx+0]
   movdqu  xmm1, [rdx+16]

--- a/CryptoLib/src/Include/Simd/ChaCha/ChaCha7539ProcessBlocks2Sse2_i386.inc
+++ b/CryptoLib/src/Include/Simd/ChaCha/ChaCha7539ProcessBlocks2Sse2_i386.inc
@@ -1,7 +1,20 @@
-// ChaCha7539 (IETF) 128B, SSE2, i386. Two 64B blocks; little-endian state in [esi]. Rounds: ChaChaSse2_DoubleRoundBody.inc.
-// Fused I/O xor: read plaintext at AIn (edi), xor with ChaCha output, write to AOut (eax) — no 64B LK/keystream temp in Pascal.
-// After ClpSimdProc4Begin_i386.inc: ebx=ARounds, esi=AState (R/W), edi=AIn, eax=AOut.
-// ecx: 16B stack realign before each 64B round scratch. edx: copy of ARounds between blocks. Word 12 at [esi+48] +2 per 64B block; wrap 0 -> ChaCha7539RaiseCounter7539.
+// ChaCha7539 (IETF) 128B (two 64B blocks), fused I/O, pure SSE2 (i386).
+// -------------------------------------------------------------------
+// Little-endian state in [esi]. Rounds: ChaChaSse2_DoubleRoundBody.inc.
+// Fused I/O xor: read plaintext at AIn (edi), xor with ChaCha output, write
+// to AOut (eax) - no 64B LK/keystream temp in Pascal.
+//
+// On entry (after ClpSimdProc4Begin_i386.inc):
+//   ebx = ARounds, esi = AState (R/W), edi = AIn, eax = AOut.
+//
+// ecx: 16B stack realign before each 64B round scratch. edx: copy of
+// ARounds between blocks. Word 12 at [esi+48] +2 per 64B block; wrap 0 ->
+// ChaCha7539RaiseCounter7539.
+//
+// Reference: RFC 7539 (IETF ChaCha20, superseded by RFC 8439) - the
+// 32-bit-counter/96-bit-nonce state layout that this kernel operates on;
+// quarter-round arithmetic per D.J. Bernstein, "ChaCha, a variant of
+// Salsa20".
   mov     edx, ebx
   // --- block 1 (counter C in memory) ---
   mov     ecx, esp

--- a/CryptoLib/src/Include/Simd/ChaCha/ChaCha7539ProcessBlocks2Sse2_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/ChaCha/ChaCha7539ProcessBlocks2Sse2_x86_64.inc
@@ -1,7 +1,19 @@
-// ChaCha7539 (IETF) 128B, SSE2. Two 64B blocks; little-endian state in [rdx]. Rounds: ChaChaSse2_DoubleRoundBody.inc.
-// Fused I/O xor: read plaintext at AIn (r8), xor with ChaCha output, write to AOut (r9) — no 64B LK/keystream temp in Pascal.
-// After ClpSimdProc4Begin_x86_64.inc: rcx=ARounds, rdx=AState (R/W, 16 UInt32), r8=AIn, r9=AOut.
-// Word 12 at [rdx+48] is advanced by 2 (once per 64B block). On 32-bit counter wrap to 0, calls ChaCha7539RaiseCounter7539.
+// ChaCha7539 (IETF) 128B (two 64B blocks), fused I/O, pure SSE2 (x86-64).
+// -------------------------------------------------------------------
+// Little-endian state in [rdx]. Rounds: ChaChaSse2_DoubleRoundBody.inc.
+// Fused I/O xor: read plaintext at AIn (r8), xor with ChaCha output, write
+// to AOut (r9) - no 64B LK/keystream temp in Pascal.
+//
+// On entry (after ClpSimdProc4Begin_x86_64.inc):
+//   rcx = ARounds, rdx = AState (R/W, 16 UInt32), r8 = AIn, r9 = AOut.
+//
+// Word 12 at [rdx+48] is advanced by 2 (once per 64B block). On 32-bit
+// counter wrap to 0, calls ChaCha7539RaiseCounter7539.
+//
+// Reference: RFC 7539 (IETF ChaCha20, superseded by RFC 8439) - the
+// 32-bit-counter/96-bit-nonce state layout that this kernel operates on;
+// quarter-round arithmetic per D.J. Bernstein, "ChaCha, a variant of
+// Salsa20".
   mov     r11, rcx
   // --- block 1 (counter C in memory) ---
   sub     rsp, 64

--- a/CryptoLib/src/Include/Simd/ChaCha/ChaChaSse2_DoubleRoundBody.inc
+++ b/CryptoLib/src/Include/Simd/ChaCha/ChaChaSse2_DoubleRoundBody.inc
@@ -1,6 +1,14 @@
-// One ChaCha double round (2 column rounds + 3 row shuffles), SSE2. Shared IA-32 / x86-64: XMM ARX only — no I/O xor here.
-// ChaCha20 parent stores keystream to AOut; ChaCha7539 parent xors in/out (fused I/O) after the round loop.
-// Include after the loop label; parent must emit: sub <roundsReg>, 2 / jg <loopLabel>.
+// One ChaCha double round, shared SSE2 body (IA-32 / x86-64).
+// -------------------------------------------------------------------
+// 2 column rounds + 3 row shuffles: XMM ARX only - no I/O xor here.
+// ChaCha20 parent stores keystream to AOut; ChaCha7539 parent xors in/out
+// (fused I/O) after the round loop.
+//
+// Include after the loop label; parent must emit: sub <roundsReg>, 2 /
+// jg <loopLabel>.
+//
+// Reference: D.J. Bernstein, "ChaCha, a variant of Salsa20" - the
+// quarter-round arithmetic that this body implements.
   paddd   xmm0, xmm1
   pxor    xmm3, xmm0
   movdqa  xmm4, xmm3

--- a/CryptoLib/src/Include/Simd/Gcm/GcmGhashFull_i386.inc
+++ b/CryptoLib/src/Include/Simd/Gcm/GcmGhashFull_i386.inc
@@ -37,7 +37,6 @@
 //
 // PCLMULQDQ / PSHUFD and the PSHUFB memory-operand form are db-encoded
 // for broad assembler compatibility.
-//
   mov       edx, esp
   sub       esp, 72
   and       esp, -16                            // align the frame

--- a/CryptoLib/src/Include/Simd/Gcm/GcmGhashFull_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Gcm/GcmGhashFull_x86_64.inc
@@ -37,7 +37,6 @@
 //
 // PCLMULQDQ / PSHUFD and pxor forms touching xmm8/xmm9 are db-encoded
 // for broad assembler compatibility.
-//
 {$I ..\..\Include\Simd\Common\ClpSimdNonVolatileSave_x86_64.inc}
   sub       rsp, 24                             // [rsp] 16-aligned
   mov       rax, $C200000000000000

--- a/CryptoLib/src/Include/Simd/Gcm/GcmPclmulMultiplyExt_i386.inc
+++ b/CryptoLib/src/Include/Simd/Gcm/GcmPclmulMultiplyExt_i386.inc
@@ -1,10 +1,17 @@
 // SSE2 + PCLMULQDQ Karatsuba-style carryless multiply without reduction (i386).
+// -------------------------------------------------------------------
 // MultiplyExt: Z0, Z1, Z2 only (no Z1 merge / reduction). Operands are 16-byte
 // limbs, LE UInt64 pair each.
-// After ClpSimdProc3Begin_i386.inc: ebx = PX, esi = PY, edi = POut
-// (48 bytes: Z0, Z1, Z2).
+//
+// On entry (after ClpSimdProc3Begin_i386.inc):
+//   ebx = PX, esi = PY, edi = POut (48 bytes: Z0, Z1, Z2).
+//
 // PCLMULQDQ instructions are db-encoded for broad assembler compatibility.
 //
+// Reference: Shay Gueron / Michael E. Kounavis, "Intel(R) Carry-Less
+// Multiplication Instruction and its Usage for Computing the GCM Mode"
+// (white paper) - the 3-multiply carry-less Karatsuba split that this
+// kernel implements.
   movdqu    xmm0, [ebx]
   movdqu    xmm1, [esi]
 

--- a/CryptoLib/src/Include/Simd/Gcm/GcmPclmulMultiplyExt_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Gcm/GcmPclmulMultiplyExt_x86_64.inc
@@ -1,10 +1,17 @@
 // SSE2 + PCLMULQDQ Karatsuba-style carryless multiply without reduction (x86-64).
+// -------------------------------------------------------------------
 // MultiplyExt: Z0, Z1, Z2 only (no Z1 merge / reduction). Operands are 16-byte
 // limbs, LE UInt64 pair each.
-// After ClpSimdProc3Begin_x86_64.inc: rcx = PX, rdx = PY, r8 = POut
-// (48 bytes: Z0, Z1, Z2).
+//
+// On entry (after ClpSimdProc3Begin_x86_64.inc):
+//   rcx = PX, rdx = PY, r8 = POut (48 bytes: Z0, Z1, Z2).
+//
 // PCLMULQDQ instructions are db-encoded for broad assembler compatibility.
 //
+// Reference: Shay Gueron / Michael E. Kounavis, "Intel(R) Carry-Less
+// Multiplication Instruction and its Usage for Computing the GCM Mode"
+// (white paper) - the 3-multiply carry-less Karatsuba split that this
+// kernel implements.
   movdqu    xmm0, [rcx]
   movdqu    xmm1, [rdx]
 

--- a/CryptoLib/src/Include/Simd/Gcm/GcmPclmulPartial_i386.inc
+++ b/CryptoLib/src/Include/Simd/Gcm/GcmPclmulPartial_i386.inc
@@ -1,14 +1,20 @@
 // SSE2 + PCLMULQDQ GHASH field multiply, partial carryless product (i386).
+// -------------------------------------------------------------------
 // Produces the 256-bit Karatsuba partial product (Z0, Z1, Z2) for two GHASH
-// field elements before degree reduction.
-// After ClpSimdProc3Begin_i386.inc: ebx = @X (TFieldElement), esi = @Y,
-// edi = @TGcmPartial128 output.
-// X.N0, X.N1 and Y.N0, Y.N1 are UInt64 GHASH field limbs (TFieldElement).
-// Pack each limb into xmm as high qword then low (movq + punpcklqdq);
-// little-endian 128-bit layout.
+// field elements before degree reduction. X.N0, X.N1 and Y.N0, Y.N1 are
+// UInt64 GHASH field limbs (TFieldElement); each limb is packed into xmm as
+// high qword then low (movq + punpcklqdq), little-endian 128-bit layout.
 // Epilogue: pop edi, esi, ebx (matches ClpSimdProc3Begin_i386.inc pushes).
+//
+// On entry (after ClpSimdProc3Begin_i386.inc):
+//   ebx = @X (TFieldElement), esi = @Y, edi = @TGcmPartial128 output.
+//
 // PCLMULQDQ instructions are db-encoded for broad assembler compatibility.
 //
+// Reference: Shay Gueron / Michael E. Kounavis, "Intel(R) Carry-Less
+// Multiplication Instruction and its Usage for Computing the GCM Mode"
+// (white paper) - the 3-multiply carry-less Karatsuba split that this
+// kernel implements.
   movq      xmm0, qword ptr [ebx + 8]
   movq      xmm4, qword ptr [ebx]
   punpcklqdq xmm0, xmm4

--- a/CryptoLib/src/Include/Simd/Gcm/GcmPclmulPartial_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Gcm/GcmPclmulPartial_x86_64.inc
@@ -1,13 +1,19 @@
 // SSE2 + PCLMULQDQ GHASH field multiply, partial carryless product (x86-64).
+// -------------------------------------------------------------------
 // Produces the 256-bit Karatsuba partial product (Z0, Z1, Z2) for two GHASH
-// field elements before degree reduction.
-// After ClpSimdProc3Begin_x86_64.inc: rcx = @X (TFieldElement), rdx = @Y,
-// r8 = @TGcmPartial128 output.
-// X.N0, X.N1 and Y.N0, Y.N1 are UInt64 GHASH field limbs (TFieldElement).
-// Pack each limb into xmm as high qword then low (movq + punpcklqdq);
-// little-endian 128-bit layout.
+// field elements before degree reduction. X.N0, X.N1 and Y.N0, Y.N1 are
+// UInt64 GHASH field limbs (TFieldElement); each limb is packed into xmm as
+// high qword then low (movq + punpcklqdq), little-endian 128-bit layout.
+//
+// On entry (after ClpSimdProc3Begin_x86_64.inc):
+//   rcx = @X (TFieldElement), rdx = @Y, r8 = @TGcmPartial128 output.
+//
 // PCLMULQDQ instructions are db-encoded for broad assembler compatibility.
 //
+// Reference: Shay Gueron / Michael E. Kounavis, "Intel(R) Carry-Less
+// Multiplication Instruction and its Usage for Computing the GCM Mode"
+// (white paper) - the 3-multiply carry-less Karatsuba split that this
+// kernel implements.
   movq      xmm0, qword ptr [rcx + 8]
   movq      xmm4, qword ptr [rcx]
   punpcklqdq xmm0, xmm4

--- a/CryptoLib/src/Include/Simd/Gcm/GcmReduce3FoldSse2_i386.inc
+++ b/CryptoLib/src/Include/Simd/Gcm/GcmReduce3FoldSse2_i386.inc
@@ -1,10 +1,17 @@
 // SSE2 3-limb GHASH reduction (i386).
+// -------------------------------------------------------------------
 // Fold Z1 into (Z0, Z2), then reduce the (Z0, Z2) pair modulo the GCM
 // polynomial x^128 + x^7 + x^2 + x + 1, writing the resulting 16-byte field
 // element to POut. Z0/Z1/Z2 are the three 128-bit limbs carried across a batch
 // of Karatsuba-style PCLMULQDQ GHASH products.
-// After ClpSimdProc4Begin_i386.inc: ebx = PZ0, esi = PZ1, edi = PZ2, eax = POut.
 //
+// On entry (after ClpSimdProc4Begin_i386.inc):
+//   ebx = PZ0, esi = PZ1, edi = PZ2, eax = POut.
+//
+// Reference: Shay Gueron / Michael E. Kounavis, "Intel(R) Carry-Less
+// Multiplication Instruction and its Usage for Computing the GCM Mode"
+// (white paper) - the shift/XOR reduction modulo the GCM polynomial that
+// this kernel implements.
   movdqu    xmm0, [ebx]
   movdqu    xmm2, [edi]
   movdqu    xmm1, [esi]

--- a/CryptoLib/src/Include/Simd/Gcm/GcmReduce3FoldSse2_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Gcm/GcmReduce3FoldSse2_x86_64.inc
@@ -1,10 +1,17 @@
 // SSE2 3-limb GHASH reduction (x86-64).
+// -------------------------------------------------------------------
 // Fold Z1 into (Z0, Z2), then reduce the (Z0, Z2) pair modulo the GCM
 // polynomial x^128 + x^7 + x^2 + x + 1, writing the resulting 16-byte field
 // element to POut. Z0/Z1/Z2 are the three 128-bit limbs carried across a batch
 // of Karatsuba-style PCLMULQDQ GHASH products.
-// After ClpSimdProc4Begin_x86_64.inc: rcx = PZ0, rdx = PZ1, r8 = PZ2, r9 = POut.
 //
+// On entry (after ClpSimdProc4Begin_x86_64.inc):
+//   rcx = PZ0, rdx = PZ1, r8 = PZ2, r9 = POut.
+//
+// Reference: Shay Gueron / Michael E. Kounavis, "Intel(R) Carry-Less
+// Multiplication Instruction and its Usage for Computing the GCM Mode"
+// (white paper) - the shift/XOR reduction modulo the GCM polynomial that
+// this kernel implements.
 {$I ..\..\Include\Simd\Common\ClpSimdNonVolatileSave_x86_64.inc}
   movdqu    xmm0, [rcx]
   movdqu    xmm2, [r8]

--- a/CryptoLib/src/Include/Simd/Poly1305/Poly1305BlocksBulkSse2Core_i386.inc
+++ b/CryptoLib/src/Include/Simd/Poly1305/Poly1305BlocksBulkSse2Core_i386.inc
@@ -18,6 +18,10 @@
 // Power table: row j at [esi + 16*j]; rows 0..4 r-limbs [r2,r2,r2,r1],
 // rows 5..8 s-limbs (5*r), row 9 pad. Bulk reads [+16*j] (broadcast r^2);
 // tail reads [+16*j+4] ([r^2,r^1]).
+//
+// Reference: Goll/Gueron, "Vectorization of Poly1305 Message Authentication
+// Code" - the radix-2^26 multi-lane construction that this 2-lane form narrows
+// from the 4-lane AVX2 kernel (Poly1305BlocksBulkAvx2Core_i386.inc).
 
   // ---- 64B-aligned frame: table copy + D slots + mask/pad ----
   mov     edx, esp

--- a/CryptoLib/src/Include/Simd/Poly1305/Poly1305BlocksBulkSse2Core_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Poly1305/Poly1305BlocksBulkSse2Core_x86_64.inc
@@ -13,6 +13,10 @@
 // Power table: row j at [rdx + 16*j]; rows 0..4 r-limbs [r2,r2,r2,r1],
 // rows 5..8 s-limbs (5*r), row 9 pad. Bulk reads [+16*j] (broadcast r^2);
 // tail reads [+16*j+4] ([r^2,r^1]).
+//
+// Reference: Goll/Gueron, "Vectorization of Poly1305 Message Authentication
+// Code" - the radix-2^26 multi-lane construction that this 2-lane form narrows
+// from the 4-lane AVX2 kernel (Poly1305BlocksBulkAvx2Core_x86_64.inc).
 
 {$I ..\..\Include\Simd\Common\ClpSimdNonVolatileSave_x86_64.inc}
   // ---- 64B-aligned frame: bulk table rows copied in once ----

--- a/CryptoLib/src/Include/Simd/Salsa/Salsa20BlockSse2_i386.inc
+++ b/CryptoLib/src/Include/Simd/Salsa/Salsa20BlockSse2_i386.inc
@@ -1,6 +1,16 @@
-// Salsa20 block, pure SSE2 i386. Diagonal transpose via scalar gather/scatter (no pblendw).
-// After ClpSimdProc3Begin_i386.inc: ebx = ARounds, esi = AIn, edi = AOut.
-// Rounds: Salsa20Sse2_TwoColumnRoundsBody.inc. End with: add esp, 512; pop edi; pop esi; pop ebx
+// Salsa20 one-block (16*UInt32) core, pure SSE2 (i386).
+// -------------------------------------------------------------------
+// Diagonal transpose via scalar gather/scatter (no pblendw).
+//
+// On entry (after ClpSimdProc3Begin_i386.inc):
+//   ebx = ARounds, esi = AIn, edi = AOut.
+//
+// Rounds: Salsa20Sse2_TwoColumnRoundsBody.inc. End with: add esp, 512;
+// pop edi; pop esi; pop ebx.
+//
+// Reference: D.J. Bernstein's Salsa20 SSE2 reference implementation
+// (cr.yp.to/salsa20/) - the diagonal-extraction layout that this kernel's
+// gather/scatter reproduces (see Salsa20BlockSse2_x86_64.inc).
   sub     esp, 512
 { -- diagonal gather: b0..b3 into [esp+0..63] -- }
   mov     eax, [esi+0]

--- a/CryptoLib/src/Include/Simd/Salsa/Salsa20BlockSse2_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Salsa/Salsa20BlockSse2_x86_64.inc
@@ -1,10 +1,18 @@
-// Salsa20 one 16*UInt32 block: LE state in, LE state+input out, pure SSE2.
-// The 4-lane quarter round works on the diagonal layout
+// Salsa20 one-block (16*UInt32) core, pure SSE2 (x86-64).
+// -------------------------------------------------------------------
+// LE state in, LE state+input out. The 4-lane quarter round works on the
+// diagonal layout
 //   b0=[s0,s5,s10,s15] b1=[s12,s1,s6,s11] b2=[s8,s13,s2,s7] b3=[s4,s9,s14,s3].
 // SSE2 has no pblendw, so the diagonal transpose is a direct scalar gather on
 // the way in and the inverse scatter on the way out (dword granular, no masks).
 // Rounds: Salsa20Sse2_TwoColumnRoundsBody.inc (pure SSE2 body).
-// After ClpSimdProc3Begin_x86_64.inc: rcx = ARounds, rdx = AIn (16 UInt32), r8 = AOut (16 UInt32).
+//
+// On entry (after ClpSimdProc3Begin_x86_64.inc):
+//   rcx = ARounds, rdx = AIn (16 UInt32), r8 = AOut (16 UInt32).
+//
+// Reference: D.J. Bernstein's Salsa20 SSE2 reference implementation
+// (cr.yp.to/salsa20/) - the diagonal-extraction layout that this kernel's
+// gather/scatter reproduces.
 {$I ..\..\Include\Simd\Common\ClpSimdNonVolatileSave_x86_64.inc}
   sub     rsp, 512
   mov     r9, rcx

--- a/CryptoLib/src/Include/Simd/Salsa/Salsa20ProcessBlocks2Sse2_i386.inc
+++ b/CryptoLib/src/Include/Simd/Salsa/Salsa20ProcessBlocks2Sse2_i386.inc
@@ -1,8 +1,17 @@
-// Salsa20 128B, pure SSE2 i386: two 64B blocks, fused I/O (xor). Diagonal transpose via
-// scalar gather/scatter (no pblendw); see Salsa20BlockSse2_i386.inc.
-// After ClpSimdProc4Begin_i386: ebx=ARounds, esi=AState, edi=AIn, eax=AOut.
-// Rounds: Salsa20Sse2_TwoColumnRoundsBody.inc.
-// edx: saved ARounds. push eax/pop eax: gather clobbers eax; xor needs AOut in eax.
+// Salsa20 128B (two 64B blocks), fused I/O, pure SSE2 (i386).
+// -------------------------------------------------------------------
+// Diagonal transpose via scalar gather/scatter (no pblendw); see
+// Salsa20BlockSse2_i386.inc. Rounds: Salsa20Sse2_TwoColumnRoundsBody.inc.
+//
+// On entry (after ClpSimdProc4Begin_i386.inc):
+//   ebx = ARounds, esi = AState, edi = AIn, eax = AOut.
+//
+// edx: saved ARounds. push eax/pop eax: gather clobbers eax; xor needs
+// AOut in eax.
+//
+// Reference: D.J. Bernstein's Salsa20 SSE2 reference implementation
+// (cr.yp.to/salsa20/) - the diagonal-extraction layout that this kernel's
+// gather/scatter reproduces.
   mov     edx, ebx
   push    eax
   sub     esp, 512

--- a/CryptoLib/src/Include/Simd/Salsa/Salsa20ProcessBlocks2Sse2_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Salsa/Salsa20ProcessBlocks2Sse2_x86_64.inc
@@ -1,8 +1,17 @@
-// Salsa20 128B, pure SSE2: two 64B blocks, fused I/O (xor) like ChaCha7539ProcessBlocks2Sse2.
-// Diagonal transpose done as a scalar gather/scatter (no pblendw); see Salsa20BlockSse2_x86_64.inc.
-// Rounds: Salsa20Sse2_TwoColumnRoundsBody.inc.
-// After ClpSimdProc4Begin_x86_64.inc: rcx=ARounds, rdx=AState, r8=AIn (plain), r9=AOut (cipher).
-// r10 = round counter per block. Counter words: FEngineState[8]@[rdx+32], FEngineState[9]@[rdx+36].
+// Salsa20 128B (two 64B blocks), fused I/O, pure SSE2 (x86-64).
+// -------------------------------------------------------------------
+// Two 64B blocks, fused I/O (xor) like ChaCha7539ProcessBlocks2Sse2. Diagonal
+// transpose done as a scalar gather/scatter (no pblendw); see
+// Salsa20BlockSse2_x86_64.inc. Rounds: Salsa20Sse2_TwoColumnRoundsBody.inc.
+//
+// On entry (after ClpSimdProc4Begin_x86_64.inc):
+//   rcx = ARounds, rdx = AState, r8 = AIn (plain), r9 = AOut (cipher).
+//   r10 = round counter per block. Counter words: FEngineState[8]@[rdx+32],
+//   FEngineState[9]@[rdx+36].
+//
+// Reference: D.J. Bernstein's Salsa20 SSE2 reference implementation
+// (cr.yp.to/salsa20/) - the diagonal-extraction layout that this kernel's
+// gather/scatter reproduces.
 {$I ..\..\Include\Simd\Common\ClpSimdNonVolatileSave_x86_64.inc}
   sub     rsp, 512
 { -------- block 1 (64B) at I/O offset 0 -------- }

--- a/CryptoLib/src/Include/Simd/Salsa/Salsa20Sse2_TwoColumnRoundsBody.inc
+++ b/CryptoLib/src/Include/Simd/Salsa/Salsa20Sse2_TwoColumnRoundsBody.inc
@@ -1,9 +1,15 @@
-// Two Salsa20 column rounds (4-lane SSE4.1 quarter-round path): swap xmm1/xmm3,
-// first SalsaQ on xmm0..3, diagonal pshufd, swap again, second SalsaQ, pshufd.
-// Shared IA-32 / x86-64: XMM ARX + pshufd only — no stack, no GPR round counter.
-// Parent must emit the loop label immediately before this include, then after
-// the include: sub <roundsReg>, 2 / jg <sameLabel>. xmm0..xmm3 hold packed
-// state lanes; xmm4..xmm7 are scratch.
+// Two Salsa20 column rounds, shared SSE2 body (IA-32 / x86-64).
+// -------------------------------------------------------------------
+// 4-lane quarter-round path: swap xmm1/xmm3, first SalsaQ on xmm0..3,
+// diagonal pshufd, swap again, second SalsaQ, pshufd. XMM ARX + pshufd
+// only - no stack, no GPR round counter.
+//
+// Parent must emit the loop label immediately before this include, then
+// after the include: sub <roundsReg>, 2 / jg <sameLabel>. xmm0..xmm3 hold
+// packed state lanes; xmm4..xmm7 are scratch.
+//
+// Reference: D.J. Bernstein, "Salsa20 specification" (cr.yp.to/salsa20/) -
+// the quarterround/rowround/columnround arithmetic that this body implements.
   movdqa  xmm4, xmm1
   movdqa  xmm1, xmm3
   movdqa  xmm3, xmm4


### PR DESCRIPTION
Bring every .inc header under CryptoLib/src/Include/Simd/ to a consistent template (technique summary, entry/exit registers, variant flags, and a Reference: line citing the actual external source where one exists)