### PR TITLE
Accept empty values in ASN.1 constructors where empty is legal

### DIFF
--- a/CryptoLib.Tests/src/Asn1/Asn1StreamReadTests.pas
+++ b/CryptoLib.Tests/src/Asn1/Asn1StreamReadTests.pas
@@ -112,6 +112,11 @@ type
     procedure TestTaggedPrimitiveWithEmptyContentsDecodes;
     procedure TestImplicitNullRoundTrips;
     procedure TestOctetStringContentsNilIsEmptyNotAnError;
+    procedure TestOctetStringFromContentsNilIsEmptyNotAnError;
+    procedure TestSequenceAndSetFromNilGenericArrayAreEmpty;
+    procedure TestBmpStringAndAddAllAcceptEmpty;
+    procedure TestEmptyStringTypesAreAccepted;
+    procedure TestBitStringEmptyDataWithZeroPadBitsIsAccepted;
   end;
 
 implementation
@@ -511,6 +516,146 @@ begin
 
   CheckNull(TDerOctetString.WithContentsOptional(nil),
     'the optional form must still report absence as nil');
+end;
+
+// An empty OCTET STRING (04 00) is legal, and Pascal cannot tell an empty array from nil, so the
+// non-optional FromContents/WithContents builders must accept nil as the empty octet string rather
+// than rejecting it. Only the Optional forms carry absence.
+procedure TAsn1StreamReadTest.TestOctetStringFromContentsNilIsEmptyNotAnError;
+var
+  LDer: IDerOctetString;
+  LBer: IBerOctetString;
+begin
+  LDer := TDerOctetString.FromContents(nil);
+  CheckNotNull(LDer, 'DER FromContents(nil) must give the empty octet string, not an error');
+  CheckEquals(0, System.Length(LDer.GetOctets()), 'the DER octet string must be empty');
+
+  LBer := TBerOctetString.WithContents(nil);
+  CheckNotNull(LBer, 'BER WithContents(nil) must give the empty octet string, not an error');
+  CheckEquals(0, System.Length(LBer.GetOctets()), 'the BER octet string must be empty');
+
+  LBer := TBerOctetString.FromContents(nil);
+  CheckNotNull(LBer, 'BER FromContents(nil) must give the empty octet string, not an error');
+  CheckEquals(0, System.Length(LBer.GetOctets()), 'the BER octet string must be empty');
+
+  CheckNull(TDerOctetString.FromContentsOptional(nil),
+    'the DER optional form must still report absence as nil');
+  CheckNull(TBerOctetString.WithContentsOptional(nil),
+    'the BER optional form must still report absence as nil');
+  CheckNull(TBerOctetString.FromContentsOptional(nil),
+    'the BER optional form must still report absence as nil');
+end;
+
+// An empty SEQUENCE (30 00) and SET (31 00) are legal. The generic-array constructors must accept a
+// nil/empty element array as the empty container rather than rejecting it.
+procedure TAsn1StreamReadTest.TestSequenceAndSetFromNilGenericArrayAreEmpty;
+var
+  LNilElements: TCryptoLibGenericArray<IAsn1Encodable>;
+  LSeq: IDerSequence;
+  LSet: IDerSet;
+  LEncoded: TCryptoLibByteArray;
+begin
+  LSeq := TDerSequence.Create(LNilElements);
+  CheckNotNull(LSeq, 'an empty element array must give the empty SEQUENCE, not an error');
+  CheckEquals(0, LSeq.Count, 'the SEQUENCE must have no elements');
+  LEncoded := LSeq.GetEncoded();
+  CheckEquals(2, System.Length(LEncoded), 'the empty SEQUENCE must encode to two bytes');
+  CheckEquals(Int32($30), Int32(LEncoded[0]), 'the SEQUENCE tag octet');
+  CheckEquals(Int32($00), Int32(LEncoded[1]), 'the SEQUENCE length octet must be zero');
+
+  LSet := TDerSet.Create(LNilElements);
+  CheckNotNull(LSet, 'an empty element array must give the empty SET, not an error');
+  CheckEquals(0, LSet.Count, 'the SET must have no elements');
+  LEncoded := LSet.GetEncoded();
+  CheckEquals(2, System.Length(LEncoded), 'the empty SET must encode to two bytes');
+  CheckEquals(Int32($31), Int32(LEncoded[0]), 'the SET tag octet');
+  CheckEquals(Int32($00), Int32(LEncoded[1]), 'the SET length octet must be zero');
+end;
+
+// An empty BMPString is legal (a zero-length string), and adding an empty array to a vector is a
+// legal no-op. Neither may be rejected because Pascal cannot tell an empty array from nil.
+procedure TAsn1StreamReadTest.TestBmpStringAndAddAllAcceptEmpty;
+var
+  LNilBytes: TCryptoLibByteArray;
+  LNilElements: TCryptoLibGenericArray<IAsn1Encodable>;
+  LBmp: IDerBmpString;
+  LVector: IAsn1EncodableVector;
+begin
+  LBmp := TDerBmpString.Create(LNilBytes);
+  CheckNotNull(LBmp, 'empty BMPString contents must give the empty string, not an error');
+  CheckEquals('', LBmp.GetString(), 'the BMPString must be empty');
+
+  LVector := TAsn1EncodableVector.Create();
+  LVector.AddAll(LNilElements);
+  CheckEquals(0, LVector.Count, 'AddAll of an empty array must be a no-op');
+end;
+
+// A zero-length string is legal for every ASN.1 string type, and Pascal's empty string is the
+// closest thing to nil, so the string constructors must accept '' rather than rejecting it.
+procedure TAsn1StreamReadTest.TestEmptyStringTypesAreAccepted;
+var
+  LBmp: IDerBmpString;
+  LGen: IDerGeneralString;
+  LIA5: IDerIA5String;
+  LNum: IDerNumericString;
+  LPrn: IDerPrintableString;
+  LT61: IDerT61String;
+  LVis: IDerVisibleString;
+begin
+  LBmp := TDerBmpString.Create('');
+  CheckNotNull(LBmp, 'empty BMPString must be accepted');
+  CheckEquals('', LBmp.GetString(), 'BMPString must be empty');
+
+  LGen := TDerGeneralString.Create('');
+  CheckNotNull(LGen, 'empty GeneralString must be accepted');
+  CheckEquals('', LGen.GetString(), 'GeneralString must be empty');
+
+  LIA5 := TDerIA5String.Create('');
+  CheckNotNull(LIA5, 'empty IA5String must be accepted');
+  CheckEquals('', LIA5.GetString(), 'IA5String must be empty');
+
+  LNum := TDerNumericString.Create('');
+  CheckNotNull(LNum, 'empty NumericString must be accepted');
+  CheckEquals('', LNum.GetString(), 'NumericString must be empty');
+
+  LPrn := TDerPrintableString.Create('');
+  CheckNotNull(LPrn, 'empty PrintableString must be accepted');
+  CheckEquals('', LPrn.GetString(), 'PrintableString must be empty');
+
+  LT61 := TDerT61String.Create('');
+  CheckNotNull(LT61, 'empty T61String must be accepted');
+  CheckEquals('', LT61.GetString(), 'T61String must be empty');
+
+  LVis := TDerVisibleString.Create('');
+  CheckNotNull(LVis, 'empty VisibleString must be accepted');
+  CheckEquals('', LVis.GetString(), 'VisibleString must be empty');
+end;
+
+// The empty BIT STRING (03 01 00) is legal: empty bit data with a zero pad-bit count. The
+// data+padBits constructor must accept it, while still rejecting empty data with non-zero pad bits.
+procedure TAsn1StreamReadTest.TestBitStringEmptyDataWithZeroPadBitsIsAccepted;
+var
+  LNilData: TCryptoLibByteArray;
+  LBits: IDerBitString;
+  LEncoded: TCryptoLibByteArray;
+  LRaised: Boolean;
+begin
+  LBits := TDerBitString.Create(LNilData, 0);
+  CheckNotNull(LBits, 'empty bit data with zero pad bits must be accepted');
+  LEncoded := LBits.GetEncoded();
+  CheckEquals(3, System.Length(LEncoded), 'the empty BIT STRING must encode to three bytes');
+  CheckEquals(Int32($03), Int32(LEncoded[0]), 'the BIT STRING tag octet');
+  CheckEquals(Int32($01), Int32(LEncoded[1]), 'the length octet must be one');
+  CheckEquals(Int32($00), Int32(LEncoded[2]), 'the single content octet is the zero pad-bit count');
+
+  LRaised := False;
+  try
+    TDerBitString.Create(LNilData, 3);
+  except
+    on E: EArgumentCryptoLibException do
+      LRaised := True;
+  end;
+  CheckTrue(LRaised, 'empty bit data with non-zero pad bits must still be rejected');
 end;
 
 initialization

--- a/CryptoLib.Tests/src/Asn1/BitStringTests.pas
+++ b/CryptoLib.Tests/src/Asn1/BitStringTests.pas
@@ -88,11 +88,13 @@ begin
     Fail('zero encoding wrong');
   end;
 
+  // nil is indistinguishable from empty in Pascal, so (nil, 1) is empty data with a non-zero
+  // pad-bit count, rejected as that violation rather than as a nil-data error
   try
     TDerBitString.Create(nil, 1);
     Fail('exception not thrown');
   except
-    on E: EArgumentNilCryptoLibException do
+    on E: EArgumentCryptoLibException do
     begin
       // Expected
     end;

--- a/CryptoLib/src/Asn1/ClpAsn1Core.pas
+++ b/CryptoLib/src/Asn1/ClpAsn1Core.pas
@@ -35,7 +35,6 @@ uses
 resourcestring
   SInitialCapacityMustNotBeNegative = 'initial capacity must not be negative';
   SElementNil = 'element cannot be nil';
-  SEncodableArrayNil = 'encodable array cannot be nil';
   SOtherVectorNil = 'vector cannot be nil';
   SExtraDataFoundAfterObject = 'extra data found after object';
   SIndexOutOfRange = 'index %d out of range (element count %d)';
@@ -506,9 +505,6 @@ procedure TAsn1EncodableVector.AddAll(const AE: TCryptoLibGenericArray<IAsn1Enco
 var
   LI: Int32;
 begin
-  if AE = nil then
-    raise EArgumentNilCryptoLibException.CreateRes(@SEncodableArrayNil);
-
   for LI := 0 to System.Length(AE) - 1 do
     Add(AE[LI]);
 end;

--- a/CryptoLib/src/Asn1/ClpAsn1Objects.pas
+++ b/CryptoLib/src/Asn1/ClpAsn1Objects.pas
@@ -66,7 +66,6 @@ resourcestring
   SElement2Nil = 'element2 cannot be nil';
   SElementsCannotContainNil = 'elements cannot contain nil';
   SElementVectorNil = 'element vector cannot be nil';
-  SElementsNil = 'elements cannot be nil';
   SIndexOutOfRange = 'index out of range';
   SSequenceNil = 'sequence cannot be nil';
   SSetNil = 'set cannot be nil';
@@ -75,7 +74,6 @@ resourcestring
   SContentsNil = 'contents cannot be nil';
   SZeroLengthDataWithNonZeroPadBits = 'zero length data with non-zero pad bits';
   SPadBitsOutOfRange = 'pad bits cannot be greater than 7 or less than 0';
-  SDataNil = 'data cannot be nil';
   SPadBitsMustBeInRangeZeroToSeven = 'pad bits must be in the range 0 to 7';
   SIfDataIsEmptyPadBitsMustBeZero = 'if data is empty, padBits must be 0';
   STruncatedBitStringDetected = 'truncated BIT STRING detected';
@@ -86,7 +84,6 @@ resourcestring
   SInputSequenceTooLarge = 'input sequence too large';
   SNoTaggedObjectFoundInSequence = 'no tagged object found in sequence, structure does not seem to be of type External';
   SMalformedBmpStringEncodingEncountered = 'malformed BMPString encoding encountered';
-  SStrNil = 'string cannot be nil';
   SEofEncounteredInMiddleOfBmpString = 'EOF encountered in middle of BMPString';
   SDerBmpStringLengthMismatch = 'BMP string length mismatch after parsing';
   SEofEncounteredReadingBooleanOctet = 'EOF encountered reading BOOLEAN octet';
@@ -4254,8 +4251,6 @@ var
   LI: Int32;
 begin
   inherited Create;
-  if AC = nil then
-    raise EArgumentNilCryptoLibException.CreateRes(@SElementsNil);
   System.SetLength(FElements, System.Length(AC));
   for LI := 0 to System.Length(AC) - 1 do
     FElements[LI] := AC[LI];
@@ -5013,8 +5008,6 @@ var
   LI: Int32;
 begin
   inherited Create;
-  if AC = nil then
-    raise EArgumentNilCryptoLibException.CreateRes(@SElementsNil);
   System.SetLength(FElements, System.Length(AC));
   for LI := 0 to System.Length(AC) - 1 do
     FElements[LI] := AC[LI];
@@ -6347,8 +6340,6 @@ end;
 
 class function TDerOctetString.FromContents(const AContents: TCryptoLibByteArray): IDerOctetString;
 begin
-  if AContents = nil then
-    raise EArgumentNilCryptoLibException.CreateRes(@SContentsNil);
   Result := InternalFromContents(AContents);
 end;
 
@@ -6426,8 +6417,6 @@ end;
 
 class function TBerOctetString.FromContents(const AContents: TCryptoLibByteArray): IBerOctetString;
 begin
-  if AContents = nil then
-    raise EArgumentNilCryptoLibException.CreateRes(@SContentsNil);
   Result := InternalFromContents(AContents);
 end;
 
@@ -6464,8 +6453,6 @@ end;
 
 class function TBerOctetString.WithContents(const AContents: TCryptoLibByteArray): IBerOctetString;
 begin
-  if AContents = nil then
-    raise EArgumentNilCryptoLibException.CreateRes(@SContentsNil);
   Result := InternalWithContents(AContents);
 end;
 
@@ -6631,8 +6618,6 @@ end;
 constructor TDerBitString.Create(const AData: TCryptoLibByteArray; APadBits: Int32);
 begin
   inherited Create();
-  if AData = nil then
-    raise EArgumentNilCryptoLibException.CreateRes(@SDataNil);
   if (APadBits < 0) or (APadBits > 7) then
     raise EArgumentCryptoLibException.CreateRes(@SPadBitsMustBeInRangeZeroToSeven);
   if (System.Length(AData) = 0) and (APadBits <> 0) then
@@ -7588,8 +7573,6 @@ var
   LCs: TCryptoLibCharArray;
 begin
   inherited Create();
-  if AStr = nil then
-    raise EArgumentNilCryptoLibException.CreateRes(@SContentsNil);
   LByteLen := System.Length(AStr);
   if (LByteLen and 1) <> 0 then
     raise EArgumentCryptoLibException.CreateRes(@SMalformedBmpStringEncodingEncountered);
@@ -7603,8 +7586,6 @@ end;
 constructor TDerBmpString.Create(const AStr: String);
 begin
   inherited Create();
-  if AStr = '' then
-    raise EArgumentNilCryptoLibException.CreateRes(@SStrNil);
   FStr := AStr;
 end;
 
@@ -10787,8 +10768,6 @@ end;
 constructor TDerGeneralString.Create(const AStr: String);
 begin
   inherited Create();
-  if AStr = '' then
-    raise EArgumentNilCryptoLibException.CreateRes(@SStrNil);
   FContents := TConverters.ConvertStringToBytes(AStr, TEncoding.ASCII);
 end;
 
@@ -11118,8 +11097,6 @@ end;
 constructor TDerIA5String.Create(const AStr: String; AValidate: Boolean);
 begin
   inherited Create();
-  if AStr = '' then
-    raise EArgumentNilCryptoLibException.CreateRes(@SStrNil);
   if AValidate and not IsIA5String(AStr) then
     raise EArgumentCryptoLibException.CreateRes(@SStringContainsIllegalCharacters);
   FContents := TConverters.ConvertStringToBytes(AStr, TEncoding.ASCII);
@@ -11309,8 +11286,6 @@ end;
 constructor TDerNumericString.Create(const AStr: String; AValidate: Boolean);
 begin
   inherited Create();
-  if AStr = '' then
-    raise EArgumentNilCryptoLibException.CreateRes(@SStrNil);
   if AValidate and not IsNumericString(AStr) then
     raise EArgumentCryptoLibException.CreateRes(@SStringContainsIllegalCharacters);
   FContents := TConverters.ConvertStringToBytes(AStr, TEncoding.ASCII);
@@ -11517,8 +11492,6 @@ end;
 constructor TDerPrintableString.Create(const AStr: String);
 begin
   inherited Create();
-  if AStr = '' then
-    raise EArgumentNilCryptoLibException.CreateRes(@SStrNil);
   FContents := TConverters.ConvertStringToBytes(AStr, TEncoding.ASCII);
 end;
 
@@ -11729,8 +11702,6 @@ end;
 constructor TDerT61String.Create(const AStr: String);
 begin
   inherited Create();
-  if AStr = '' then
-    raise EArgumentNilCryptoLibException.CreateRes(@SStrNil);
   FContents := TConverters.ConvertStringToBytes(AStr, FEncoding);
 end;
 
@@ -12264,8 +12235,6 @@ end;
 constructor TDerVisibleString.Create(const AStr: String);
 begin
   inherited Create();
-  if AStr = '' then
-    raise EArgumentNilCryptoLibException.CreateRes(@SStrNil);
   FContents := TConverters.ConvertStringToBytes(AStr, TEncoding.ASCII);
 end;
 


### PR DESCRIPTION
Accept empty values in ASN.1 constructors where empty is legal

A guard implemented as `if AArray = nil then raise` (or `if AStr = '' then raise`) is a misimplementation: a Pascal empty dynamic array and empty string are indistinguishable from nil, so the guard also rejects the legal empty value it was never meant to catch. This drops those guards wherever an empty value is valid per X.690, so empty OCTET STRINGs, SEQUENCEs, SETs, strings and BIT STRINGs construct and decode instead of raising.

Fixed:
- OCTET STRING contents builders: TDerOctetString.FromContents, TBerOctetString.FromContents / .WithContents (empty OCTET STRING is 04 00).
- Container constructors from a generic array: TAsn1Sequence.Create, TAsn1Set.Create (empty SEQUENCE/SET are 30 00 / 31 00).
- TAsn1EncodableVector.AddAll(array): adding an empty array is a no-op.
- Empty-string constructors of the string types: BMPString, GeneralString, IA5String, NumericString, PrintableString, T61String, VisibleString (an empty string is legal; charset validation passes vacuously).
- TDerBitString.Create(data, padBits): empty data with a zero pad-bit count is the empty BIT STRING (03 01 00); the existing "empty data requires zero pad bits" check was dead behind the nil guard.

The *Optional forms (nil -> nil) are unchanged, and contents that are genuinely invalid when empty (BIT STRING contents, BOOLEAN, OBJECT IDENTIFIER, and OID identifier / time strings) still reject as before.

Removed the now-unused resourcestrings SElementsNil, SEncodableArrayNil, SStrNil and SDataNil. Updated BitStringTests.TestZeroLengthStrings: Create(nil, 1) now raises the "empty data, pad bits must be zero" argument error instead of a nil-data error - still a rejection, the accurate reason.

Added tests covering the empty OCTET STRING / SEQUENCE / SET / AddAll / BMPString cases, all seven empty string types, and the empty BIT STRING.