### PR TITLE
Consolidate scattered config knobs into TCryptoLibConfig

### DIFF
--- a/CryptoLib.Tests/src/Asn1/Asn1IntegerTests.pas
+++ b/CryptoLib.Tests/src/Asn1/Asn1IntegerTests.pas
@@ -32,6 +32,7 @@ uses
   ClpAsn1Objects,
   ClpIAsn1Objects,
   ClpBigInteger,
+  ClpCryptoLibConfig,
   ClpEncoders,
   ClpCryptoLibTypes,
   CryptoLibTestBase;
@@ -95,6 +96,7 @@ end;
 
 procedure TAsn1IntegerTest.TearDown;
 begin
+  TCryptoLibConfig.Asn1.ResetToDefaults();
   FSuspectKey := nil;
   inherited;
 end;
@@ -147,7 +149,7 @@ var
   LRawInt: TCryptoLibByteArray;
   LInteger: IDerInteger;
 begin
-  TDerInteger.AllowUnsafeInteger := False;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := False;
   try
     LRawInt := DecodeHex('0010FF');
     LInteger := TDerInteger.Create(LRawInt);
@@ -165,7 +167,7 @@ procedure TAsn1IntegerTest.TestInvalidEncoding_00_32Bits;
 var
   LRawInt: TCryptoLibByteArray;
 begin
-  TDerInteger.AllowUnsafeInteger := False;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := False;
 
   try
     LRawInt := DecodeHex('0000000010FF');
@@ -183,7 +185,7 @@ procedure TAsn1IntegerTest.TestInvalidEncoding_FF;
 var
   LRawInt: TCryptoLibByteArray;
 begin
-  TDerInteger.AllowUnsafeInteger := False;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := False;
 
   try
     LRawInt := DecodeHex('FF81FF');
@@ -201,7 +203,7 @@ procedure TAsn1IntegerTest.TestInvalidEncoding_FF_32Bits;
 var
   LRawInt: TCryptoLibByteArray;
 begin
-  TDerInteger.AllowUnsafeInteger := False;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := False;
 
   try
     LRawInt := DecodeHex('FFFFFFFF01FF');
@@ -220,7 +222,7 @@ var
   LRawInt: TCryptoLibByteArray;
   LInteger: IDerInteger;
 begin
-  TDerInteger.AllowUnsafeInteger := True;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := True;
   LRawInt := DecodeHex('FFFFFF10FF000000');
   LInteger := TDerInteger.Create(LRawInt);
   CheckLongValue(LInteger, -1026513960960);
@@ -231,7 +233,7 @@ var
   LRawInt: TCryptoLibByteArray;
   LInteger: IDerInteger;
 begin
-  TDerInteger.AllowUnsafeInteger := True;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := True;
   LRawInt := DecodeHex('FFFEFF10FF000000');
   LInteger := TDerInteger.Create(LRawInt);
   CheckLongValue(LInteger, -282501490671616);
@@ -242,7 +244,7 @@ var
   LRawInt: TCryptoLibByteArray;
   LInteger: IDerInteger;
 begin
-  TDerInteger.AllowUnsafeInteger := True;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := True;
   LRawInt := DecodeHex('FFFFFE10FF000000');
   LInteger := TDerInteger.Create(LRawInt);
   CheckLongValue(LInteger, -2126025588736);
@@ -253,7 +255,7 @@ var
   LRawInt: TCryptoLibByteArray;
   LInteger: IDerInteger;
 begin
-  TDerInteger.AllowUnsafeInteger := True;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := True;
   LRawInt := DecodeHex('00000010FF000000');
   LInteger := TDerInteger.Create(LRawInt);
   CheckLongValue(LInteger, 72997666816);
@@ -265,7 +267,7 @@ var
   LInteger: IDerInteger;
   LBigInteger: TBigInteger;
 begin
-  TDerInteger.AllowUnsafeInteger := True;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := True;
   LRawInt := DecodeHex('FFFFFFFE10FF000000000000');
   LInteger := TDerInteger.Create(LRawInt);
   LBigInteger := TBigInteger.Create(DecodeHex('FFFFFFFE10FF000000000000'));
@@ -287,13 +289,13 @@ var
   LRawInt: TCryptoLibByteArray;
   LInteger: IDerInteger;
 begin
-  TDerInteger.AllowUnsafeInteger := False;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := False;
 
   LRawInt := DecodeHex('10FF');
   LInteger := TDerInteger.Create(LRawInt);
   CheckIntValue(LInteger, 4351);
 
-  TDerInteger.AllowUnsafeInteger := True;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := True;
 
   LRawInt := DecodeHex('10FF');
   LInteger := TDerInteger.Create(LRawInt);
@@ -305,13 +307,13 @@ var
   LRawInt: TCryptoLibByteArray;
   LInteger: IDerInteger;
 begin
-  TDerInteger.AllowUnsafeInteger := False;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := False;
 
   LRawInt := DecodeHex('10');
   LInteger := TDerInteger.Create(LRawInt);
   CheckIntValue(LInteger, 16);
 
-  TDerInteger.AllowUnsafeInteger := True;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := True;
 
   LRawInt := DecodeHex('10');
   LInteger := TDerInteger.Create(LRawInt);
@@ -320,7 +322,7 @@ end;
 
 procedure TAsn1IntegerTest.TestSuspectKeySequence;
 begin
-  TDerInteger.AllowUnsafeInteger := True;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := True;
   TAsn1Sequence.GetInstance(FSuspectKey);
 end;
 
@@ -328,7 +330,7 @@ procedure TAsn1IntegerTest.TestLargeIntegerWithUnsafeAllowed;
 var
   LInteger: IDerInteger;
 begin
-  TDerInteger.AllowUnsafeInteger := True;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := True;
   LInteger := TDerInteger.Create(DecodeHex
     ('ffda47bfc776bcd269da4832626ac332adfca6dd835e8ecd83cd1ebe7d709b0e'));
 end;
@@ -337,7 +339,7 @@ procedure TAsn1IntegerTest.TestLargeEnumeratedWithUnsafeAllowed;
 var
   LEnumerated: IDerEnumerated;
 begin
-  TDerInteger.AllowUnsafeInteger := True;
+  TCryptoLibConfig.Asn1.AllowUnsafeInteger := True;
   LEnumerated := TDerEnumerated.Create(DecodeHex
     ('005a47bfc776bcd269da4832626ac332adfca6dd835e8ecd83cd1ebe7d709b0e'));
 end;
@@ -346,9 +348,9 @@ procedure TAsn1IntegerTest.TestLargeIntegerWithUnsafeDisabled;
 var
   LOriginalValue: Boolean;
 begin
-  LOriginalValue := TDerInteger.AllowUnsafeInteger;
+  LOriginalValue := TCryptoLibConfig.Asn1.AllowUnsafeInteger;
   try
-    TDerInteger.AllowUnsafeInteger := False;
+    TCryptoLibConfig.Asn1.AllowUnsafeInteger := False;
 
     try
       TDerInteger.Create(DecodeHex
@@ -362,7 +364,7 @@ begin
       end;
     end;
   finally
-    TDerInteger.AllowUnsafeInteger := LOriginalValue;
+    TCryptoLibConfig.Asn1.AllowUnsafeInteger := LOriginalValue;
   end;
 end;
 
@@ -370,9 +372,9 @@ procedure TAsn1IntegerTest.TestSuspectKeySequenceWithUnsafeDisabled;
 var
   LOriginalValue: Boolean;
 begin
-  LOriginalValue := TDerInteger.AllowUnsafeInteger;
+  LOriginalValue := TCryptoLibConfig.Asn1.AllowUnsafeInteger;
   try
-    TDerInteger.AllowUnsafeInteger := False;
+    TCryptoLibConfig.Asn1.AllowUnsafeInteger := False;
 
     try
       TAsn1Sequence.GetInstance(FSuspectKey);
@@ -386,7 +388,7 @@ begin
       end;
     end;
   finally
-    TDerInteger.AllowUnsafeInteger := LOriginalValue;
+    TCryptoLibConfig.Asn1.AllowUnsafeInteger := LOriginalValue;
   end;
 end;
 
@@ -394,9 +396,9 @@ procedure TAsn1IntegerTest.TestLargeIntegerWithUnsafeDisabled2;
 var
   LOriginalValue: Boolean;
 begin
-  LOriginalValue := TDerInteger.AllowUnsafeInteger;
+  LOriginalValue := TCryptoLibConfig.Asn1.AllowUnsafeInteger;
   try
-    TDerInteger.AllowUnsafeInteger := False;
+    TCryptoLibConfig.Asn1.AllowUnsafeInteger := False;
 
     try
       TDerInteger.Create(DecodeHex
@@ -410,7 +412,7 @@ begin
       end;
     end;
   finally
-    TDerInteger.AllowUnsafeInteger := LOriginalValue;
+    TCryptoLibConfig.Asn1.AllowUnsafeInteger := LOriginalValue;
   end;
 end;
 
@@ -418,9 +420,9 @@ procedure TAsn1IntegerTest.TestLargeEnumeratedWithUnsafeDisabled;
 var
   LOriginalValue: Boolean;
 begin
-  LOriginalValue := TDerInteger.AllowUnsafeInteger;
+  LOriginalValue := TCryptoLibConfig.Asn1.AllowUnsafeInteger;
   try
-    TDerInteger.AllowUnsafeInteger := False;
+    TCryptoLibConfig.Asn1.AllowUnsafeInteger := False;
 
     try
       TDerEnumerated.Create(DecodeHex
@@ -434,7 +436,7 @@ begin
       end;
     end;
   finally
-    TDerInteger.AllowUnsafeInteger := LOriginalValue;
+    TCryptoLibConfig.Asn1.AllowUnsafeInteger := LOriginalValue;
   end;
 end;
 
@@ -442,9 +444,9 @@ procedure TAsn1IntegerTest.TestLargeEnumeratedWithUnsafeDisabled2;
 var
   LOriginalValue: Boolean;
 begin
-  LOriginalValue := TDerInteger.AllowUnsafeInteger;
+  LOriginalValue := TCryptoLibConfig.Asn1.AllowUnsafeInteger;
   try
-    TDerInteger.AllowUnsafeInteger := False;
+    TCryptoLibConfig.Asn1.AllowUnsafeInteger := False;
 
     try
       TDerEnumerated.Create(DecodeHex
@@ -458,7 +460,7 @@ begin
       end;
     end;
   finally
-    TDerInteger.AllowUnsafeInteger := LOriginalValue;
+    TCryptoLibConfig.Asn1.AllowUnsafeInteger := LOriginalValue;
   end;
 end;
 

--- a/CryptoLib.Tests/src/Asn1/Asn1SequenceParserTests.pas
+++ b/CryptoLib.Tests/src/Asn1/Asn1SequenceParserTests.pas
@@ -600,78 +600,64 @@ end;
 
 procedure TTestAsn1SequenceParser.TestMaximumConstructedNestingDerExceedsLimit;
 var
-  LOldMaxDepth: Int32;
-  LI: Int32;
+  LMaxDepth, LI: Int32;
   LInner: IAsn1Encodable;
   LVec: IAsn1EncodableVector;
   LData: TCryptoLibByteArray;
 begin
-  LOldMaxDepth := TAsn1InputStream.MaxConstructedDepth;
+  LMaxDepth := TAsn1InputStream.FindDepth;
+
+  LInner := TDerInteger.ValueOf(0);
+  for LI := 1 to LMaxDepth + 1 do
+  begin
+    LVec := TAsn1EncodableVector.Create();
+    LVec.Add(LInner);
+    LInner := TDerSequence.FromVector(LVec);
+  end;
+  LData := LInner.GetDerEncoded();
+
   try
-    TAsn1InputStream.MaxConstructedDepth :=
-      TAsn1InputStream.DefaultMaxConstructedDepth;
-
-    LInner := TDerInteger.ValueOf(0);
-    for LI := 1 to TAsn1InputStream.DefaultMaxConstructedDepth + 1 do
-    begin
-      LVec := TAsn1EncodableVector.Create();
-      LVec.Add(LInner);
-      LInner := TDerSequence.FromVector(LVec);
-    end;
-    LData := LInner.GetDerEncoded();
-
-    try
-      TAsn1Object.FromByteArray(LData);
-      Fail('expected EAsn1ParsingCryptoLibException');
-    except
-      on E: EAsn1ParsingCryptoLibException do
-        CheckEquals('maximum nested construction level reached', E.Message);
-    end;
-  finally
-    TAsn1InputStream.MaxConstructedDepth := LOldMaxDepth;
+    TAsn1Object.FromByteArray(LData);
+    Fail('expected EAsn1ParsingCryptoLibException');
+  except
+    on E: EAsn1ParsingCryptoLibException do
+      CheckEquals('maximum nested construction level reached', E.Message);
   end;
 end;
 
 procedure TTestAsn1SequenceParser.TestMaximumConstructedNestingBerIndefiniteExceedsLimit;
 var
-  LOldMaxDepth: Int32;
-  LI, LJ, LCl, LNewLen: Int32;
+  LMaxDepth, LI, LJ, LCl, LNewLen: Int32;
   LCore: TCryptoLibByteArray;
   LData: TCryptoLibByteArray;
 begin
-  LOldMaxDepth := TAsn1InputStream.MaxConstructedDepth;
+  LMaxDepth := TAsn1InputStream.FindDepth;
+
+  System.SetLength(LCore, 3);
+  LCore[0] := $02;
+  LCore[1] := $01;
+  LCore[2] := $00;
+
+  for LI := 1 to LMaxDepth + 1 do
+  begin
+    LCl := System.Length(LCore);
+    LNewLen := 2 + LCl + 2;
+    System.SetLength(LData, LNewLen);
+    LData[0] := $30;
+    LData[1] := $80;
+    for LJ := 0 to LCl - 1 do
+      LData[2 + LJ] := LCore[LJ];
+    LData[2 + LCl] := 0;
+    LData[2 + LCl + 1] := 0;
+    LCore := LData;
+  end;
+
   try
-    TAsn1InputStream.MaxConstructedDepth :=
-      TAsn1InputStream.DefaultMaxConstructedDepth;
-
-    System.SetLength(LCore, 3);
-    LCore[0] := $02;
-    LCore[1] := $01;
-    LCore[2] := $00;
-
-    for LI := 1 to TAsn1InputStream.DefaultMaxConstructedDepth + 1 do
-    begin
-      LCl := System.Length(LCore);
-      LNewLen := 2 + LCl + 2;
-      System.SetLength(LData, LNewLen);
-      LData[0] := $30;
-      LData[1] := $80;
-      for LJ := 0 to LCl - 1 do
-        LData[2 + LJ] := LCore[LJ];
-      LData[2 + LCl] := 0;
-      LData[2 + LCl + 1] := 0;
-      LCore := LData;
-    end;
-
-    try
-      TAsn1Object.FromByteArray(LCore);
-      Fail('expected EAsn1ParsingCryptoLibException');
-    except
-      on E: EAsn1ParsingCryptoLibException do
-        CheckEquals('maximum nested construction level reached', E.Message);
-    end;
-  finally
-    TAsn1InputStream.MaxConstructedDepth := LOldMaxDepth;
+    TAsn1Object.FromByteArray(LCore);
+    Fail('expected EAsn1ParsingCryptoLibException');
+  except
+    on E: EAsn1ParsingCryptoLibException do
+      CheckEquals('maximum nested construction level reached', E.Message);
   end;
 end;
 

--- a/CryptoLib.Tests/src/Asn1/InputStreamTests.pas
+++ b/CryptoLib.Tests/src/Asn1/InputStreamTests.pas
@@ -35,6 +35,7 @@ uses
   ClpIAsn1Objects,
   ClpIAsn1Core,
   ClpAsn1Streams,
+  ClpCryptoLibConfig,
   ClpStreams,
   ClpEncoders,
   ClpCryptoLibTypes,
@@ -104,6 +105,7 @@ end;
 
 procedure TInputStreamTest.TearDown;
 begin
+  TCryptoLibConfig.Asn1.ResetToDefaults();
   FOutOfBoundsLength := nil;
   FNegativeLength := nil;
   FOutsideLimitLength := nil;
@@ -220,9 +222,9 @@ var
   LDummy: TDummyStreamWithoutKnownLimit;
   LAIn: TAsn1InputStream;
 begin
-  LSaved := TAsn1InputStream.MaxLimitForUnknownStream;
+  LSaved := TCryptoLibConfig.Asn1.MaxLimit;
   try
-    TAsn1InputStream.MaxLimitForUnknownStream := 1024;
+    TCryptoLibConfig.Asn1.MaxLimit := 1024;
     LDummy := TDummyStreamWithoutKnownLimit.Create;
     LAIn := TAsn1InputStream.Create(LDummy);
     try
@@ -231,7 +233,7 @@ begin
       LAIn.Free;
     end;
 
-    TAsn1InputStream.MaxLimitForUnknownStream := LSaved;
+    TCryptoLibConfig.Asn1.MaxLimit := LSaved;
 
     LDummy := TDummyStreamWithoutKnownLimit.Create;
     LAIn := TAsn1InputStream.Create(LDummy);
@@ -241,7 +243,7 @@ begin
       LAIn.Free;
     end;
   finally
-    TAsn1InputStream.MaxLimitForUnknownStream := LSaved;
+    TCryptoLibConfig.Asn1.MaxLimit := LSaved;
   end;
 end;
 
@@ -250,9 +252,9 @@ var
   LSaved: Int32;
   LDummy: TDummyStreamWithoutKnownLimit;
 begin
-  LSaved := TAsn1InputStream.MaxLimitForUnknownStream;
+  LSaved := TCryptoLibConfig.Asn1.MaxLimit;
   try
-    TAsn1InputStream.MaxLimitForUnknownStream := -10;
+    TCryptoLibConfig.Asn1.MaxLimit := -10;
     LDummy := TDummyStreamWithoutKnownLimit.Create();
     try
       CheckEquals(0, TAsn1InputStream.FindLimit(LDummy));
@@ -260,7 +262,7 @@ begin
       LDummy.Free;
     end;
   finally
-    TAsn1InputStream.MaxLimitForUnknownStream := LSaved;
+    TCryptoLibConfig.Asn1.MaxLimit := LSaved;
   end;
 end;
 

--- a/CryptoLib.Tests/src/Crypto/RSATests.pas
+++ b/CryptoLib.Tests/src/Crypto/RSATests.pas
@@ -31,6 +31,7 @@ uses
   TestFramework,
 {$ENDIF FPC}
   ClpBigInteger,
+  ClpCryptoLibConfig,
   ClpIRsaParameters,
   ClpRsaParameters,
   ClpIRsaGenerators,
@@ -392,13 +393,9 @@ begin
 end;
 
 procedure TTestRSA.TestMaxSizeRejectsOversizedModulus;
-var
-  LOldMaxSize, LOldMaxMRTests: Int32;
 begin
-  LOldMaxSize := TRsaKeyParameters.MaxSize;
-  LOldMaxMRTests := TRsaKeyParameters.MaxMRTests;
   try
-    TRsaKeyParameters.MaxSize := 512;
+    TCryptoLibConfig.Rsa.MaxSize := 512;
     CheckTrue(FPubParams.Modulus.BitLength > 512, 'test modulus must exceed MaxSize cap');
     try
       TRsaKeyParameters.Create(False, FPubParams.Modulus, FPubParams.Exponent);
@@ -408,46 +405,36 @@ begin
         CheckEquals('RSA modulus out of range', E.Message);
     end;
   finally
-    TRsaKeyParameters.MaxSize := LOldMaxSize;
-    TRsaKeyParameters.MaxMRTests := LOldMaxMRTests;
+    TCryptoLibConfig.Rsa.ResetToDefaults();
   end;
 end;
 
 procedure TTestRSA.TestMaxMRTestsZeroSkipsCompositeCheck;
 var
-  LOldMaxSize, LOldMaxMRTests: Int32;
   LParams: IRsaKeyParameters;
 begin
-  LOldMaxSize := TRsaKeyParameters.MaxSize;
-  LOldMaxMRTests := TRsaKeyParameters.MaxMRTests;
   try
-    TRsaKeyParameters.MaxMRTests := 0;
+    TCryptoLibConfig.Rsa.MaxMRTests := 0;
     LParams := TRsaKeyParameters.Create(False, FPubParams.Modulus, FPubParams.Exponent);
     CheckTrue(LParams.Modulus.Equals(FPubParams.Modulus), 'modulus should be accepted when MR is disabled');
   finally
-    TRsaKeyParameters.MaxSize := LOldMaxSize;
-    TRsaKeyParameters.MaxMRTests := LOldMaxMRTests;
+    TCryptoLibConfig.Rsa.ResetToDefaults();
   end;
 end;
 
 procedure TTestRSA.TestMaxSizeMaxMRTestsUnsetDefault;
 var
-  LOldMaxSize, LOldMaxMRTests: Int32;
   LParams: IRsaKeyParameters;
 begin
-  LOldMaxSize := TRsaKeyParameters.MaxSize;
-  LOldMaxMRTests := TRsaKeyParameters.MaxMRTests;
   try
-    TRsaKeyParameters.MaxSize := -1;
-    TRsaKeyParameters.MaxMRTests := -1;
-    CheckEquals(-1, TRsaKeyParameters.MaxSize, 'unset MaxSize should be -1');
-    CheckEquals(-1, TRsaKeyParameters.MaxMRTests, 'unset MaxMRTests should be -1');
+    TCryptoLibConfig.Rsa.ResetToDefaults();
+    CheckFalse(TCryptoLibConfig.Rsa.MaxMRTests.HasValue,
+      'unset MaxMRTests should have no value');
     LParams := TRsaKeyParameters.Create(False, FPubParams.Modulus, FPubParams.Exponent);
     CheckTrue(LParams.Modulus.Equals(FPubParams.Modulus),
       'default limits should accept standard test modulus');
   finally
-    TRsaKeyParameters.MaxSize := LOldMaxSize;
-    TRsaKeyParameters.MaxMRTests := LOldMaxMRTests;
+    TCryptoLibConfig.Rsa.ResetToDefaults();
   end;
 end;
 

--- a/CryptoLib.Tests/src/Pkcs/PkcsEncryptedPrivateKeyInfoTests.pas
+++ b/CryptoLib.Tests/src/Pkcs/PkcsEncryptedPrivateKeyInfoTests.pas
@@ -45,6 +45,7 @@ uses
   ClpPrivateKeyInfoFactory,
   ClpPrivateKeyFactory,
   ClpPbeUtilities,
+  ClpCryptoLibConfig,
   ClpAsn1Objects,
   ClpIPkcsAsn1Objects,
   ClpPkcsAsn1Objects,
@@ -90,6 +91,7 @@ end;
 
 procedure TTestPkcsEncryptedPrivateKeyInfo.TearDown;
 begin
+  TCryptoLibConfig.Pbe.ResetToDefaults();
   inherited;
 end;
 
@@ -236,9 +238,9 @@ begin
     TNistObjectIdentifiers.IdAes256Cbc, TPkcsObjectIdentifiers.IdHmacWithSha256,
     LPassword, LSalt, 2048, TSecureRandom.Create() as ISecureRandom, LPlain);
 
-  LOldMax := TPbeUtilities.MaxIterationCount;
+  LOldMax := TCryptoLibConfig.Pbe.MaxIterationCount;
   try
-    TPbeUtilities.MaxIterationCount := 1;
+    TCryptoLibConfig.Pbe.MaxIterationCount := 1;
     try
       TPrivateKeyInfoFactory.CreatePrivateKeyInfo(LPassword, LEncInfo);
       Fail('excessive PBKDF2 iteration count accepted');
@@ -248,7 +250,7 @@ begin
           'unexpected message: ' + E.Message);
     end;
   finally
-    TPbeUtilities.MaxIterationCount := LOldMax;
+    TCryptoLibConfig.Pbe.MaxIterationCount := LOldMax;
   end;
 end;
 
@@ -265,9 +267,9 @@ begin
   LSalt := DecodeHex('0102030405060708');
   LPbeParams := TPbeParameter.Create(LSalt, 2048);
 
-  LOldMax := TPbeUtilities.MaxIterationCount;
+  LOldMax := TCryptoLibConfig.Pbe.MaxIterationCount;
   try
-    TPbeUtilities.MaxIterationCount := 1;
+    TCryptoLibConfig.Pbe.MaxIterationCount := 1;
     try
       TPbeUtilities.GenerateCipherParameters(LPbeAlgorithm, LPassword, LPbeParams);
       Fail('excessive PBE iteration count accepted');
@@ -277,7 +279,7 @@ begin
           'unexpected message: ' + E.Message);
     end;
   finally
-    TPbeUtilities.MaxIterationCount := LOldMax;
+    TCryptoLibConfig.Pbe.MaxIterationCount := LOldMax;
   end;
 end;
 
@@ -286,9 +288,9 @@ var
   LOldMax: Int32;
   LCount: Int32;
 begin
-  LOldMax := TPbeUtilities.MaxIterationCount;
+  LOldMax := TCryptoLibConfig.Pbe.MaxIterationCount;
   try
-    TPbeUtilities.MaxIterationCount := -1;
+    TCryptoLibConfig.Pbe.ResetToDefaults();
 
     LCount := TPbeUtilities.CheckPbeIterationCount(TDerInteger.ValueOf(5000000));
     CheckEquals(5000000, LCount, 'default max iteration count should allow 5_000_000');
@@ -302,7 +304,7 @@ begin
           'unexpected message: ' + E.Message);
     end;
   finally
-    TPbeUtilities.MaxIterationCount := LOldMax;
+    TCryptoLibConfig.Pbe.MaxIterationCount := LOldMax;
   end;
 end;
 
@@ -328,9 +330,9 @@ begin
     TDerOctetString.FromContents(LIv));
   LPbeS2Params := TPbeS2Parameters.Create(LKeyDerivFunc, LEncScheme);
 
-  LOldMax := TPbeUtilities.MaxIterationCount;
+  LOldMax := TCryptoLibConfig.Pbe.MaxIterationCount;
   try
-    TPbeUtilities.MaxIterationCount := -1;
+    TCryptoLibConfig.Pbe.ResetToDefaults();
     try
       TPbeUtilities.GenerateCipherParameters(TPkcsObjectIdentifiers.IdPbeS2,
         LPassword, LPbeS2Params);
@@ -341,7 +343,7 @@ begin
           'unexpected message: ' + E.Message);
     end;
   finally
-    TPbeUtilities.MaxIterationCount := LOldMax;
+    TCryptoLibConfig.Pbe.MaxIterationCount := LOldMax;
   end;
 end;
 

--- a/CryptoLib/src/Asn1/ClpAsn1Objects.pas
+++ b/CryptoLib/src/Asn1/ClpAsn1Objects.pas
@@ -26,6 +26,7 @@ uses
   Math,
   DateUtils,
   ClpBitOperations,
+  ClpCryptoLibConfig,
   ClpCryptoLibTypes,
   ClpBigInteger,
   ClpBigIntegerUtilities,
@@ -2569,15 +2570,12 @@ type
       FThree: IDerInteger;
       FFour: IDerInteger;
       FFive: IDerInteger;
-      FAllowUnsafeInteger: Boolean;
     class function GetZero(): IDerInteger; static;
     class function GetOne(): IDerInteger; static;
     class function GetTwo(): IDerInteger; static;
     class function GetThree(): IDerInteger; static;
     class function GetFour(): IDerInteger; static;
     class function GetFive(): IDerInteger; static;
-    class function GetAllowUnsafeInteger(): Boolean; static;
-    class procedure SetAllowUnsafeInteger(const AValue: Boolean); static;
     class function AllowUnsafe(): Boolean; static;
     class constructor Create;
   strict protected
@@ -2679,11 +2677,7 @@ type
     class property Three: IDerInteger read GetThree;
     class property Four: IDerInteger read GetFour;
     class property Five: IDerInteger read GetFive;
-    /// <summary>
-    /// Allow unsafe integer operations (bypasses some validation).
-    /// </summary>
-    class property AllowUnsafeInteger: Boolean read GetAllowUnsafeInteger write SetAllowUnsafeInteger;
-    
+
     function GetBytes(): TCryptoLibByteArray;
     /// <summary>
     /// Get the BigInteger value.
@@ -12450,7 +12444,6 @@ begin
   FThree := FSmallConstants[3];
   FFour := FSmallConstants[4];
   FFive := FSmallConstants[5];
-  FAllowUnsafeInteger := False;
 end;
 
 class function TDerInteger.GetZero(): IDerInteger;
@@ -12550,19 +12543,9 @@ begin
   Result := TDerInteger.Create(AContents, False);
 end;
 
-class function TDerInteger.GetAllowUnsafeInteger(): Boolean;
-begin
-  Result := FAllowUnsafeInteger;
-end;
-
-class procedure TDerInteger.SetAllowUnsafeInteger(const AValue: Boolean);
-begin
-  FAllowUnsafeInteger := AValue;
-end;
-
 class function TDerInteger.AllowUnsafe(): Boolean;
 begin
-  Result := AllowUnsafeInteger;
+  Result := TCryptoLibConfig.Asn1.AllowUnsafeInteger;
 end;
 
 class function TDerInteger.IsMalformed(const ABytes: TCryptoLibByteArray): Boolean;

--- a/CryptoLib/src/Asn1/ClpAsn1Streams.pas
+++ b/CryptoLib/src/Asn1/ClpAsn1Streams.pas
@@ -31,6 +31,7 @@ uses
   ClpAsn1Tags,
   ClpBitOperations,
   ClpPlatformUtilities,
+  ClpCryptoLibConfig,
   ClpCryptoLibTypes,
   ClpStreams,
   ClpStreamUtilities;
@@ -443,17 +444,12 @@ type
   /// </summary>
   TAsn1InputStream = class(TFilterStream)
   strict private
-    class var
-      FMaxLimitForUnknownStream: Int32;
-      FMaxConstructedDepth: Int32;
     var
       FDepth: Int32;
       FLimit: Int32;
       FLeaveOpen: Boolean;
       FTmp: TCryptoLibByteArray;
       FStream: TStream;
-
-    class constructor Create;
 
     function BuildObject(ATagHdr, ATagNo, ALength: Int32): IAsn1Object;
     function ReadTaggedObjectDL(ATagClass, ATagNo: Int32;
@@ -506,13 +502,8 @@ type
     property Limit: Int32 read FLimit;
 
     /// <summary>
-    /// Default recursion budget when <see cref="MaxConstructedDepth"/> is <c>-1</c>.
-    /// </summary>
-    const
-      DefaultMaxConstructedDepth = 64;
-
-    /// <summary>
-    /// Effective root recursion budget for nested constructed values (used when creating streams and parsers).
+    /// Effective root recursion budget for nested constructed values (used when creating streams
+    /// and parsers). Reflects <c>TCryptoLibConfig.Asn1.MaxDepth</c>.
     /// </summary>
     class function FindDepth: Int32; static;
 
@@ -520,18 +511,6 @@ type
     /// Returns the parent's decremented recursion budget or raises <see cref="EAsn1ParsingCryptoLibException"/> when the budget is exhausted.
     /// </summary>
     class function DecrementDepth(AParentDepth: Int32): Int32; static;
-
-    /// <summary>
-    /// When <c>FindLimit</c> cannot infer a stream bound, this value applies if set (not <c>-1</c>);
-    /// normalized with <c>Max(0, …)</c>; <c>-1</c> leaves behavior unchanged (<c>MaxInt</c>).
-    /// </summary>
-    class property MaxLimitForUnknownStream: Int32 read FMaxLimitForUnknownStream
-      write FMaxLimitForUnknownStream;
-
-    /// <summary>
-    /// Application override: anything except <c>-1</c> yields <c>Max(0, …)</c> from <see cref="FindDepth"/>; <c>-1</c> selects <see cref="DefaultMaxConstructedDepth"/>.
-    /// </summary>
-    class property MaxConstructedDepth: Int32 read FMaxConstructedDepth write FMaxConstructedDepth;
 
     /// <summary>
     /// Read the next ASN.1 object from the stream.
@@ -616,18 +595,9 @@ end;
 
 { TAsn1InputStream }
 
-class constructor TAsn1InputStream.Create;
-begin
-  FMaxLimitForUnknownStream := -1;
-  FMaxConstructedDepth := -1;
-end;
-
 class function TAsn1InputStream.FindDepth: Int32;
 begin
-  if FMaxConstructedDepth <> -1 then
-    Result := Max(0, FMaxConstructedDepth)
-  else
-    Result := DefaultMaxConstructedDepth;
+  Result := Max(0, TCryptoLibConfig.Asn1.MaxDepth);
 end;
 
 class function TAsn1InputStream.DecrementDepth(AParentDepth: Int32): Int32;
@@ -1696,10 +1666,7 @@ begin
     Exit;
   end;
 
-  if FMaxLimitForUnknownStream <> -1 then
-    Result := Max(0, FMaxLimitForUnknownStream)
-  else
-    Result := Int32.MaxValue;
+  Result := Max(0, TCryptoLibConfig.Asn1.MaxLimit);
 end;
 
 class function TAsn1InputStream.ReadTagNumber(const AInput: TStream;

--- a/CryptoLib/src/Asn1/X509/ClpX509Asn1Objects.pas
+++ b/CryptoLib/src/Asn1/X509/ClpX509Asn1Objects.pas
@@ -40,6 +40,7 @@ uses
   ClpX509ObjectIdentifiers,
   ClpPkcsObjectIdentifiers,
   ClpBigInteger,
+  ClpCryptoLibConfig,
   ClpCryptoLibTypes,
   ClpArrayUtilities,
   ClpAsn1Utilities,
@@ -1677,8 +1678,6 @@ type
   TTbsCertificateStructure = class(TAsn1Encodable, ITbsCertificateStructure)
 
   strict private
-  class var
-    FAllowNonDERTbsCertificate: Boolean;
   var
     FVersion: IDerInteger;
     FSerialNumber: IDerInteger;
@@ -1709,8 +1708,6 @@ type
     function GetExtensions: IX509Extensions;
 
   public
-    class constructor Create;
-
     class function GetInstance(AObj: TObject): ITbsCertificateStructure; overload; static;
     /// <summary>
     /// Get instance from ASN.1 convertible.
@@ -1721,11 +1718,6 @@ type
       AExplicitly: Boolean): ITbsCertificateStructure; overload; static;
     class function GetTagged(const ATaggedObject: IAsn1TaggedObject;
       ADeclaredExplicit: Boolean): ITbsCertificateStructure; static;
-
-    class function GetAllowNonDERTbsCertificate: Boolean; static;
-    class procedure SetAllowNonDERTbsCertificate(AValue: Boolean); static;
-
-    class property AllowNonDERTbsCertificate: Boolean read GetAllowNonDERTbsCertificate write SetAllowNonDERTbsCertificate;
 
     constructor Create(const ASeq: IAsn1Sequence); overload;
     constructor Create(const AVersion: IDerInteger; const ASerialNumber: IDerInteger;
@@ -4516,28 +4508,13 @@ begin
   Result := FExtensions;
 end;
 
-class constructor TTbsCertificateStructure.Create;
-begin
-  FAllowNonDERTbsCertificate := False;
-end;
-
-class function TTbsCertificateStructure.GetAllowNonDERTbsCertificate: Boolean;
-begin
-  Result := FAllowNonDERTbsCertificate;
-end;
-
-class procedure TTbsCertificateStructure.SetAllowNonDERTbsCertificate(AValue: Boolean);
-begin
-  FAllowNonDERTbsCertificate := AValue;
-end;
-
 function TTbsCertificateStructure.ToAsn1Object: IAsn1Object;
 var
   LV: IAsn1EncodableVector;
 begin
   if FSeq <> nil then
   begin
-    if AllowNonDERTbsCertificate then
+    if TCryptoLibConfig.X509.AllowNonDerTbsCertificate then
     begin
       Result := FSeq;
       Exit;

--- a/CryptoLib/src/Crypto/ClpPbeUtilities.pas
+++ b/CryptoLib/src/Crypto/ClpPbeUtilities.pas
@@ -26,6 +26,7 @@ uses
   Generics.Collections,
   ClpAsn1Objects,
   ClpIAsn1Objects,
+  ClpCryptoLibConfig,
   ClpCryptoLibTypes,
   ClpIAsn1Core,
   ClpIDigest,
@@ -84,16 +85,13 @@ type
     Pkcs5S2 = 'Pkcs5S2';
     Pkcs12 = 'Pkcs12';
     OpenSsl = 'OpenSsl';
-    DefaultMaxIterationCount = 5000000;
   class var
     FAlgorithms: TDictionary<String, String>;
     FAlgorithmType: TDictionary<String, String>;
     FOids: TDictionary<String, IDerObjectIdentifier>;
-    FMaxIterationCount: Int32;
   class constructor Create;
   class destructor Destroy;
   strict private
-    class function GetEffectiveMaxIterationCount: Int32; static;
     class function MakePbeGenerator(const AType: String; const ADigest: IDigest;
       const AKey: TCryptoLibByteArray; const ASalt: TCryptoLibByteArray;
       AIterationCount: Int32): IPbeParametersGenerator; static;
@@ -175,15 +173,9 @@ type
 
     /// <summary>
     /// Validates a supplied PBE/PBKDF2 iteration count against
-    /// <see cref="MaxIterationCount"/> (or <see cref="DefaultMaxIterationCount"/> when unset).
+    /// <c>TCryptoLibConfig.Pbe.MaxIterationCount</c>.
     /// </summary>
     class function CheckPbeIterationCount(const AIterationCountObject: IDerInteger): Int32; static;
-
-    /// <summary>
-    /// Maximum allowed PBE iteration count when decrypting PKCS#8 / PEM keys.
-    /// Unset (<c>-1</c>) or any negative value selects <see cref="DefaultMaxIterationCount"/>.
-    /// </summary>
-    class property MaxIterationCount: Int32 read FMaxIterationCount write FMaxIterationCount;
   end;
 
 implementation
@@ -193,7 +185,6 @@ uses
 
 class constructor TPbeUtilities.Create;
 begin
-  FMaxIterationCount := -1;
   FAlgorithms := TDictionary<String, String>.Create(TCryptoLibComparers.OrdinalIgnoreCaseEqualityComparer);
   FAlgorithmType := TDictionary<String, String>.Create(TCryptoLibComparers.OrdinalIgnoreCaseEqualityComparer);
   FOids := TDictionary<String, IDerObjectIdentifier>.Create(TCryptoLibComparers.OrdinalIgnoreCaseEqualityComparer);
@@ -294,14 +285,6 @@ begin
   FOids.Free;
 end;
 
-class function TPbeUtilities.GetEffectiveMaxIterationCount: Int32;
-begin
-  if FMaxIterationCount < 0 then
-    Result := DefaultMaxIterationCount
-  else
-    Result := FMaxIterationCount;
-end;
-
 class function TPbeUtilities.CheckPbeIterationCount(
   const AIterationCountObject: IDerInteger): Int32;
 var
@@ -311,7 +294,7 @@ begin
     (not AIterationCountObject.TryGetIntValueExact(LIterationCount)) or
     (LIterationCount <= 0) then
     raise EArgumentCryptoLibException.CreateRes(@SInvalidPbeIterationCount);
-  LMax := GetEffectiveMaxIterationCount;
+  LMax := TCryptoLibConfig.Pbe.MaxIterationCount;
   if LIterationCount > LMax then
     raise EArgumentCryptoLibException.CreateResFmt(@SPbeIterationExceedsMax,
       [LIterationCount, LMax]);

--- a/CryptoLib/src/Crypto/Parameters/ClpDHParameters.pas
+++ b/CryptoLib/src/Crypto/Parameters/ClpDHParameters.pas
@@ -33,6 +33,7 @@ uses
   ClpNat,
   ClpBitOperations,
   ClpArrayUtilities,
+  ClpCryptoLibConfig,
   ClpCryptoLibTypes;
 
 resourcestring
@@ -158,20 +159,9 @@ type
     IDHPublicKeyParameters)
 
   strict private
-    /// <summary>
-    /// Default maximum DH modulus bit length when <see cref="MaxSize"/> is unset (<c>-1</c>).
-    /// </summary>
-    const
-      DefaultMaxBitLength = 16384;
-    class var
-      FMaxSize: Int32;
-
     var
     FY: TBigInteger;
 
-    class constructor Create;
-
-    class function GetEffectiveMaxSize: Int32; static;
     class function Legendre(const AA, AB: TBigInteger): Int32; static;
 
     class function Validate(const AY: TBigInteger; const ADHParams: IDHParameters)
@@ -182,12 +172,6 @@ type
     function GetY: TBigInteger; virtual;
 
   public
-    /// <summary>
-    /// Maximum allowed DH modulus bit length for externally supplied keys.
-    /// Unset (<c>-1</c>) or any negative value selects <see cref="DefaultMaxBitLength"/>.
-    /// </summary>
-    class property MaxSize: Int32 read FMaxSize write FMaxSize;
-
     constructor Create(const AY: TBigInteger;
       const AParameters: IDHParameters); overload;
 
@@ -582,19 +566,6 @@ begin
   end;
 end;
 
-class constructor TDHPublicKeyParameters.Create;
-begin
-  FMaxSize := -1;
-end;
-
-class function TDHPublicKeyParameters.GetEffectiveMaxSize: Int32;
-begin
-  if FMaxSize < 0 then
-    Result := DefaultMaxBitLength
-  else
-    Result := FMaxSize;
-end;
-
 class function TDHPublicKeyParameters.Validate(const AY: TBigInteger;
   const ADHParams: IDHParameters): TBigInteger;
 var
@@ -607,7 +578,7 @@ begin
 
   LP := ADHParams.P;
 
-  if LP.BitLength > GetEffectiveMaxSize then
+  if LP.BitLength > TCryptoLibConfig.DH.MaxSize then
     raise EArgumentCryptoLibException.CreateRes(@SDHModulusOutOfRange);
 
   if ((AY.CompareTo(TBigInteger.Two) < 0) or

--- a/CryptoLib/src/Crypto/Parameters/ClpDsaParameters.pas
+++ b/CryptoLib/src/Crypto/Parameters/ClpDsaParameters.pas
@@ -28,6 +28,7 @@ uses
   ClpKeyGenerationParameters,
   ClpISecureRandom,
   ClpArrayUtilities,
+  ClpCryptoLibConfig,
   ClpCryptoLibTypes;
 
 resourcestring
@@ -120,32 +121,15 @@ type
     IDsaPublicKeyParameters)
 
   strict private
-    /// <summary>
-    /// Default maximum DSA modulus bit length when <see cref="MaxSize"/> is unset (<c>-1</c>).
-    /// </summary>
-    const
-      DefaultMaxBitLength = 16384;
-    class var
-      FMaxSize: Int32;
-
     var
     FY: TBigInteger;
 
-    class constructor Create;
-
-    class function GetEffectiveMaxSize: Int32; static;
     class function Validate(const AY: TBigInteger;
       const AParameters: IDsaParameters): TBigInteger; static; inline;
 
     function GetY: TBigInteger; inline;
 
   public
-    /// <summary>
-    /// Maximum allowed DSA modulus bit length for externally supplied keys.
-    /// Unset (<c>-1</c>) or any negative value selects <see cref="DefaultMaxBitLength"/>.
-    /// </summary>
-    class property MaxSize: Int32 read FMaxSize write FMaxSize;
-
     constructor Create(const AY: TBigInteger; const AParameters: IDsaParameters);
 
     function Equals(const AOther: IDsaPublicKeyParameters): Boolean;
@@ -406,19 +390,6 @@ end;
 
 { TDsaPublicKeyParameters }
 
-class constructor TDsaPublicKeyParameters.Create;
-begin
-  FMaxSize := -1;
-end;
-
-class function TDsaPublicKeyParameters.GetEffectiveMaxSize: Int32;
-begin
-  if FMaxSize < 0 then
-    Result := DefaultMaxBitLength
-  else
-    Result := FMaxSize;
-end;
-
 function TDsaPublicKeyParameters.GetY: TBigInteger;
 begin
   Result := FY;
@@ -433,7 +404,7 @@ begin
   end;
   if (AParameters <> nil) then
   begin
-    if AParameters.P.BitLength > GetEffectiveMaxSize then
+    if AParameters.P.BitLength > TCryptoLibConfig.Dsa.MaxSize then
       raise EArgumentCryptoLibException.CreateRes(@SDsaModulusOutOfRange);
     if ((AY.CompareTo(TBigInteger.Two) < 0) or
       (AY.CompareTo(AParameters.P.Subtract(TBigInteger.Two)) > 0) or

--- a/CryptoLib/src/Crypto/Parameters/ClpRsaParameters.pas
+++ b/CryptoLib/src/Crypto/Parameters/ClpRsaParameters.pas
@@ -30,6 +30,7 @@ uses
   ClpAsymmetricKeyParameter,
   ClpKeyGenerationParameters,
   ClpISecureRandom,
+  ClpCryptoLibConfig,
   ClpCryptoLibTypes;
 
 resourcestring
@@ -49,22 +50,11 @@ type
   TRsaKeyParameters = class(TAsymmetricKeyParameter, IRsaKeyParameters)
 
   strict private
-    /// <summary>
-    /// Default maximum RSA modulus bit length when <see cref="MaxSize"/> is unset (<c>-1</c>).
-    /// </summary>
-    const
-      DefaultMaxBitLength = 16384;
-    class var
-      FMaxSize: Int32;
-      FMaxMRTests: Int32;
     var
     FModulus: TBigInteger;
     FExponent: TBigInteger;
 
-    class constructor Create;
-
     class function Validate(const AModulus: TBigInteger; AIsInternal: Boolean): TBigInteger; static;
-    class function GetEffectiveMaxSize: Int32; static;
     class function GetEffectiveMaxMRTests(ABits: Int32): Int32; static;
     class function GetMRIterations(ABits: Int32): Int32; static;
 
@@ -75,19 +65,6 @@ type
   public
 
     class function ValidateModulus(const AModulus: TBigInteger): TBigInteger; static;
-
-    /// <summary>
-    /// Maximum allowed RSA modulus bit length for externally supplied keys.
-    /// Unset (<c>-1</c>) or any negative value selects <see cref="DefaultMaxBitLength"/>.
-    /// </summary>
-    class property MaxSize: Int32 read FMaxSize write FMaxSize;
-
-    /// <summary>
-    /// Enhanced Miller-Rabin iteration count for externally supplied moduli.
-    /// Unset (<c>-1</c>) or any negative value selects a bit-length-dependent default;
-    /// <c>0</c> disables composite testing.
-    /// </summary>
-    class property MaxMRTests: Int32 read FMaxMRTests write FMaxMRTests;
 
     constructor Create(AIsPrivate: Boolean;
       const AModulus, AExponent: TBigInteger); overload;
@@ -204,26 +181,12 @@ implementation
 
 { TRsaKeyParameters }
 
-class constructor TRsaKeyParameters.Create;
-begin
-  FMaxSize := -1;
-  FMaxMRTests := -1;
-end;
-
-class function TRsaKeyParameters.GetEffectiveMaxSize: Int32;
-begin
-  if FMaxSize < 0 then
-    Result := DefaultMaxBitLength
-  else
-    Result := FMaxSize;
-end;
-
 class function TRsaKeyParameters.GetEffectiveMaxMRTests(ABits: Int32): Int32;
 begin
-  if FMaxMRTests < 0 then
-    Result := GetMRIterations(ABits)
+  if TCryptoLibConfig.Rsa.MaxMRTests.HasValue then
+    Result := TCryptoLibConfig.Rsa.MaxMRTests.Value
   else
-    Result := FMaxMRTests;
+    Result := GetMRIterations(ABits);
 end;
 
 class function TRsaKeyParameters.GetMRIterations(ABits: Int32): Int32;
@@ -254,7 +217,7 @@ begin
   begin
     if not AModulus.TestBit(0) then
       raise EArgumentCryptoLibException.CreateRes(@SRsaModulusIsEven);
-    if AModulus.BitLength > GetEffectiveMaxSize then
+    if AModulus.BitLength > TCryptoLibConfig.Rsa.MaxSize then
       raise EArgumentCryptoLibException.CreateRes(@SRsaModulusOutOfRange);
     if TBigIntegerUtilities.HasAnySmallFactors(AModulus) then
       raise EArgumentCryptoLibException.CreateRes(@SRsaModulusHasSmallPrimeFactor);

--- a/CryptoLib/src/Interfaces/Pkcs/ClpIPkcs12Store.pas
+++ b/CryptoLib/src/Interfaces/Pkcs/ClpIPkcs12Store.pas
@@ -49,7 +49,7 @@ type
     /// </exception>
     /// <exception cref="EIOCryptoLibException">
     /// The MAC verification failed, a password was supplied when none is required (unless
-    /// <see cref="TPkcs12Store.IgnoreUselessPassword"/> is <c>true</c>), or bag attributes conflict.
+    /// <c>TCryptoLibConfig.Pkcs12.IgnoreUselessPassword</c> is <c>true</c>), or bag attributes conflict.
     /// </exception>
     procedure Load(const AInput: TStream; const APassword: TCryptoLibCharArray);
     /// <summary>

--- a/CryptoLib/src/Math/EC/ClpECCurve.pas
+++ b/CryptoLib/src/Math/EC/ClpECCurve.pas
@@ -44,6 +44,7 @@ uses
   ClpBigIntegerUtilities,
   ClpECLookupTables,
   ClpECCurveConstants,
+  ClpCryptoLibConfig,
   ClpCryptoLibTypes;
 
 resourcestring
@@ -171,8 +172,6 @@ type
     class var
       FKnownPrimes: TDictionary<TBigInteger, Boolean>;
       FLockPrimes: TCriticalSection;
-      FMaxFieldSize: Int32;
-      FCertainty: Int32;
     class procedure ImplCheckQ(const AQ: TBigInteger); static;
     class function ImplIsPrime(const AQ: TBigInteger): Boolean; static;
     class function ImplGetIterations(ABits, ACertainty: Int32): Int32; static;
@@ -190,8 +189,6 @@ type
     function RandomFieldElement(const ARandom: ISecureRandom): IECFieldElement; override;
     function RandomFieldElementMult(const ARandom: ISecureRandom): IECFieldElement; override;
     function DecompressPoint(AYTilde: Int32; const AX1: TBigInteger): IECPoint; override;
-    class property MaxFieldSize: Int32 read FMaxFieldSize write FMaxFieldSize;
-    class property Certainty: Int32 read FCertainty write FCertainty;
   end;
 
   TFpCurve = class sealed(TAbstractFpCurve, IECCurve, IFpCurve)
@@ -218,13 +215,10 @@ type
   end;
 
   TAbstractF2mCurve = class abstract(TECCurve, IECCurve, IAbstractF2mCurve)
-  strict private
-    class var FMaxFieldSize: Int32;
   strict protected
     class function ImplRandomFieldElementMult(const ARandom: ISecureRandom; AM: Int32): TBigInteger; static;
     function GetIsKoblitz: Boolean; virtual;
   public
-    class constructor Create;
     constructor Create(AM, AK1, AK2, AK3: Int32);
     class function Inverse(AM: Int32; const AKs: TCryptoLibInt32Array; const AX: TBigInteger): TBigInteger; static;
     function CreatePoint(const AX, AY: TBigInteger): IECPoint; override;
@@ -233,7 +227,6 @@ type
     function RandomFieldElementMult(const ARandom: ISecureRandom): IECFieldElement; override;
     function DecompressPoint(AYTilde: Int32; const AX1: TBigInteger): IECPoint; override;
     function SolveQuadraticEquation(const ABeta: IECFieldElement): IECFieldElement; virtual;
-    class property MaxFieldSize: Int32 read FMaxFieldSize write FMaxFieldSize;
   end;
 
   TF2mCurve = class sealed(TAbstractF2mCurve, IECCurve, IF2mCurve)
@@ -857,8 +850,6 @@ class constructor TAbstractFpCurve.Create;
 begin
   FKnownPrimes := TDictionary<TBigInteger, Boolean>.Create(TBigIntegerUtilities.BigIntegerEqualityComparer);
   FLockPrimes := TCriticalSection.Create;
-  FMaxFieldSize := 1042; // 2 * 521
-  FCertainty := 100;
 end;
 
 class destructor TAbstractFpCurve.Destroy;
@@ -899,7 +890,7 @@ end;
 
 class procedure TAbstractFpCurve.ImplCheckQ(const AQ: TBigInteger);
 begin
-  if AQ.BitLength > FMaxFieldSize then
+  if AQ.BitLength > TCryptoLibConfig.EC.FpMaxSize then
     raise EArgumentCryptoLibException.CreateRes(@SFpQValueOutOfRange);
   if not ImplIsPrime(AQ) then
     raise EArgumentCryptoLibException.CreateRes(@SFpQValueNotPrime);
@@ -911,7 +902,7 @@ var
 begin
   if TPrimes.HasAnySmallFactors(AQ) then
     Exit(False);
-  LIterations := ImplGetIterations(AQ.BitLength, FCertainty);
+  LIterations := ImplGetIterations(AQ.BitLength, TCryptoLibConfig.EC.FpCertainty);
   Result := TPrimes.IsMRProbablePrime(AQ, TSecureRandom.MasterRandom, LIterations);
 end;
 
@@ -1116,16 +1107,11 @@ end;
 
 { TAbstractF2mCurve }
 
-class constructor TAbstractF2mCurve.Create;
-begin
-  FMaxFieldSize := 1142; // 2 * 571
-end;
-
 function BuildF2mField(AM, AK1, AK2, AK3: Int32): IFiniteField;
 var
   LExponents: TCryptoLibInt32Array;
 begin
-  if AM > TAbstractF2mCurve.MaxFieldSize then
+  if AM > TCryptoLibConfig.EC.F2mMaxSize then
     raise EArgumentCryptoLibException.CreateRes(@SF2mMValueOutOfRange);
   if (AK2 or AK3) = 0 then
     LExponents := TCryptoLibInt32Array.Create(0, AK1, AM)

--- a/CryptoLib/src/Misc/ClpCryptoLibConfig.pas
+++ b/CryptoLib/src/Misc/ClpCryptoLibConfig.pas
@@ -26,8 +26,70 @@ uses
 
 resourcestring
   SMaxPolicyNodesNotPositive = 'the valid policy tree node ceiling must be greater than zero, got %d';
+  SConfigCeilingNotPositive = 'the %s must be greater than zero, got %d';
+  SConfigValueNegative = 'the %s must not be negative, got %d';
 
 type
+  /// <summary>
+  /// The ASN.1 parsing settings, reached as <c>TCryptoLibConfig.Asn1</c>.
+  /// </summary>
+  TAsn1Config = class sealed(TObject)
+
+  strict private
+  const
+    /// <summary>
+    /// Recursion budget applied to constructed-object nesting when <see cref="MaxDepth" /> is
+    /// unset. Read it through <see cref="MaxDepth" />, which reports it whenever nothing has
+    /// been set.
+    /// </summary>
+    DefaultMaxDepth = Int32(64);
+    /// <summary>
+    /// Byte ceiling applied to a stream whose length cannot be inferred, when
+    /// <see cref="MaxLimit" /> is unset. Unbounded by default.
+    /// </summary>
+    DefaultMaxLimit = High(Int32);
+
+  class var
+    FAllowUnsafeInteger: Boolean;
+    FMaxDepth: TNullable<Int32>;
+    FMaxLimit: TNullable<Int32>;
+
+    class function GetAllowUnsafeInteger: Boolean; static;
+    class procedure SetAllowUnsafeInteger(AValue: Boolean); static;
+    class function GetMaxDepth: Int32; static;
+    class procedure SetMaxDepth(AValue: Int32); static;
+    class function GetMaxLimit: Int32; static;
+    class procedure SetMaxLimit(AValue: Int32); static;
+
+  public
+    /// <summary>Restores this area's settings to their defaults.</summary>
+    class procedure ResetToDefaults(); static;
+
+    /// <summary>
+    /// Accepts a DER INTEGER carrying redundant leading sign bytes, which the encoding rules
+    /// forbid, rather than rejecting it outright. Off by default.
+    /// </summary>
+    class property AllowUnsafeInteger: Boolean read GetAllowUnsafeInteger
+      write SetAllowUnsafeInteger;
+
+    /// <summary>
+    /// The ceiling on constructed-object nesting, bounding the recursion a crafted stream can
+    /// provoke. A negative value is tolerated and clamped to zero where it is applied; call
+    /// <see cref="ResetToDefaults" /> to go back to the default.
+    /// </summary>
+    class property MaxDepth: Int32 read GetMaxDepth write SetMaxDepth;
+
+    /// <summary>
+    /// The byte ceiling applied when a stream's length cannot be inferred, bounding an
+    /// unbounded read. A negative value is tolerated and clamped to zero where it is applied;
+    /// call <see cref="ResetToDefaults" /> to go back to the default (unbounded).
+    /// </summary>
+    class property MaxLimit: Int32 read GetMaxLimit write SetMaxLimit;
+  end;
+
+  /// <summary>Class reference, so the settings are reachable without an instance.</summary>
+  TCryptoLibConfigAsn1 = class of TAsn1Config;
+
   /// <summary>
   /// The X.509 and certification path settings, reached as <c>TCryptoLibConfig.X509</c>.
   /// </summary>
@@ -51,6 +113,7 @@ type
     FSgp22NameConstraints: Boolean;
     FAllowLenientRfc822Name: Boolean;
     FAllowLenientIPAddressMask: Boolean;
+    FAllowNonDerTbsCertificate: Boolean;
 
     class function GetMaxPolicyNodes: Int32; static;
     class procedure SetMaxPolicyNodes(AValue: Int32); static;
@@ -60,6 +123,8 @@ type
     class procedure SetAllowLenientRfc822Name(AValue: Boolean); static;
     class function GetAllowLenientIPAddressMask: Boolean; static;
     class procedure SetAllowLenientIPAddressMask(AValue: Boolean); static;
+    class function GetAllowNonDerTbsCertificate: Boolean; static;
+    class procedure SetAllowNonDerTbsCertificate(AValue: Boolean); static;
 
   public
     /// <summary>Restores this area's settings to their defaults.</summary>
@@ -92,10 +157,257 @@ type
     /// </summary>
     class property AllowLenientIPAddressMask: Boolean read GetAllowLenientIPAddressMask
       write SetAllowLenientIPAddressMask;
+
+    /// <summary>
+    /// Accepts a TBSCertificate whose fields are not in strict DER form, rather than rejecting it.
+    /// Off by default.
+    /// </summary>
+    class property AllowNonDerTbsCertificate: Boolean read GetAllowNonDerTbsCertificate
+      write SetAllowNonDerTbsCertificate;
   end;
 
   /// <summary>Class reference, so the settings are reachable without an instance.</summary>
   TCryptoLibConfigX509 = class of TX509Config;
+
+  /// <summary>
+  /// The Diffie-Hellman settings, reached as <c>TCryptoLibConfig.DH</c>.
+  /// </summary>
+  TDHConfig = class sealed(TObject)
+
+  strict private
+  const
+    /// <summary>
+    /// The DH modulus bit-length ceiling applied to externally supplied keys when
+    /// <see cref="MaxSize" /> is unset.
+    /// </summary>
+    DefaultMaxSize = Int32(16384);
+
+  class var
+    FMaxSize: TNullable<Int32>;
+
+    class function GetMaxSize: Int32; static;
+    class procedure SetMaxSize(AValue: Int32); static;
+
+  public
+    /// <summary>Restores this area's settings to their defaults.</summary>
+    class procedure ResetToDefaults(); static;
+
+    /// <summary>
+    /// The maximum DH modulus bit length accepted for externally supplied keys. Assigning less
+    /// than one raises; call <see cref="ResetToDefaults" /> to go back to the default.
+    /// </summary>
+    class property MaxSize: Int32 read GetMaxSize write SetMaxSize;
+  end;
+
+  /// <summary>Class reference, so the settings are reachable without an instance.</summary>
+  TCryptoLibConfigDH = class of TDHConfig;
+
+  /// <summary>
+  /// The DSA settings, reached as <c>TCryptoLibConfig.Dsa</c>.
+  /// </summary>
+  TDsaConfig = class sealed(TObject)
+
+  strict private
+  const
+    /// <summary>
+    /// The DSA modulus bit-length ceiling applied to externally supplied keys when
+    /// <see cref="MaxSize" /> is unset.
+    /// </summary>
+    DefaultMaxSize = Int32(16384);
+
+  class var
+    FMaxSize: TNullable<Int32>;
+
+    class function GetMaxSize: Int32; static;
+    class procedure SetMaxSize(AValue: Int32); static;
+
+  public
+    /// <summary>Restores this area's settings to their defaults.</summary>
+    class procedure ResetToDefaults(); static;
+
+    /// <summary>
+    /// The maximum DSA modulus bit length accepted for externally supplied keys. Assigning less
+    /// than one raises; call <see cref="ResetToDefaults" /> to go back to the default.
+    /// </summary>
+    class property MaxSize: Int32 read GetMaxSize write SetMaxSize;
+  end;
+
+  /// <summary>Class reference, so the settings are reachable without an instance.</summary>
+  TCryptoLibConfigDsa = class of TDsaConfig;
+
+  /// <summary>
+  /// The RSA settings, reached as <c>TCryptoLibConfig.Rsa</c>.
+  /// </summary>
+  TRsaConfig = class sealed(TObject)
+
+  strict private
+  const
+    /// <summary>
+    /// The RSA modulus bit-length ceiling applied to externally supplied keys when
+    /// <see cref="MaxSize" /> is unset.
+    /// </summary>
+    DefaultMaxSize = Int32(16384);
+
+  class var
+    FMaxSize: TNullable<Int32>;
+    /// <summary>
+    /// Nullable rather than sentinel-encoded: the effective default is a bit-length-dependent
+    /// count computed by the caller, and <c>0</c> is a legal value that disables the test, so
+    /// "unset" cannot be folded onto any integer.
+    /// </summary>
+    FMaxMRTests: TNullable<Int32>;
+
+    class function GetMaxSize: Int32; static;
+    class procedure SetMaxSize(AValue: Int32); static;
+    class function GetMaxMRTests: TNullable<Int32>; static;
+    class procedure SetMaxMRTests(const AValue: TNullable<Int32>); static;
+
+  public
+    /// <summary>Restores this area's settings to their defaults.</summary>
+    class procedure ResetToDefaults(); static;
+
+    /// <summary>
+    /// The maximum RSA modulus bit length accepted for externally supplied keys. Assigning less
+    /// than one raises; call <see cref="ResetToDefaults" /> to go back to the default.
+    /// </summary>
+    class property MaxSize: Int32 read GetMaxSize write SetMaxSize;
+
+    /// <summary>
+    /// The enhanced Miller-Rabin iteration count for externally supplied moduli. When unset a
+    /// bit-length-dependent count is used; <c>0</c> disables composite testing. Assigning a
+    /// negative value raises.
+    /// </summary>
+    class property MaxMRTests: TNullable<Int32> read GetMaxMRTests write SetMaxMRTests;
+  end;
+
+  /// <summary>Class reference, so the settings are reachable without an instance.</summary>
+  TCryptoLibConfigRsa = class of TRsaConfig;
+
+  /// <summary>
+  /// The elliptic-curve settings, reached as <c>TCryptoLibConfig.EC</c>. The prime-field (Fp)
+  /// and binary-field (F2m) ceilings are separate, mirroring the reference's <c>EC.Fp_*</c> /
+  /// <c>EC.F2m_*</c> keys.
+  /// </summary>
+  TECConfig = class sealed(TObject)
+
+  strict private
+  const
+    /// <summary>Prime-field bit-length ceiling when <see cref="FpMaxSize" /> is unset (2 * 521).</summary>
+    DefaultFpMaxSize = Int32(1042);
+    /// <summary>Binary-field degree ceiling when <see cref="F2mMaxSize" /> is unset (2 * 571).</summary>
+    DefaultF2mMaxSize = Int32(1142);
+    /// <summary>Primality certainty when <see cref="FpCertainty" /> is unset.</summary>
+    DefaultFpCertainty = Int32(100);
+
+  class var
+    FFpMaxSize: TNullable<Int32>;
+    FF2mMaxSize: TNullable<Int32>;
+    FFpCertainty: TNullable<Int32>;
+
+    class function GetFpMaxSize: Int32; static;
+    class procedure SetFpMaxSize(AValue: Int32); static;
+    class function GetF2mMaxSize: Int32; static;
+    class procedure SetF2mMaxSize(AValue: Int32); static;
+    class function GetFpCertainty: Int32; static;
+    class procedure SetFpCertainty(AValue: Int32); static;
+
+  public
+    /// <summary>Restores this area's settings to their defaults.</summary>
+    class procedure ResetToDefaults(); static;
+
+    /// <summary>
+    /// The maximum bit length accepted for a prime-field (Fp) curve. Assigning less than one
+    /// raises; call <see cref="ResetToDefaults" /> to go back to the default.
+    /// </summary>
+    class property FpMaxSize: Int32 read GetFpMaxSize write SetFpMaxSize;
+
+    /// <summary>
+    /// The maximum degree accepted for a binary-field (F2m) curve. Assigning less than one
+    /// raises; call <see cref="ResetToDefaults" /> to go back to the default.
+    /// </summary>
+    class property F2mMaxSize: Int32 read GetF2mMaxSize write SetF2mMaxSize;
+
+    /// <summary>
+    /// The primality certainty used when validating a prime-field (Fp) curve. Zero is legal;
+    /// assigning a negative value raises.
+    /// </summary>
+    class property FpCertainty: Int32 read GetFpCertainty write SetFpCertainty;
+  end;
+
+  /// <summary>Class reference, so the settings are reachable without an instance.</summary>
+  TCryptoLibConfigEC = class of TECConfig;
+
+  /// <summary>
+  /// The password-based encryption settings, reached as <c>TCryptoLibConfig.Pbe</c>.
+  /// </summary>
+  TPbeConfig = class sealed(TObject)
+
+  strict private
+  const
+    /// <summary>Iteration-count ceiling when <see cref="MaxIterationCount" /> is unset.</summary>
+    DefaultMaxIterationCount = Int32(5000000);
+
+  class var
+    FMaxIterationCount: TNullable<Int32>;
+
+    class function GetMaxIterationCount: Int32; static;
+    class procedure SetMaxIterationCount(AValue: Int32); static;
+
+  public
+    /// <summary>Restores this area's settings to their defaults.</summary>
+    class procedure ResetToDefaults(); static;
+
+    /// <summary>
+    /// The ceiling on the PBE iteration count, bounding the work a crafted parameter set can
+    /// demand. Assigning less than one raises; call <see cref="ResetToDefaults" /> to go back to
+    /// the default.
+    /// </summary>
+    class property MaxIterationCount: Int32 read GetMaxIterationCount write SetMaxIterationCount;
+  end;
+
+  /// <summary>Class reference, so the settings are reachable without an instance.</summary>
+  TCryptoLibConfigPbe = class of TPbeConfig;
+
+  /// <summary>
+  /// The PKCS#12 settings, reached as <c>TCryptoLibConfig.Pkcs12</c>.
+  /// </summary>
+  TPkcs12Config = class sealed(TObject)
+
+  strict private
+  const
+    /// <summary>Iteration-count ceiling when <see cref="MaxIterationCount" /> is unset.</summary>
+    DefaultMaxIterationCount = Int32(5000000);
+
+  class var
+    FMaxIterationCount: TNullable<Int32>;
+    FIgnoreUselessPassword: Boolean;
+
+    class function GetMaxIterationCount: Int32; static;
+    class procedure SetMaxIterationCount(AValue: Int32); static;
+    class function GetIgnoreUselessPassword: Boolean; static;
+    class procedure SetIgnoreUselessPassword(AValue: Boolean); static;
+
+  public
+    /// <summary>Restores this area's settings to their defaults.</summary>
+    class procedure ResetToDefaults(); static;
+
+    /// <summary>
+    /// The ceiling on the PKCS#12 iteration count, bounding the work a crafted keystore can
+    /// demand. Assigning less than one raises; call <see cref="ResetToDefaults" /> to go back to
+    /// the default.
+    /// </summary>
+    class property MaxIterationCount: Int32 read GetMaxIterationCount write SetMaxIterationCount;
+
+    /// <summary>
+    /// Loads a PKCS#12 keystore whose integrity is not password-protected without demanding a
+    /// password, rather than rejecting it. Off by default.
+    /// </summary>
+    class property IgnoreUselessPassword: Boolean read GetIgnoreUselessPassword
+      write SetIgnoreUselessPassword;
+  end;
+
+  /// <summary>Class reference, so the settings are reachable without an instance.</summary>
+  TCryptoLibConfigPkcs12 = class of TPkcs12Config;
 
   /// <summary>
   /// Process-wide switches that relax or tighten what the library accepts, grouped by area.
@@ -113,17 +425,92 @@ type
   TCryptoLibConfig = class sealed(TObject)
 
   strict private
+    class function GetAsn1: TCryptoLibConfigAsn1; static;
     class function GetX509: TCryptoLibConfigX509; static;
+    class function GetDH: TCryptoLibConfigDH; static;
+    class function GetDsa: TCryptoLibConfigDsa; static;
+    class function GetRsa: TCryptoLibConfigRsa; static;
+    class function GetEC: TCryptoLibConfigEC; static;
+    class function GetPbe: TCryptoLibConfigPbe; static;
+    class function GetPkcs12: TCryptoLibConfigPkcs12; static;
 
   public
     /// <summary>Restores every area's settings to their defaults.</summary>
     class procedure ResetToDefaults(); static;
 
+    /// <summary>The ASN.1 parsing settings.</summary>
+    class property Asn1: TCryptoLibConfigAsn1 read GetAsn1;
+
     /// <summary>The X.509 and certification path settings.</summary>
     class property X509: TCryptoLibConfigX509 read GetX509;
+
+    /// <summary>The Diffie-Hellman settings.</summary>
+    class property DH: TCryptoLibConfigDH read GetDH;
+
+    /// <summary>The DSA settings.</summary>
+    class property Dsa: TCryptoLibConfigDsa read GetDsa;
+
+    /// <summary>The RSA settings.</summary>
+    class property Rsa: TCryptoLibConfigRsa read GetRsa;
+
+    /// <summary>The elliptic-curve settings.</summary>
+    class property EC: TCryptoLibConfigEC read GetEC;
+
+    /// <summary>The password-based encryption settings.</summary>
+    class property Pbe: TCryptoLibConfigPbe read GetPbe;
+
+    /// <summary>The PKCS#12 settings.</summary>
+    class property Pkcs12: TCryptoLibConfigPkcs12 read GetPkcs12;
   end;
 
 implementation
+
+{ TAsn1Config }
+
+class procedure TAsn1Config.ResetToDefaults();
+begin
+  FAllowUnsafeInteger := False;
+  FMaxDepth := TNullable<Int32>.None;
+  FMaxLimit := TNullable<Int32>.None;
+end;
+
+class function TAsn1Config.GetAllowUnsafeInteger: Boolean;
+begin
+  Result := FAllowUnsafeInteger;
+end;
+
+class procedure TAsn1Config.SetAllowUnsafeInteger(AValue: Boolean);
+begin
+  FAllowUnsafeInteger := AValue;
+end;
+
+class function TAsn1Config.GetMaxDepth: Int32;
+begin
+  if FMaxDepth.HasValue then
+    Result := FMaxDepth.Value
+  else
+    Result := DefaultMaxDepth;
+end;
+
+class procedure TAsn1Config.SetMaxDepth(AValue: Int32);
+begin
+  // a negative value is clamped to zero at the point of use
+  FMaxDepth := TNullable<Int32>.Some(AValue);
+end;
+
+class function TAsn1Config.GetMaxLimit: Int32;
+begin
+  if FMaxLimit.HasValue then
+    Result := FMaxLimit.Value
+  else
+    Result := DefaultMaxLimit;
+end;
+
+class procedure TAsn1Config.SetMaxLimit(AValue: Int32);
+begin
+  // a negative value is clamped to zero at the point of use
+  FMaxLimit := TNullable<Int32>.Some(AValue);
+end;
 
 { TX509Config }
 
@@ -133,6 +520,7 @@ begin
   FSgp22NameConstraints := False;
   FAllowLenientRfc822Name := False;
   FAllowLenientIPAddressMask := False;
+  FAllowNonDerTbsCertificate := False;
 end;
 
 class function TX509Config.GetMaxPolicyNodes: Int32;
@@ -182,16 +570,274 @@ begin
   FAllowLenientIPAddressMask := AValue;
 end;
 
+class function TX509Config.GetAllowNonDerTbsCertificate: Boolean;
+begin
+  Result := FAllowNonDerTbsCertificate;
+end;
+
+class procedure TX509Config.SetAllowNonDerTbsCertificate(AValue: Boolean);
+begin
+  FAllowNonDerTbsCertificate := AValue;
+end;
+
+{ TDHConfig }
+
+class procedure TDHConfig.ResetToDefaults();
+begin
+  FMaxSize := TNullable<Int32>.None;
+end;
+
+class function TDHConfig.GetMaxSize: Int32;
+begin
+  if FMaxSize.HasValue then
+    Result := FMaxSize.Value
+  else
+    Result := DefaultMaxSize;
+end;
+
+class procedure TDHConfig.SetMaxSize(AValue: Int32);
+begin
+  if AValue < 1 then
+    raise EArgumentCryptoLibException.CreateResFmt(@SConfigCeilingNotPositive,
+      ['maximum DH modulus bit length', AValue]);
+
+  FMaxSize := TNullable<Int32>.Some(AValue);
+end;
+
+{ TDsaConfig }
+
+class procedure TDsaConfig.ResetToDefaults();
+begin
+  FMaxSize := TNullable<Int32>.None;
+end;
+
+class function TDsaConfig.GetMaxSize: Int32;
+begin
+  if FMaxSize.HasValue then
+    Result := FMaxSize.Value
+  else
+    Result := DefaultMaxSize;
+end;
+
+class procedure TDsaConfig.SetMaxSize(AValue: Int32);
+begin
+  if AValue < 1 then
+    raise EArgumentCryptoLibException.CreateResFmt(@SConfigCeilingNotPositive,
+      ['maximum DSA modulus bit length', AValue]);
+
+  FMaxSize := TNullable<Int32>.Some(AValue);
+end;
+
+{ TRsaConfig }
+
+class procedure TRsaConfig.ResetToDefaults();
+begin
+  FMaxSize := TNullable<Int32>.None;
+  FMaxMRTests := TNullable<Int32>.None;
+end;
+
+class function TRsaConfig.GetMaxSize: Int32;
+begin
+  if FMaxSize.HasValue then
+    Result := FMaxSize.Value
+  else
+    Result := DefaultMaxSize;
+end;
+
+class procedure TRsaConfig.SetMaxSize(AValue: Int32);
+begin
+  if AValue < 1 then
+    raise EArgumentCryptoLibException.CreateResFmt(@SConfigCeilingNotPositive,
+      ['maximum RSA modulus bit length', AValue]);
+
+  FMaxSize := TNullable<Int32>.Some(AValue);
+end;
+
+class function TRsaConfig.GetMaxMRTests: TNullable<Int32>;
+begin
+  Result := FMaxMRTests;
+end;
+
+class procedure TRsaConfig.SetMaxMRTests(const AValue: TNullable<Int32>);
+begin
+  if AValue.HasValue and (AValue.Value < 0) then
+    raise EArgumentCryptoLibException.CreateResFmt(@SConfigValueNegative,
+      ['RSA Miller-Rabin iteration count', AValue.Value]);
+
+  FMaxMRTests := AValue;
+end;
+
+{ TECConfig }
+
+class procedure TECConfig.ResetToDefaults();
+begin
+  FFpMaxSize := TNullable<Int32>.None;
+  FF2mMaxSize := TNullable<Int32>.None;
+  FFpCertainty := TNullable<Int32>.None;
+end;
+
+class function TECConfig.GetFpMaxSize: Int32;
+begin
+  if FFpMaxSize.HasValue then
+    Result := FFpMaxSize.Value
+  else
+    Result := DefaultFpMaxSize;
+end;
+
+class procedure TECConfig.SetFpMaxSize(AValue: Int32);
+begin
+  if AValue < 1 then
+    raise EArgumentCryptoLibException.CreateResFmt(@SConfigCeilingNotPositive,
+      ['maximum prime-field curve bit length', AValue]);
+
+  FFpMaxSize := TNullable<Int32>.Some(AValue);
+end;
+
+class function TECConfig.GetF2mMaxSize: Int32;
+begin
+  if FF2mMaxSize.HasValue then
+    Result := FF2mMaxSize.Value
+  else
+    Result := DefaultF2mMaxSize;
+end;
+
+class procedure TECConfig.SetF2mMaxSize(AValue: Int32);
+begin
+  if AValue < 1 then
+    raise EArgumentCryptoLibException.CreateResFmt(@SConfigCeilingNotPositive,
+      ['maximum binary-field curve degree', AValue]);
+
+  FF2mMaxSize := TNullable<Int32>.Some(AValue);
+end;
+
+class function TECConfig.GetFpCertainty: Int32;
+begin
+  if FFpCertainty.HasValue then
+    Result := FFpCertainty.Value
+  else
+    Result := DefaultFpCertainty;
+end;
+
+class procedure TECConfig.SetFpCertainty(AValue: Int32);
+begin
+  if AValue < 0 then
+    raise EArgumentCryptoLibException.CreateResFmt(@SConfigValueNegative,
+      ['prime-field curve primality certainty', AValue]);
+
+  FFpCertainty := TNullable<Int32>.Some(AValue);
+end;
+
+{ TPbeConfig }
+
+class procedure TPbeConfig.ResetToDefaults();
+begin
+  FMaxIterationCount := TNullable<Int32>.None;
+end;
+
+class function TPbeConfig.GetMaxIterationCount: Int32;
+begin
+  if FMaxIterationCount.HasValue then
+    Result := FMaxIterationCount.Value
+  else
+    Result := DefaultMaxIterationCount;
+end;
+
+class procedure TPbeConfig.SetMaxIterationCount(AValue: Int32);
+begin
+  if AValue < 1 then
+    raise EArgumentCryptoLibException.CreateResFmt(@SConfigCeilingNotPositive,
+      ['maximum PBE iteration count', AValue]);
+
+  FMaxIterationCount := TNullable<Int32>.Some(AValue);
+end;
+
+{ TPkcs12Config }
+
+class procedure TPkcs12Config.ResetToDefaults();
+begin
+  FMaxIterationCount := TNullable<Int32>.None;
+  FIgnoreUselessPassword := False;
+end;
+
+class function TPkcs12Config.GetMaxIterationCount: Int32;
+begin
+  if FMaxIterationCount.HasValue then
+    Result := FMaxIterationCount.Value
+  else
+    Result := DefaultMaxIterationCount;
+end;
+
+class procedure TPkcs12Config.SetMaxIterationCount(AValue: Int32);
+begin
+  if AValue < 1 then
+    raise EArgumentCryptoLibException.CreateResFmt(@SConfigCeilingNotPositive,
+      ['maximum PKCS#12 iteration count', AValue]);
+
+  FMaxIterationCount := TNullable<Int32>.Some(AValue);
+end;
+
+class function TPkcs12Config.GetIgnoreUselessPassword: Boolean;
+begin
+  Result := FIgnoreUselessPassword;
+end;
+
+class procedure TPkcs12Config.SetIgnoreUselessPassword(AValue: Boolean);
+begin
+  FIgnoreUselessPassword := AValue;
+end;
+
 { TCryptoLibConfig }
+
+class function TCryptoLibConfig.GetAsn1: TCryptoLibConfigAsn1;
+begin
+  Result := TAsn1Config;
+end;
 
 class function TCryptoLibConfig.GetX509: TCryptoLibConfigX509;
 begin
   Result := TX509Config;
 end;
 
+class function TCryptoLibConfig.GetDH: TCryptoLibConfigDH;
+begin
+  Result := TDHConfig;
+end;
+
+class function TCryptoLibConfig.GetDsa: TCryptoLibConfigDsa;
+begin
+  Result := TDsaConfig;
+end;
+
+class function TCryptoLibConfig.GetRsa: TCryptoLibConfigRsa;
+begin
+  Result := TRsaConfig;
+end;
+
+class function TCryptoLibConfig.GetEC: TCryptoLibConfigEC;
+begin
+  Result := TECConfig;
+end;
+
+class function TCryptoLibConfig.GetPbe: TCryptoLibConfigPbe;
+begin
+  Result := TPbeConfig;
+end;
+
+class function TCryptoLibConfig.GetPkcs12: TCryptoLibConfigPkcs12;
+begin
+  Result := TPkcs12Config;
+end;
+
 class procedure TCryptoLibConfig.ResetToDefaults();
 begin
+  TAsn1Config.ResetToDefaults();
   TX509Config.ResetToDefaults();
+  TDHConfig.ResetToDefaults();
+  TDsaConfig.ResetToDefaults();
+  TRsaConfig.ResetToDefaults();
+  TECConfig.ResetToDefaults();
+  TPbeConfig.ResetToDefaults();
+  TPkcs12Config.ResetToDefaults();
 end;
 
 end.

--- a/CryptoLib/src/Pkcs/ClpPkcs12Store.pas
+++ b/CryptoLib/src/Pkcs/ClpPkcs12Store.pas
@@ -58,6 +58,7 @@ uses
   ClpCryptoLibComparers,
   ClpCollectionUtilities,
   ClpArrayUtilities,
+  ClpCryptoLibConfig,
   ClpCryptoLibTypes,
   ClpEncoders,
   ClpPbeUtilities,
@@ -119,7 +120,6 @@ type
       end;
   strict private
     class var
-      FIgnoreUselessPassword: Boolean;
       FCertIDEqualityComparer: IEqualityComparer<TCertID>;
       FCertIDComparer: IComparer<TCertID>;
     class constructor Create;
@@ -189,11 +189,6 @@ type
     const
       DefaultIterations = 1024;
       DefaultSaltSize = 20;
-    /// <summary>
-    /// When <c>true</c>, suppresses the error raised when <see cref="Load"/> is called with a password
-    /// but the file does not require one.
-    /// </summary>
-    class property IgnoreUselessPassword: Boolean read FIgnoreUselessPassword write FIgnoreUselessPassword;
     /// <summary>Calculate PBE MAC for PKCS#12 (exposed for Pkcs12Utilities).</summary>
     class function CalculatePbeMac(const AMacAlgID: IAlgorithmIdentifier;
       const ASalt: TCryptoLibByteArray; AIterations: Int32;
@@ -227,7 +222,7 @@ type
     /// </exception>
     /// <exception cref="EIOCryptoLibException">
     /// The MAC verification failed, a password was supplied when none is required (unless
-    /// <see cref="IgnoreUselessPassword"/> is <c>true</c>), or bag attributes conflict.
+    /// <c>TCryptoLibConfig.Pkcs12.IgnoreUselessPassword</c> is <c>true</c>), or bag attributes conflict.
     /// </exception>
     procedure Load(const AInput: TStream; const APassword: TCryptoLibCharArray);
     /// <summary>
@@ -483,7 +478,6 @@ end;
 
 class constructor TPkcs12Store.Create;
 begin
-  FIgnoreUselessPassword := False;
   FCertIDEqualityComparer := TCertIDEqualityComparer.Create;
   FCertIDComparer := TCertIDComparer.Create;
 end;
@@ -951,7 +945,7 @@ begin
       MapKey('unmarked', LUnmarkedKeyEntry);
     if not LPasswordNeeded and (APassword <> nil) then
     begin
-      LIgnore := FIgnoreUselessPassword;
+      LIgnore := TCryptoLibConfig.Pkcs12.IgnoreUselessPassword;
       if not LIgnore then
         raise EIOCryptoLibException.CreateRes(@SPasswordNotNeeded);
     end;

--- a/CryptoLib/src/Pkcs/ClpPkcs12Utilities.pas
+++ b/CryptoLib/src/Pkcs/ClpPkcs12Utilities.pas
@@ -30,6 +30,7 @@ uses
   ClpPkcsAsn1Objects,
   ClpIX509Asn1Objects,
   ClpX509Asn1Objects,
+  ClpCryptoLibConfig,
   ClpCryptoLibTypes;
 
 resourcestring
@@ -47,13 +48,6 @@ type
   /// </summary>
   TPkcs12Utilities = class sealed(TObject)
   strict private
-    const
-      DefaultMaxPkcs12Iterations = 5000000;
-    class var
-      FMaxPkcs12Iterations: Int32;
-    class constructor Create;
-
-    class function GetEffectiveMaxPkcs12Iterations: Int32; static;
     class function DLEncode(const AAsn1Encodable: IAsn1Encodable): TCryptoLibByteArray; static;
 
   public
@@ -77,8 +71,6 @@ type
     /// <returns>Byte array representing the DER encoding of the PFX structure.</returns>
     class function ConvertToDefiniteLength(const ABerPkcs12File: TCryptoLibByteArray;
       const APassword: TCryptoLibCharArray): TCryptoLibByteArray; overload; static;
-
-    class property MaxPkcs12Iterations: Int32 read FMaxPkcs12Iterations write FMaxPkcs12Iterations;
   end;
 
 implementation
@@ -88,26 +80,13 @@ uses
 
 { TPkcs12Utilities }
 
-class constructor TPkcs12Utilities.Create;
-begin
-  FMaxPkcs12Iterations := -1;
-end;
-
-class function TPkcs12Utilities.GetEffectiveMaxPkcs12Iterations: Int32;
-begin
-  if FMaxPkcs12Iterations < 0 then
-    Result := DefaultMaxPkcs12Iterations
-  else
-    Result := FMaxPkcs12Iterations;
-end;
-
 class function TPkcs12Utilities.ValidateIterations(AIterationCount: Int32): Int32;
 var
   LMax: Int32;
 begin
   if AIterationCount < 0 then
     raise EInvalidOperationCryptoLibException.CreateRes(@SNegativePkcs12IterationCount);
-  LMax := GetEffectiveMaxPkcs12Iterations;
+  LMax := TCryptoLibConfig.Pkcs12.MaxIterationCount;
   if AIterationCount > LMax then
     raise EInvalidOperationCryptoLibException.CreateResFmt(@SPkcs12IterationExceedsMax, [AIterationCount, LMax]);
   Result := AIterationCount;


### PR DESCRIPTION
Consolidate scattered config knobs into TCryptoLibConfig

Move the 13 remaining process-wide configuration switches off their individual owning classes into the central TCryptoLibConfig facade, grouped by area. This completes the config consolidation begun in the PKIX work (which migrated the first four X.509 knobs).

Knobs migrated (old location -> config):
  TDerInteger.AllowUnsafeInteger            -> Asn1.AllowUnsafeInteger
  TAsn1InputStream.MaxConstructedDepth      -> Asn1.MaxDepth
  TAsn1InputStream.MaxLimitForUnknownStream -> Asn1.MaxLimit
  TTbsCertificateStructure.AllowNonDER...   -> X509.AllowNonDerTbsCertificate
  TDHPublicKeyParameters.MaxSize            -> DH.MaxSize
  TDsaPublicKeyParameters.MaxSize           -> Dsa.MaxSize
  TRsaKeyParameters.MaxSize / MaxMRTests    -> Rsa.MaxSize / Rsa.MaxMRTests
  TAbstractFpCurve.MaxFieldSize / Certainty -> EC.FpMaxSize / EC.FpCertainty
  TAbstractF2mCurve.MaxFieldSize            -> EC.F2mMaxSize
  TPbeUtilities.MaxIterationCount           -> Pbe.MaxIterationCount
  TPkcs12Utilities.MaxPkcs12Iterations      -> Pkcs12.MaxIterationCount
  TPkcs12Store.IgnoreUselessPassword        -> Pkcs12.IgnoreUselessPassword

BREAKING: the old public class properties are removed outright, not left as forwarders. Callers set these through TCryptoLibConfig.<Area>.* now.

Design notes:
- EC uses a single area (EC.FpMaxSize / FpCertainty / F2mMaxSize) rather than splitting the prime-field and binary-field settings apart.
- Rsa.MaxMRTests is exposed as TNullable<Int32>: its default is bit-length dependent and 0 is a legal "disable" value, so unset cannot fold onto an integer. GetMRIterations stays in TRsaKeyParameters.
- Numeric ceilings validate and raise on non-positive values; the two ASN.1 parse-limits (MaxDepth, MaxLimit) instead tolerate negatives and clamp to zero at the point of use.
- Nullable-with-default-in-getter replaces the old -1 sentinel encoding.

Tests updated to drive the settings through TCryptoLibConfig and to reset via ResetToDefaults in TearDown.