### PR TITLE
Stage pre-whitened counters in the fused AES-NI CTR kernels; fix SIC counter wrap OOB

### DIFF
--- a/CryptoLib.Tests/src/Crypto/SicBulkParityTests.pas
+++ b/CryptoLib.Tests/src/Crypto/SicBulkParityTests.pas
@@ -62,11 +62,19 @@ type
   strict private
     procedure RunParityForEngine(AEngineFactory: TBlockCipherFactory;
       AKeyLen, AIvLen, ABlockSize: Int32; const ALabel: String);
+    // Engine-agnostic: any bulk/kernel provider must produce
+    // per-block-identical output across counter wrap boundaries.
+    procedure RunWrapCaseForEngine(AEngineFactory: TBlockCipherFactory;
+      const AIvHex: String; ABlockCount: Int32; const ALabel: String);
+    procedure RunWrapCasesForEngine(AEngineFactory: TBlockCipherFactory;
+      const ALabel: String);
   published
 {$IFDEF CRYPTOLIB_X86_SIMD}
     procedure TestAesX86SicBulkParity;
+    procedure TestAesX86SicCounterWrapParity;
 {$ENDIF CRYPTOLIB_X86_SIMD}
     procedure TestAesScalarSicBulkParity;
+    procedure TestAesScalarSicCounterWrapParity;
     procedure TestBlowfishSicBulkParity;
   end;
 
@@ -188,7 +196,83 @@ begin
   // 16-byte block, 16-byte key, 12-byte IV (leaves a 4-byte counter suffix).
   RunParityForEngine(@CreateAesX86Engine, 16, 12, 16, 'AES-NI (TAesEngineX86)');
 end;
+
+procedure TTestSicBulkParity.TestAesX86SicCounterWrapParity;
+begin
+  if not TAesEngineX86.IsSupported then
+    Exit;
+  RunWrapCasesForEngine(@CreateAesX86Engine, 'AES-NI (TAesEngineX86)');
+end;
 {$ENDIF CRYPTOLIB_X86_SIMD}
+
+procedure TTestSicBulkParity.RunWrapCaseForEngine(
+  AEngineFactory: TBlockCipherFactory; const AIvHex: String;
+  ABlockCount: Int32; const ALabel: String);
+var
+  LRnd: ISecureRandom;
+  LKey, LIV, LPlain, LOutRef, LOutBulk: TBytes;
+  LKeyParam: IKeyParameter;
+  LParams: IParametersWithIV;
+  LRefSic, LBulkSic: ISicBlockCipher;
+  LBulkMode: IBulkBlockCipherMode;
+  LOff, LTotalBytes: Int32;
+begin
+  LRnd := TSecureRandom.Create();
+  System.SetLength(LKey, 16);
+  LRnd.NextBytes(LKey);
+  LIV := DecodeHex(AIvHex);
+  LTotalBytes := ABlockCount * 16;
+  System.SetLength(LPlain, LTotalBytes);
+  LRnd.NextBytes(LPlain);
+  System.SetLength(LOutRef, LTotalBytes);
+  System.SetLength(LOutBulk, LTotalBytes);
+
+  LKeyParam := TKeyParameter.Create(LKey) as IKeyParameter;
+  LParams := TParametersWithIV.Create(LKeyParam, LIV) as IParametersWithIV;
+
+  // Reference: per-block ProcessBlock loop (scalar big-endian counter carry).
+  LRefSic := TSicBlockCipher.Create(AEngineFactory()) as ISicBlockCipher;
+  LRefSic.Init(True, LParams);
+  LOff := 0;
+  while LOff < LTotalBytes do
+  begin
+    LRefSic.ProcessBlock(LPlain, LOff, LOutRef, LOff);
+    System.Inc(LOff, 16);
+  end;
+
+  // Bulk: single ProcessBlocks call across the counter boundary.
+  LBulkSic := TSicBlockCipher.Create(AEngineFactory()) as ISicBlockCipher;
+  LBulkSic.Init(True, LParams);
+  if not Supports(LBulkSic, IBulkBlockCipherMode, LBulkMode) then
+    Fail(Format('%s wrap case: TSicBlockCipher does not expose IBulkBlockCipherMode',
+      [ALabel]));
+  LBulkMode.ProcessBlocks(LPlain, 0, ABlockCount, LOutBulk, 0);
+
+  if not AreEqual(LOutRef, LOutBulk) then
+    Fail(Format('%s SIC counter-wrap parity mismatch (iv=%s, %d blocks)',
+      [ALabel, AIvHex, ABlockCount]));
+end;
+
+procedure TTestSicBulkParity.RunWrapCasesForEngine(
+  AEngineFactory: TBlockCipherFactory; const ALabel: String);
+begin
+  // Full 16-byte IVs landing the low-dword 2^32 boundary at different points
+  // within one bulk call. Accelerated kernels that split runs at that boundary
+  // must stay per-block-identical; the scalar bulk path must too.
+  // Boundary exactly 8 blocks in: batch-aligned split + upper-bytes carry.
+  RunWrapCaseForEngine(AEngineFactory, '000102030405060708090A0BFFFFFFF8', 24, ALabel);
+  // Boundary mid-batch: crossing handled block-at-a-time.
+  RunWrapCaseForEngine(AEngineFactory, '000102030405060708090A0BFFFFFFFE', 24, ALabel);
+  // Carry cascade through several upper counter bytes.
+  RunWrapCaseForEngine(AEngineFactory, '000102030405FFFFFFFFFFFFFFFFFFFC', 24, ALabel);
+  // Full 128-bit wrap: counter returns to zero mid-run.
+  RunWrapCaseForEngine(AEngineFactory, 'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE', 24, ALabel);
+end;
+
+procedure TTestSicBulkParity.TestAesScalarSicCounterWrapParity;
+begin
+  RunWrapCasesForEngine(@CreateAesScalarEngine, 'AES scalar (TAesEngine)');
+end;
 
 procedure TTestSicBulkParity.TestAesScalarSicBulkParity;
 begin

--- a/CryptoLib/src/Crypto/CipherKernels/Block/ClpAesNiCtrKernel.pas
+++ b/CryptoLib/src/Crypto/CipherKernels/Block/ClpAesNiCtrKernel.pas
@@ -74,8 +74,11 @@ type
   // Context handed to the fused AES-NI CTR keystream + XOR kernel. Field offsets
   // match the [rcx + N] / [ebx + N] accesses in AesNiCtrEight_x86_64.inc and
   // AesNiCtrEight_i386.inc (8-byte fields on x86_64, 4-byte on i386). The kernel
-  // loops internally over BlockCount blocks, advancing InPtr/OutPtr and the
-  // 16-byte big-endian counter at CounterPtr in place.
+  // loops internally over BlockCount blocks, advancing InPtr/OutPtr and the low
+  // dword of the 16-byte big-endian counter at CounterPtr in place. The counters
+  // are staged pre-whitened (K_0 folded into the scalar counter build), so the
+  // kernel requires the low-32 counter dword not to wrap within one call;
+  // ProcessCtrBlocks enforces that by splitting runs at the 2^32 boundary.
   TCtrFusedCtx = record
     InPtr: Pointer;
     OutPtr: Pointer;
@@ -85,8 +88,9 @@ type
   end;
 
 // Fused AES-NI CTR keystream + XOR (encrypt-only; CTR keystream is the same for
-// encrypt and decrypt). Each proc processes BlockCount blocks (a multiple of 8),
-// looping internally, and advances the 16-byte big-endian counter in place.
+// encrypt and decrypt). Each proc processes BlockCount blocks (a positive
+// multiple of 8 with ctr32 + BlockCount <= 2^32), looping internally; only the
+// counter's low dword is advanced in place.
 procedure AesNiCtrEnc128(PCtx: Pointer);
 {$DEFINE CRYPTOLIB_AESNI_KEY128}
 {$IFDEF CRYPTOLIB_X86_64_ASM}
@@ -144,24 +148,91 @@ begin
   Result := FUSED_CTR_BATCH_BLOCKS;
 end;
 
+{$IFDEF CRYPTOLIB_X86_SIMD}
+// Big-endian +1 over ACounter[AHigh..ALow], dropping any carry out of ALow.
+// AHigh=15/ALow=0 is the SIC whole-counter increment; AHigh=11/ALow=0 is the
+// upper-bytes carry after the kernel consumed a run up to the 2^32 boundary.
+procedure CtrIncrementBigEndian(ACounter: PByte; AHigh, ALow: Int32); inline;
+var
+  LJ: Int32;
+begin
+  LJ := AHigh;
+  repeat
+    System.Inc(ACounter[LJ]);
+    if ACounter[LJ] <> 0 then
+      Break;
+    System.Dec(LJ);
+  until LJ < ALow;
+end;
+{$ENDIF CRYPTOLIB_X86_SIMD}
+
 procedure TAesNiCtrKernel.ProcessCtrBlocks(AInPtr, AOutPtr, ACounter: Pointer;
   ABlockCount: NativeInt);
 {$IFDEF CRYPTOLIB_X86_SIMD}
 var
   LCtx: TCtrFusedCtx;
+  LIn, LOut, LCtr: PByte;
+  LRemaining, LChunk: NativeInt;
+  LUntilWrap: UInt64;
+  LCtr32: Cardinal;
+  LKs: array [0 .. 15] of Byte;
+  LI, LJ: Int32;
 {$ENDIF CRYPTOLIB_X86_SIMD}
 begin
 {$IFDEF CRYPTOLIB_X86_SIMD}
-  LCtx.InPtr := AInPtr;
-  LCtx.OutPtr := AOutPtr;
-  LCtx.KeysPtr := FKeys;
-  LCtx.CounterPtr := ACounter;
-  LCtx.BlockCount := NativeUInt(ABlockCount);
-  case FRounds of
-    10: AesNiCtrEnc128(@LCtx);
-    12: AesNiCtrEnc192(@LCtx);
-  else
-    AesNiCtrEnc256(@LCtx);
+  LIn := AInPtr;
+  LOut := AOutPtr;
+  LCtr := ACounter;
+  LRemaining := ABlockCount;
+  while LRemaining > 0 do
+  begin
+    // The kernel stages counters pre-whitened and carries no in-loop carry
+    // logic, so a single call must not cross the 2^32 boundary of the low
+    // counter dword. Split the run there and apply the (rare) carry here.
+    LCtr32 := (Cardinal(LCtr[12]) shl 24) or (Cardinal(LCtr[13]) shl 16) or
+      (Cardinal(LCtr[14]) shl 8) or Cardinal(LCtr[15]);
+    LUntilWrap := UInt64($100000000) - LCtr32;
+    if UInt64(LRemaining) <= LUntilWrap then
+      LChunk := LRemaining
+    else
+      LChunk := NativeInt(LUntilWrap) and not NativeInt(7);
+
+    if LChunk > 0 then
+    begin
+      LCtx.InPtr := LIn;
+      LCtx.OutPtr := LOut;
+      LCtx.KeysPtr := FKeys;
+      LCtx.CounterPtr := LCtr;
+      LCtx.BlockCount := NativeUInt(LChunk);
+      case FRounds of
+        10: AesNiCtrEnc128(@LCtx);
+        12: AesNiCtrEnc192(@LCtx);
+      else
+        AesNiCtrEnc256(@LCtx);
+      end;
+      if UInt64(LChunk) = LUntilWrap then
+        CtrIncrementBigEndian(LCtr, 11, 0); // low dword wrapped to 0 in the kernel
+      System.Inc(LIn, LChunk * 16);
+      System.Inc(LOut, LChunk * 16);
+      System.Dec(LRemaining, LChunk);
+    end
+    else
+    begin
+      // Fewer than 8 blocks left before the boundary: bridge one batch a
+      // block at a time with full big-endian carry (at most once per 2^32
+      // blocks, or when the initial counter starts near the wrap).
+      for LI := 1 to 8 do
+      begin
+        FEngine.ProcessBlock(LCtr, @LKs[0]);
+        for LJ := 0 to 15 do
+          LOut[LJ] := LIn[LJ] xor LKs[LJ];
+        CtrIncrementBigEndian(LCtr, 15, 0);
+        System.Inc(LIn, 16);
+        System.Inc(LOut, 16);
+      end;
+      FillChar(LKs, SizeOf(LKs), 0);
+      System.Dec(LRemaining, 8);
+    end;
   end;
 {$ENDIF CRYPTOLIB_X86_SIMD}
 end;

--- a/CryptoLib/src/Crypto/Modes/ClpSicBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpSicBlockCipher.pas
@@ -239,10 +239,11 @@ begin
   for LI := 0 to System.Pred(System.Length(FCounterOut)) do
     AOutput[AOutOff + LI] := Byte(FCounterOut[LI] xor AInput[AInOff + LI]);
 
-  LJ := System.Length(FCounter);
-  System.Dec(LJ);
+  // Big-endian increment; on a full wrap (all bytes FF) the counter returns
+  // to zero. The LJ > 0 guard stops at byte 0 without underflowing the array.
+  LJ := System.Length(FCounter) - 1;
   System.Inc(FCounter[LJ]);
-  while ((LJ >= 0) and (FCounter[LJ] = 0)) do
+  while ((FCounter[LJ] = 0) and (LJ > 0)) do
   begin
     System.Dec(LJ);
     System.Inc(FCounter[LJ]);
@@ -328,10 +329,11 @@ begin
   begin
     System.Move(FCounter[0], APlainCounters[LI * FBlockSize], FBlockSize);
 
-    LJ := System.Length(FCounter);
-    System.Dec(LJ);
+    // Same guarded big-endian increment as ProcessBlock: full wrap returns
+    // to zero without underflowing the array.
+    LJ := System.Length(FCounter) - 1;
     System.Inc(FCounter[LJ]);
-    while ((LJ >= 0) and (FCounter[LJ] = 0)) do
+    while ((FCounter[LJ] = 0) and (LJ > 0)) do
     begin
       System.Dec(LJ);
       System.Inc(FCounter[LJ]);

--- a/CryptoLib/src/Include/Simd/Aes/Ctr/AesNiCtrEight_i386.inc
+++ b/CryptoLib/src/Include/Simd/Aes/Ctr/AesNiCtrEight_i386.inc
@@ -10,31 +10,44 @@
 // batch - the scalar counter build overlaps the aesenc throughput instead of
 // serialising ahead of it.
 //
+// Counters are staged PRE-WHITENED: the K_0 XOR is folded into the scalar
+// counter build. The whitened base block (counter ^ K_0) is written to all
+// eight scratch slots once at entry; only the counter dword (bytes 12..15)
+// changes between blocks, so each staged lane is a 4-byte patch of
+// bswap(ctr32) ^ K_0.dword3. This removes the whole round-0 pxor pass from
+// the AES port budget (the round chain starts directly at K_1) and shrinks
+// the per-lane staging from a 16-byte block copy to one dword store.
+//
 // Entry (after ClpSimdProc1Begin_i386.inc): ebx = pointer to TCtrFusedCtx. The
 // kernel pushes esi/edi and unpacks the record (InPtr loaded into ebx last):
 //   [ebx +  0]  InPtr      -> ebx : input  (advances +128 per 8-block iteration)
 //   [ebx +  4]  OutPtr     -> esi : output (advances +128)
 //   [ebx +  8]  KeysPtr    -> edi : AES round-key schedule (consumed as [edi+K])
-//   [ebx + 12]  CounterPtr -> eax : 16-byte big-endian counter (advanced in place)
+//   [ebx + 12]  CounterPtr -> eax : 16-byte big-endian counter (low dword updated
+//                                   in place; parked in a frame slot, eax then
+//                                   holds the K_0.dword3 whitening constant)
 //   [ebx + 16]  BlockCount -> ecx : positive multiple of 8 (caller guarantees it)
+//
+// Counter contract: the caller guarantees the low-32 counter dword does NOT
+// wrap within the call (ctr32 + BlockCount <= 2^32) - TAesNiCtrKernel splits
+// runs at the 2^32 boundary and propagates the carry into the upper 12 bytes
+// in Pascal. The kernel therefore carries no in-loop carry logic and never
+// touches counter bytes 0..11; only the low dword is stored back. The
+// pipeline builds one batch ahead, so edx over-runs by exactly 8 - undone
+// (modulo 2^32) before write-back.
 //
 // Exactly one of CRYPTOLIB_AESNI_KEY128 / KEY192 / KEY256 must be defined; the
 // direction is always encrypt (CTR keystream), so CRYPTOLIB_AESNI_DECRYPT must
 // NOT be defined when including this file.
 //
 // Constraints: i386 has only xmm0..7 (all volatile). BlockCount parks in a frame
-// slot so both edx and ecx serve the staging: edx holds the counter's low dword
-// native-LE across the whole span (bswap/store/bswap/add per staged block - no
-// read-modify-write of counter memory, so no store-forward stalls), while ecx
-// copies the constant 12-byte prefix from [eax+0..11] (written only by the rare
-// carry-out path, which bumps those bytes big-endian). The pipeline builds one
-// batch ahead, so edx over-runs by exactly one batch (8) - undone (with a
-// byte-wise borrow when it crosses back over a 2^32 boundary) before the low
-// dword is stored back to [eax+12]. The keystream^plaintext XOR has no free xmm for the
-// plaintext (nor can it use a memory-operand pxor, which would require the input
-// to be 16-byte aligned), so it spills lane 7 to a scratch slot above the counter
-// area and reuses xmm7 for the movdqu plaintext load. AES-NI and register pxor
-// forms are db-encoded for broad assembler compatibility.
+// slot so ecx serves the staging: edx holds the counter's low dword native-LE
+// across the whole span, eax the whitening constant. The keystream^plaintext XOR
+// has no free xmm for the plaintext (nor can it use a memory-operand pxor, which
+// would require the input to be 16-byte aligned), so it spills lane 7 to a
+// scratch slot above the counter area and reuses xmm7 for the movdqu plaintext
+// load. AES-NI and register pxor forms are db-encoded for broad assembler
+// compatibility.
   // ---- unpack TCtrFusedCtx (ebx = PCtx); load InPtr into ebx last ----
   push      esi
   push      edi
@@ -44,156 +57,66 @@
   mov       ecx, [ebx + 16]                       // BlockCount
   mov       ebx, [ebx + 0]                        // InPtr (overwrites PCtx)
 
-  sub       esp, 152                              // next-batch counters [esp+0..127]; ks7 spill [esp+128..143]; countdown [esp+144]
-  mov       [esp + 144], ecx                        // park BlockCount; ecx = staging scratch
-  mov       edx, [eax + 12]                         // counter low dword, kept native-LE in edx
+  sub       esp, 152                              // next-batch counters [esp+0..127]; ks7 spill [esp+128..143]; countdown [esp+144]; CounterPtr [esp+148]
+  mov       [esp + 144], ecx                      // park BlockCount; ecx = staging scratch
+  mov       [esp + 148], eax                      // park CounterPtr; eax = whitening constant
+  mov       edx, [eax + 12]                       // counter low dword, kept native-LE in edx
   bswap     edx
 
-  // ---- stage batch 0 into the scratch (xmm0 is free here), then load it ----
-  mov       ecx, [eax]
-  mov       [esp + 0], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 4], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 8], ecx
-  bswap     edx
-  mov       [esp + 12], edx
-  bswap     edx
+  // ---- whitened base block (counter ^ K_0) into all 8 scratch slots ----
+  movdqu    xmm0, [eax]                           // counter block
+  db $66, $0F, $EF, $07                           // pxor xmm0, [edi+0]  (K_0; schedule is 16-byte aligned)
+  movdqu    [esp + 0], xmm0
+  movdqu    [esp + 16], xmm0
+  movdqu    [esp + 32], xmm0
+  movdqu    [esp + 48], xmm0
+  movdqu    [esp + 64], xmm0
+  movdqu    [esp + 80], xmm0
+  movdqu    [esp + 96], xmm0
+  movdqu    [esp + 112], xmm0
+  mov       eax, [edi + 12]                       // K_0.dword3 whitening constant
+
+  // ---- stage batch 0: patch the whitened counter dword of each slot ----
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 12], ecx
   add       edx, 1
-  jnc       @@StgOkP0
-  mov       ecx, 11
-@@StgCyP0:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkP0
-  dec       ecx
-  jns       @@StgCyP0
-@@StgOkP0:
-  mov       ecx, [eax]
-  mov       [esp + 16], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 20], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 24], ecx
-  bswap     edx
-  mov       [esp + 28], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 28], ecx
   add       edx, 1
-  jnc       @@StgOkP1
-  mov       ecx, 11
-@@StgCyP1:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkP1
-  dec       ecx
-  jns       @@StgCyP1
-@@StgOkP1:
-  mov       ecx, [eax]
-  mov       [esp + 32], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 36], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 40], ecx
-  bswap     edx
-  mov       [esp + 44], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 44], ecx
   add       edx, 1
-  jnc       @@StgOkP2
-  mov       ecx, 11
-@@StgCyP2:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkP2
-  dec       ecx
-  jns       @@StgCyP2
-@@StgOkP2:
-  mov       ecx, [eax]
-  mov       [esp + 48], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 52], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 56], ecx
-  bswap     edx
-  mov       [esp + 60], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 60], ecx
   add       edx, 1
-  jnc       @@StgOkP3
-  mov       ecx, 11
-@@StgCyP3:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkP3
-  dec       ecx
-  jns       @@StgCyP3
-@@StgOkP3:
-  mov       ecx, [eax]
-  mov       [esp + 64], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 68], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 72], ecx
-  bswap     edx
-  mov       [esp + 76], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 76], ecx
   add       edx, 1
-  jnc       @@StgOkP4
-  mov       ecx, 11
-@@StgCyP4:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkP4
-  dec       ecx
-  jns       @@StgCyP4
-@@StgOkP4:
-  mov       ecx, [eax]
-  mov       [esp + 80], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 84], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 88], ecx
-  bswap     edx
-  mov       [esp + 92], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 92], ecx
   add       edx, 1
-  jnc       @@StgOkP5
-  mov       ecx, 11
-@@StgCyP5:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkP5
-  dec       ecx
-  jns       @@StgCyP5
-@@StgOkP5:
-  mov       ecx, [eax]
-  mov       [esp + 96], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 100], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 104], ecx
-  bswap     edx
-  mov       [esp + 108], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 108], ecx
   add       edx, 1
-  jnc       @@StgOkP6
-  mov       ecx, 11
-@@StgCyP6:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkP6
-  dec       ecx
-  jns       @@StgCyP6
-@@StgOkP6:
-  mov       ecx, [eax]
-  mov       [esp + 112], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 116], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 120], ecx
-  bswap     edx
-  mov       [esp + 124], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 124], ecx
   add       edx, 1
-  jnc       @@StgOkP7
-  mov       ecx, 11
-@@StgCyP7:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkP7
-  dec       ecx
-  jns       @@StgCyP7
-@@StgOkP7:
 
   movdqu    xmm0, [esp + 0]
   movdqu    xmm1, [esp + 16]
@@ -205,17 +128,8 @@
   movdqu    xmm7, [esp + 112]
 
 @@CtrEightLoopI386:
-  // ---- round 0: whiten with K_0 ----
-  db $66, $0F, $EF, $07                           // pxor xmm0, [edi+0]
-  db $66, $0F, $EF, $0F                           // pxor xmm1, [edi+0]
-  db $66, $0F, $EF, $17                           // pxor xmm2, [edi+0]
-  db $66, $0F, $EF, $1F                           // pxor xmm3, [edi+0]
-  db $66, $0F, $EF, $27                           // pxor xmm4, [edi+0]
-  db $66, $0F, $EF, $2F                           // pxor xmm5, [edi+0]
-  db $66, $0F, $EF, $37                           // pxor xmm6, [edi+0]
-  db $66, $0F, $EF, $3F                           // pxor xmm7, [edi+0]
-
-  // ---- rounds 1..8: aesenc, each interleaved with staging one next counter ----
+  // ---- rounds 1..8: aesenc (lanes are pre-whitened), each interleaved with
+  //      staging one next pre-whitened counter dword ----
   db $66, $0F, $38, $DC, $47, $10                 // aesenc xmm0, [edi+16]
   db $66, $0F, $38, $DC, $4F, $10                 // aesenc xmm1, [edi+16]
   db $66, $0F, $38, $DC, $57, $10                 // aesenc xmm2, [edi+16]
@@ -224,24 +138,11 @@
   db $66, $0F, $38, $DC, $6F, $10                 // aesenc xmm5, [edi+16]
   db $66, $0F, $38, $DC, $77, $10                 // aesenc xmm6, [edi+16]
   db $66, $0F, $38, $DC, $7F, $10                 // aesenc xmm7, [edi+16]
-  mov       ecx, [eax]
-  mov       [esp + 0], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 4], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 8], ecx
-  bswap     edx
-  mov       [esp + 12], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 12], ecx
   add       edx, 1
-  jnc       @@StgOkL0
-  mov       ecx, 11
-@@StgCyL0:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkL0
-  dec       ecx
-  jns       @@StgCyL0
-@@StgOkL0:
 
   db $66, $0F, $38, $DC, $47, $20                 // aesenc xmm0, [edi+32]
   db $66, $0F, $38, $DC, $4F, $20                 // aesenc xmm1, [edi+32]
@@ -251,24 +152,11 @@
   db $66, $0F, $38, $DC, $6F, $20                 // aesenc xmm5, [edi+32]
   db $66, $0F, $38, $DC, $77, $20                 // aesenc xmm6, [edi+32]
   db $66, $0F, $38, $DC, $7F, $20                 // aesenc xmm7, [edi+32]
-  mov       ecx, [eax]
-  mov       [esp + 16], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 20], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 24], ecx
-  bswap     edx
-  mov       [esp + 28], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 28], ecx
   add       edx, 1
-  jnc       @@StgOkL1
-  mov       ecx, 11
-@@StgCyL1:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkL1
-  dec       ecx
-  jns       @@StgCyL1
-@@StgOkL1:
 
   db $66, $0F, $38, $DC, $47, $30                 // aesenc xmm0, [edi+48]
   db $66, $0F, $38, $DC, $4F, $30                 // aesenc xmm1, [edi+48]
@@ -278,24 +166,11 @@
   db $66, $0F, $38, $DC, $6F, $30                 // aesenc xmm5, [edi+48]
   db $66, $0F, $38, $DC, $77, $30                 // aesenc xmm6, [edi+48]
   db $66, $0F, $38, $DC, $7F, $30                 // aesenc xmm7, [edi+48]
-  mov       ecx, [eax]
-  mov       [esp + 32], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 36], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 40], ecx
-  bswap     edx
-  mov       [esp + 44], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 44], ecx
   add       edx, 1
-  jnc       @@StgOkL2
-  mov       ecx, 11
-@@StgCyL2:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkL2
-  dec       ecx
-  jns       @@StgCyL2
-@@StgOkL2:
 
   db $66, $0F, $38, $DC, $47, $40                 // aesenc xmm0, [edi+64]
   db $66, $0F, $38, $DC, $4F, $40                 // aesenc xmm1, [edi+64]
@@ -305,24 +180,11 @@
   db $66, $0F, $38, $DC, $6F, $40                 // aesenc xmm5, [edi+64]
   db $66, $0F, $38, $DC, $77, $40                 // aesenc xmm6, [edi+64]
   db $66, $0F, $38, $DC, $7F, $40                 // aesenc xmm7, [edi+64]
-  mov       ecx, [eax]
-  mov       [esp + 48], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 52], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 56], ecx
-  bswap     edx
-  mov       [esp + 60], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 60], ecx
   add       edx, 1
-  jnc       @@StgOkL3
-  mov       ecx, 11
-@@StgCyL3:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkL3
-  dec       ecx
-  jns       @@StgCyL3
-@@StgOkL3:
 
   db $66, $0F, $38, $DC, $47, $50                 // aesenc xmm0, [edi+80]
   db $66, $0F, $38, $DC, $4F, $50                 // aesenc xmm1, [edi+80]
@@ -332,24 +194,11 @@
   db $66, $0F, $38, $DC, $6F, $50                 // aesenc xmm5, [edi+80]
   db $66, $0F, $38, $DC, $77, $50                 // aesenc xmm6, [edi+80]
   db $66, $0F, $38, $DC, $7F, $50                 // aesenc xmm7, [edi+80]
-  mov       ecx, [eax]
-  mov       [esp + 64], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 68], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 72], ecx
-  bswap     edx
-  mov       [esp + 76], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 76], ecx
   add       edx, 1
-  jnc       @@StgOkL4
-  mov       ecx, 11
-@@StgCyL4:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkL4
-  dec       ecx
-  jns       @@StgCyL4
-@@StgOkL4:
 
   db $66, $0F, $38, $DC, $47, $60                 // aesenc xmm0, [edi+96]
   db $66, $0F, $38, $DC, $4F, $60                 // aesenc xmm1, [edi+96]
@@ -359,24 +208,11 @@
   db $66, $0F, $38, $DC, $6F, $60                 // aesenc xmm5, [edi+96]
   db $66, $0F, $38, $DC, $77, $60                 // aesenc xmm6, [edi+96]
   db $66, $0F, $38, $DC, $7F, $60                 // aesenc xmm7, [edi+96]
-  mov       ecx, [eax]
-  mov       [esp + 80], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 84], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 88], ecx
-  bswap     edx
-  mov       [esp + 92], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 92], ecx
   add       edx, 1
-  jnc       @@StgOkL5
-  mov       ecx, 11
-@@StgCyL5:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkL5
-  dec       ecx
-  jns       @@StgCyL5
-@@StgOkL5:
 
   db $66, $0F, $38, $DC, $47, $70                 // aesenc xmm0, [edi+112]
   db $66, $0F, $38, $DC, $4F, $70                 // aesenc xmm1, [edi+112]
@@ -386,24 +222,11 @@
   db $66, $0F, $38, $DC, $6F, $70                 // aesenc xmm5, [edi+112]
   db $66, $0F, $38, $DC, $77, $70                 // aesenc xmm6, [edi+112]
   db $66, $0F, $38, $DC, $7F, $70                 // aesenc xmm7, [edi+112]
-  mov       ecx, [eax]
-  mov       [esp + 96], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 100], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 104], ecx
-  bswap     edx
-  mov       [esp + 108], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 108], ecx
   add       edx, 1
-  jnc       @@StgOkL6
-  mov       ecx, 11
-@@StgCyL6:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkL6
-  dec       ecx
-  jns       @@StgCyL6
-@@StgOkL6:
 
   db $66, $0F, $38, $DC, $87, $80, $00, $00, $00  // aesenc xmm0, [edi+128]
   db $66, $0F, $38, $DC, $8F, $80, $00, $00, $00  // aesenc xmm1, [edi+128]
@@ -413,24 +236,11 @@
   db $66, $0F, $38, $DC, $AF, $80, $00, $00, $00  // aesenc xmm5, [edi+128]
   db $66, $0F, $38, $DC, $B7, $80, $00, $00, $00  // aesenc xmm6, [edi+128]
   db $66, $0F, $38, $DC, $BF, $80, $00, $00, $00  // aesenc xmm7, [edi+128]
-  mov       ecx, [eax]
-  mov       [esp + 112], ecx
-  mov       ecx, [eax + 4]
-  mov       [esp + 116], ecx
-  mov       ecx, [eax + 8]
-  mov       [esp + 120], ecx
-  bswap     edx
-  mov       [esp + 124], edx
-  bswap     edx
+  mov       ecx, edx
+  bswap     ecx
+  xor       ecx, eax
+  mov       [esp + 124], ecx
   add       edx, 1
-  jnc       @@StgOkL7
-  mov       ecx, 11
-@@StgCyL7:
-  inc       byte ptr [eax + ecx]
-  jnz       @@StgOkL7
-  dec       ecx
-  jns       @@StgCyL7
-@@StgOkL7:
 
   // ---- round 9 (all key sizes): aesenc, no more staging ----
   db $66, $0F, $38, $DC, $87, $90, $00, $00, $00  // aesenc xmm0, [edi+144]
@@ -542,7 +352,7 @@
   db $66, $0F, $EF, $F8                           // pxor xmm7, xmm0
   movdqu    [esi + 112], xmm7
 
-  // ---- load the staged next-batch counters into xmm0..7 ----
+  // ---- load the staged next-batch pre-whitened counters into xmm0..7 ----
   movdqu    xmm0, [esp + 0]
   movdqu    xmm1, [esp + 16]
   movdqu    xmm2, [esp + 32]
@@ -557,17 +367,10 @@
   sub       dword ptr [esp + 144], 8
   jnz       @@CtrEightLoopI386
 
-  // ---- undo the one-batch build-ahead (edx is 8 blocks ahead); a borrow
-  //      unwinds the prefix bytes, then the low dword stores big-endian ----
+  // ---- undo the one-batch build-ahead (mod 2^32; no carry by contract),
+  //      write the low counter dword back big-endian ----
+  mov       eax, [esp + 148]                      // CounterPtr
   sub       edx, 8
-  jnc       @@CtrWbStore
-  mov       ecx, 11
-@@CtrWbBorrow:
-  sub       byte ptr [eax + ecx], 1
-  jnc       @@CtrWbStore
-  dec       ecx
-  jns       @@CtrWbBorrow
-@@CtrWbStore:
   bswap     edx
   mov       [eax + 12], edx
 

--- a/CryptoLib/src/Include/Simd/Aes/Ctr/AesNiCtrEight_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Aes/Ctr/AesNiCtrEight_x86_64.inc
@@ -8,34 +8,43 @@
 // live in xmm0..7 across the whole AES round chain, and the NEXT batch's eight
 // counter blocks are materialised (to a 128-byte stack scratch) *interleaved
 // between the aesenc rounds* of the current batch. The counter build is scalar
-// (mov / bswap / add / adc on the integer ports) so it overlaps the aesenc
+// (mov / bswap / xor on the integer ports) so it overlaps the aesenc
 // throughput (vector port) instead of serialising ahead of it. The XOR with
 // plaintext reuses xmm8 (the round-key scratch) after the final round.
+//
+// Counters are staged PRE-WHITENED: the K_0 XOR is folded into the scalar
+// counter build. The whitened base block (counter ^ K_0) is written to all
+// eight scratch slots once at entry; only the counter dword (bytes 12..15)
+// changes between blocks, so each staged lane is a 4-byte patch of
+// bswap(ctr32) ^ K_0.dword3. This removes the whole round-0 pxor pass from
+// the AES port budget, and the round chain starts directly at K_1.
 //
 // Entry (after ClpSimdProc1Begin_x86_64.inc): rcx = pointer to TCtrFusedCtx. The
 // kernel unpacks it (InPtr loaded into rcx last) into the working registers:
 //   [rcx +  0]  InPtr      -> rcx : input  (advances +128 per 8-block iteration)
 //   [rcx +  8]  OutPtr     -> rdx : output (advances +128)
 //   [rcx + 16]  KeysPtr    -> r8  : AES encrypt round-key schedule (16-byte aligned)
-//   [rcx + 24]  CounterPtr -> r9  : 16-byte big-endian counter (updated in place)
+//   [rcx + 24]  CounterPtr -> r9  : 16-byte big-endian counter (low dword updated in place)
 //   [rcx + 32]  BlockCount -> r10 : positive multiple of 8 (caller guarantees it)
+//
+// Counter contract: the caller guarantees the low-32 counter dword does NOT
+// wrap within the call (ctr32 + BlockCount <= 2^32) - TAesNiCtrKernel splits
+// runs at the 2^32 boundary and propagates the carry into the upper 12 bytes
+// in Pascal. The kernel therefore carries no in-loop carry logic and never
+// touches counter bytes 0..11; only the low dword is stored back. The
+// pipeline builds one batch ahead, so ebx over-runs by exactly 8 - undone
+// (modulo 2^32) before write-back.
 //
 // Exactly one of CRYPTOLIB_AESNI_KEY128 / KEY192 / KEY256 must be defined; the
 // direction is always encrypt (CTR keystream), so CRYPTOLIB_AESNI_DECRYPT must
 // NOT be defined when including this file.
 //
-// The 128-bit counter is held as r11 (high 64 bits, KEPT big-endian since the
-// fast path only stores it) : rbx (low 64 bits, native-LE). Each staged block
-// writes r11 || bswap(rbx) to the scratch and bumps rbx; a low-half carry-out
-// (once per 2^64 blocks) increments r11 through a bswap round-trip, matching
-// SIC's big-endian whole-counter increment. The pipeline builds one batch ahead, so on exit the counter has
-// over-run by exactly one batch (8) - undone before write-back.
-//
-// Register/stack notes: rbx is callee-saved (push/pop). xmm6-15 are saved once
-// via the shared core (xmm8 is the round-key / plaintext-XOR scratch). A 128-byte
-// stack scratch below the xmm save area holds the next batch's counter blocks.
-// AES-NI instructions and pxor forms touching xmm8 are db-encoded for broad
-// assembler compatibility.
+// Register/stack notes: rbx is callee-saved (push/pop); ebx = counter low dword
+// native-LE, r11d = K_0.dword3 (whitening constant), rax = staging scratch.
+// xmm6-15 are saved once via the shared core (xmm8 is the round-key /
+// plaintext-XOR scratch). A 128-byte stack scratch below the xmm save area
+// holds the next batch's pre-whitened counter blocks. AES-NI instructions and
+// pxor forms touching xmm8 are db-encoded for broad assembler compatibility.
   push      rbx
 {$I ..\..\..\Include\Simd\Common\ClpSimdNonVolatileSave_x86_64.inc}
   sub       rsp, 128                              // next-batch counter scratch: [rsp+0..127]
@@ -47,91 +56,64 @@
   mov       rdx, [rcx + 8]                        // OutPtr
   mov       rcx, [rcx + 0]                        // InPtr (overwrites PCtx)
 
-  mov       r11, [r9]                             // counter high 64 bits, KEPT big-endian (store-only)
-  mov       rbx, [r9 + 8]                         // counter low 64 bits, native-LE in rbx
-  bswap     rbx
+  // ---- whitened base block (counter ^ K_0) into all 8 scratch slots ----
+  movdqu    xmm0, [r9]                            // counter block
+  movdqa    xmm8, [r8]                            // K_0
+  db $66, $41, $0F, $EF, $C0                      // pxor xmm0, xmm8
+  movdqu    [rsp], xmm0
+  movdqu    [rsp + 16], xmm0
+  movdqu    [rsp + 32], xmm0
+  movdqu    [rsp + 48], xmm0
+  movdqu    [rsp + 64], xmm0
+  movdqu    [rsp + 80], xmm0
+  movdqu    [rsp + 96], xmm0
+  movdqu    [rsp + 112], xmm0
 
-  // ---- stage batch 0 into the scratch, then load it into xmm0..7 ----
-  mov       [rsp + 0], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 8], rax
-  add       rbx, 1
-  jnc       @@StgOk0
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk0:
-  mov       [rsp + 16], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 24], rax
-  add       rbx, 1
-  jnc       @@StgOk1
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk1:
-  mov       [rsp + 32], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 40], rax
-  add       rbx, 1
-  jnc       @@StgOk2
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk2:
-  mov       [rsp + 48], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 56], rax
-  add       rbx, 1
-  jnc       @@StgOk3
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk3:
-  mov       [rsp + 64], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 72], rax
-  add       rbx, 1
-  jnc       @@StgOk4
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk4:
-  mov       [rsp + 80], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 88], rax
-  add       rbx, 1
-  jnc       @@StgOk5
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk5:
-  mov       [rsp + 96], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 104], rax
-  add       rbx, 1
-  jnc       @@StgOk6
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk6:
-  mov       [rsp + 112], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 120], rax
-  add       rbx, 1
-  jnc       @@StgOk7
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk7:
+  mov       ebx, [r9 + 12]                        // counter low dword (big-endian in memory)
+  bswap     ebx                                   // native-LE in ebx
+  mov       r11d, [r8 + 12]                       // K_0.dword3 whitening constant
+
+  // ---- stage batch 0: patch the whitened counter dword of each slot ----
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 12], eax
+  add       ebx, 1
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 28], eax
+  add       ebx, 1
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 44], eax
+  add       ebx, 1
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 60], eax
+  add       ebx, 1
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 76], eax
+  add       ebx, 1
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 92], eax
+  add       ebx, 1
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 108], eax
+  add       ebx, 1
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 124], eax
+  add       ebx, 1
 
   movdqu    xmm0, [rsp]
   movdqu    xmm1, [rsp + 16]
@@ -143,18 +125,8 @@
   movdqu    xmm7, [rsp + 112]
 
 @@CtrEightLoop:
-  // ---- round 0: whiten with K_0 ----
-  movdqa    xmm8, [r8]
-  db $66, $41, $0F, $EF, $C0                      // pxor xmm0, xmm8
-  db $66, $41, $0F, $EF, $C8                      // pxor xmm1, xmm8
-  db $66, $41, $0F, $EF, $D0                      // pxor xmm2, xmm8
-  db $66, $41, $0F, $EF, $D8                      // pxor xmm3, xmm8
-  db $66, $41, $0F, $EF, $E0                      // pxor xmm4, xmm8
-  db $66, $41, $0F, $EF, $E8                      // pxor xmm5, xmm8
-  db $66, $41, $0F, $EF, $F0                      // pxor xmm6, xmm8
-  db $66, $41, $0F, $EF, $F8                      // pxor xmm7, xmm8
-
-  // ---- rounds 1..8: aesenc, each interleaved with staging one next counter ----
+  // ---- rounds 1..8: aesenc (lanes are pre-whitened), each interleaved with
+  //      staging one next pre-whitened counter dword ----
   movdqa    xmm8, [r8 + 16]
   db $66, $41, $0F, $38, $DC, $C0                 // aesenc xmm0, xmm8
   db $66, $41, $0F, $38, $DC, $C8                 // aesenc xmm1, xmm8
@@ -164,16 +136,11 @@
   db $66, $41, $0F, $38, $DC, $E8                 // aesenc xmm5, xmm8
   db $66, $41, $0F, $38, $DC, $F0                 // aesenc xmm6, xmm8
   db $66, $41, $0F, $38, $DC, $F8                 // aesenc xmm7, xmm8
-  mov       [rsp + 0], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 8], rax
-  add       rbx, 1
-  jnc       @@StgOk8
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk8:
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 12], eax
+  add       ebx, 1
 
   movdqa    xmm8, [r8 + 32]
   db $66, $41, $0F, $38, $DC, $C0                 // aesenc xmm0, xmm8
@@ -184,16 +151,11 @@
   db $66, $41, $0F, $38, $DC, $E8                 // aesenc xmm5, xmm8
   db $66, $41, $0F, $38, $DC, $F0                 // aesenc xmm6, xmm8
   db $66, $41, $0F, $38, $DC, $F8                 // aesenc xmm7, xmm8
-  mov       [rsp + 16], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 24], rax
-  add       rbx, 1
-  jnc       @@StgOk9
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk9:
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 28], eax
+  add       ebx, 1
 
   movdqa    xmm8, [r8 + 48]
   db $66, $41, $0F, $38, $DC, $C0                 // aesenc xmm0, xmm8
@@ -204,16 +166,11 @@
   db $66, $41, $0F, $38, $DC, $E8                 // aesenc xmm5, xmm8
   db $66, $41, $0F, $38, $DC, $F0                 // aesenc xmm6, xmm8
   db $66, $41, $0F, $38, $DC, $F8                 // aesenc xmm7, xmm8
-  mov       [rsp + 32], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 40], rax
-  add       rbx, 1
-  jnc       @@StgOk10
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk10:
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 44], eax
+  add       ebx, 1
 
   movdqa    xmm8, [r8 + 64]
   db $66, $41, $0F, $38, $DC, $C0                 // aesenc xmm0, xmm8
@@ -224,16 +181,11 @@
   db $66, $41, $0F, $38, $DC, $E8                 // aesenc xmm5, xmm8
   db $66, $41, $0F, $38, $DC, $F0                 // aesenc xmm6, xmm8
   db $66, $41, $0F, $38, $DC, $F8                 // aesenc xmm7, xmm8
-  mov       [rsp + 48], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 56], rax
-  add       rbx, 1
-  jnc       @@StgOk11
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk11:
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 60], eax
+  add       ebx, 1
 
   movdqa    xmm8, [r8 + 80]
   db $66, $41, $0F, $38, $DC, $C0                 // aesenc xmm0, xmm8
@@ -244,16 +196,11 @@
   db $66, $41, $0F, $38, $DC, $E8                 // aesenc xmm5, xmm8
   db $66, $41, $0F, $38, $DC, $F0                 // aesenc xmm6, xmm8
   db $66, $41, $0F, $38, $DC, $F8                 // aesenc xmm7, xmm8
-  mov       [rsp + 64], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 72], rax
-  add       rbx, 1
-  jnc       @@StgOk12
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk12:
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 76], eax
+  add       ebx, 1
 
   movdqa    xmm8, [r8 + 96]
   db $66, $41, $0F, $38, $DC, $C0                 // aesenc xmm0, xmm8
@@ -264,16 +211,11 @@
   db $66, $41, $0F, $38, $DC, $E8                 // aesenc xmm5, xmm8
   db $66, $41, $0F, $38, $DC, $F0                 // aesenc xmm6, xmm8
   db $66, $41, $0F, $38, $DC, $F8                 // aesenc xmm7, xmm8
-  mov       [rsp + 80], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 88], rax
-  add       rbx, 1
-  jnc       @@StgOk13
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk13:
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 92], eax
+  add       ebx, 1
 
   movdqa    xmm8, [r8 + 112]
   db $66, $41, $0F, $38, $DC, $C0                 // aesenc xmm0, xmm8
@@ -284,16 +226,11 @@
   db $66, $41, $0F, $38, $DC, $E8                 // aesenc xmm5, xmm8
   db $66, $41, $0F, $38, $DC, $F0                 // aesenc xmm6, xmm8
   db $66, $41, $0F, $38, $DC, $F8                 // aesenc xmm7, xmm8
-  mov       [rsp + 96], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 104], rax
-  add       rbx, 1
-  jnc       @@StgOk14
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk14:
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 108], eax
+  add       ebx, 1
 
   movdqa    xmm8, [r8 + 128]
   db $66, $41, $0F, $38, $DC, $C0                 // aesenc xmm0, xmm8
@@ -304,16 +241,11 @@
   db $66, $41, $0F, $38, $DC, $E8                 // aesenc xmm5, xmm8
   db $66, $41, $0F, $38, $DC, $F0                 // aesenc xmm6, xmm8
   db $66, $41, $0F, $38, $DC, $F8                 // aesenc xmm7, xmm8
-  mov       [rsp + 112], r11
-  mov       rax, rbx
-  bswap     rax
-  mov       [rsp + 120], rax
-  add       rbx, 1
-  jnc       @@StgOk15
-  bswap     r11
-  add       r11, 1
-  bswap     r11
-@@StgOk15:
+  mov       eax, ebx
+  bswap     eax
+  xor       eax, r11d
+  mov       [rsp + 124], eax
+  add       ebx, 1
 
   // ---- round 9 (all key sizes): aesenc, no more staging ----
   movdqa    xmm8, [r8 + 144]
@@ -413,7 +345,7 @@
   db $66, $41, $0F, $EF, $F8                      // pxor xmm7, xmm8
   movdqu    [rdx + 112], xmm7
 
-  // ---- load the staged next-batch counters into xmm0..7 ----
+  // ---- load the staged next-batch pre-whitened counters into xmm0..7 ----
   movdqu    xmm0, [rsp]
   movdqu    xmm1, [rsp + 16]
   movdqu    xmm2, [rsp + 32]
@@ -428,16 +360,11 @@
   sub       r10, 8
   jnz       @@CtrEightLoop
 
-  // ---- undo the one-batch build-ahead, write the counter back (big-endian) ----
-  sub       rbx, 8
-  jnc       @@CtrWbStore
-  bswap     r11
-  sub       r11, 1
-  bswap     r11
-@@CtrWbStore:
-  mov       [r9], r11
-  bswap     rbx
-  mov       [r9 + 8], rbx
+  // ---- undo the one-batch build-ahead (mod 2^32; no carry by contract),
+  //      write the low counter dword back big-endian ----
+  sub       ebx, 8
+  bswap     ebx
+  mov       [r9 + 12], ebx
 
   add       rsp, 128
 {$I ..\..\..\Include\Simd\Common\ClpSimdNonVolatileRestore_x86_64.inc}


### PR DESCRIPTION
Fold the K_0 whitening into the scalar counter staging of both AesNiCtrEight kernels: the whitened base block (counter ^ K_0) is written to the stack scratch once per call, and each staged lane becomes a single 4-byte patch of bswap(ctr32) ^ K_0.dword3. This deletes the whole round-0 pxor pass from the AES port budget (the round chain now starts at K_1) and all in-asm carry logic - the x86-64 bswap/add/jnc chains and the i386 byte-wise carry loops plus the 12-byte prefix copy per staged lane (11 -> 5 instructions).

The kernels now require that the low-32 counter dword not wrap within one call; TAesNiCtrKernel.ProcessCtrBlocks enforces this by splitting runs at the 2^32 boundary, propagating the carry into the upper 12 bytes in Pascal, and bridging a boundary-crossing batch block-at-a-time through the engine (at most once per 2^32 blocks). Observable semantics are unchanged: the counter remains a full 128-bit big-endian integer and the keystream is byte-identical. SP 800-38A does not mandate an increment width, so the boundary split is purely an implementation detail of the hot loop.

The new counter-wrap parity tests exposed a pre-existing bug in TSicBlockCipher itself: the big-endian counter increment (ProcessBlock and FillNextCounterBlocks) walked its carry loop one step too far, writing FCounter[-1] on a full 128-bit wrap - reachable through the public API with a legal 16-byte IV; an access violation on i386, a silent one-byte heap corruption on x86_64. Guarded the loop with (FCounter[LJ] = 0) and (LJ > 0) so a full wrap returns the counter to zero without underflowing.

Tests: TTestSicBulkParity gains engine-agnostic wrap-parity cases (RunWrapCasesForEngine) covering batch-aligned splits, mid-batch bridging, multi-byte carry cascades, and the full 128-bit wrap, run against both the AES-NI and scalar AES engines.