### PR TITLE
Constant-time AES-GCM bulk batching, mode-wide in-place AEAD correctness

### DIFF
--- a/CryptoLib.Tests/src/Crypto/AesBitSlicedTests.pas
+++ b/CryptoLib.Tests/src/Crypto/AesBitSlicedTests.pas
@@ -37,18 +37,23 @@ uses
   ClpAesEngine,
   ClpAesBitSlicedEngine,
   ClpIBlockCipher,
+  ClpIBulkBlockCipher,
+  ClpIBulkBlockCipherMode,
   ClpIAeadCipher,
   ClpKeyParameter,
   ClpIKeyParameter,
   ClpParametersWithIV,
   ClpAeadParameters,
   ClpGcmBlockCipher,
+  ClpGcmUtilities,
   ClpBasicGcmMultiplier,
   ClpIGcmMultiplier,
+  ClpSicBlockCipher,
   ClpCbcBlockCipher,
   ClpBufferedBlockCipher,
   ClpIBufferedCipher,
   ClpICipherParameters,
+  ClpPack,
   ClpCryptoLibTypes,
   ClpCryptoLibExceptions,
   CryptoLibTestBase,
@@ -71,6 +76,13 @@ type
     procedure DoGcmTest(const AKeyHex, ANonceHex, AAadHex, APlainHex,
       ACipherHex, ATagHex: String);
     function NewBitSlicedGcm(): IAeadCipher;
+    // Part A: ProcessBlocks (batched, incl. in-place) vs N sequential ProcessBlock.
+    procedure DoProcessBlocksParity(AKeyLen: Int32; AForEnc: Boolean; ACount: Int32);
+    // Parts B+C: GCM through bit-sliced (soft-bulk) vs table (per-block) engine.
+    procedure DoGcmParity(APlainLen, AKeyLen: Int32; const AAad: TBytes);
+    // In-place GCM (output buffer aliases input) round-trip + valid tag.
+    // Returns '' on success, else a description of the failing length/direction.
+    function DoGcmInPlace(APlainLen: Int32; const AAad: TBytes): String;
   published
     procedure TestFips197Kat;
     procedure TestParityWithTableEngine;
@@ -81,6 +93,13 @@ type
     procedure TestResetAndReInit;
     procedure TestReInitDifferentKeySize;
     procedure TestCallerKeyPreserved;
+    procedure TestProcessBlocksParity;
+    procedure TestProcessBlocksOverflowGuard;
+    procedure TestCtrBatchedVsSingle;
+    procedure TestGcmBatchedVsSingle;
+    procedure TestAggregatedGhashParity;
+    procedure TestChunkedStreamingParity;
+    procedure TestGcmInPlaceStreaming;
   end;
 
 implementation
@@ -495,6 +514,477 @@ begin
       LRaised := True;
   end;
   CheckTrue(LRaised, 'invalid key length did not raise');
+end;
+
+procedure TTestAesBitSliced.DoProcessBlocksParity(AKeyLen: Int32;
+  AForEnc: Boolean; ACount: Int32);
+var
+  LKey, LInput, LSeq, LBulkOut, LInPlace: TBytes;
+  LKeyParam: IKeyParameter;
+  LSeqEng, LBulkEng: IBlockCipher;
+  LBulk: IBulkBlockCipher;
+  LI: Int32;
+begin
+  System.SetLength(LKey, AKeyLen);
+  for LI := 0 to AKeyLen - 1 do
+    LKey[LI] := Byte(Random(256));
+  System.SetLength(LInput, ACount * 16);
+  for LI := 0 to System.Length(LInput) - 1 do
+    LInput[LI] := Byte(Random(256));
+  LKeyParam := TKeyParameter.Create(LKey);
+
+  // Sequential reference: ACount separate ProcessBlock calls.
+  System.SetLength(LSeq, ACount * 16);
+  LSeqEng := TAesBitSlicedEngine.Create();
+  LSeqEng.Init(AForEnc, LKeyParam as ICipherParameters);
+  for LI := 0 to ACount - 1 do
+    LSeqEng.ProcessBlock(LInput, LI * 16, LSeq, LI * 16);
+
+  // Bulk (disjoint buffers).
+  LBulkEng := TAesBitSlicedEngine.Create();
+  LBulkEng.Init(AForEnc, LKeyParam as ICipherParameters);
+  if not Supports(LBulkEng, IBulkBlockCipher, LBulk) then
+    Fail('TAesBitSlicedEngine does not expose IBulkBlockCipher');
+  System.SetLength(LBulkOut, ACount * 16);
+  LBulk.ProcessBlocks(LInput, 0, ACount, LBulkOut, 0);
+  if not AreEqual(LSeq, LBulkOut) then
+    Fail(Format('ProcessBlocks parity (disjoint) failed (%d-bit, %s, %d blocks)',
+      [AKeyLen * 8, SysUtils.BoolToStr(AForEnc, True), ACount]));
+
+  // Bulk (in-place: identical pointers, the aliasing shape SIC/GCM use).
+  LInPlace := System.Copy(LInput);
+  LBulk.ProcessBlocks(LInPlace, 0, ACount, LInPlace, 0);
+  if not AreEqual(LSeq, LInPlace) then
+    Fail(Format('ProcessBlocks parity (in-place) failed (%d-bit, %s, %d blocks)',
+      [AKeyLen * 8, SysUtils.BoolToStr(AForEnc, True), ACount]));
+end;
+
+procedure TTestAesBitSliced.TestProcessBlocksParity;
+const
+  CCounts: array [0 .. 8] of Int32 = (1, 2, 3, 4, 5, 7, 8, 13, 16);
+var
+  LKeyLens: array [0 .. 2] of Int32;
+  LKL, LDir, LC: Int32;
+begin
+  RandSeed := 424242;
+  LKeyLens[0] := 16;
+  LKeyLens[1] := 24;
+  LKeyLens[2] := 32;
+  for LKL := 0 to High(LKeyLens) do
+    for LDir := 0 to 1 do
+      for LC := 0 to High(CCounts) do
+        DoProcessBlocksParity(LKeyLens[LKL], LDir = 0, CCounts[LC]);
+end;
+
+procedure TTestAesBitSliced.TestProcessBlocksOverflowGuard;
+var
+  LBuf: TBytes;
+  LEng: IBlockCipher;
+  LBulk: IBulkBlockCipher;
+  LRaised: Boolean;
+begin
+  // A block count whose byte total (*16) would wrap Int32 must be rejected by
+  // the range check, not overflow it into an out-of-bounds transform.
+  System.SetLength(LBuf, 16);
+  LEng := TAesBitSlicedEngine.Create();
+  LEng.Init(True, TKeyParameter.Create(DecodeHex(KAT_KEY_128))
+    as ICipherParameters);
+  if not Supports(LEng, IBulkBlockCipher, LBulk) then
+    Fail('TAesBitSlicedEngine does not expose IBulkBlockCipher');
+  LRaised := False;
+  try
+    LBulk.ProcessBlocks(LBuf, 0, Int32($08000000), LBuf, 0);
+  except
+    on E: EDataLengthCryptoLibException do
+      LRaised := True;
+  end;
+  CheckTrue(LRaised, 'oversized block count must raise, not overflow the check');
+end;
+
+procedure TTestAesBitSliced.TestCtrBatchedVsSingle;
+var
+  LKey, LIv, LInput, LBatched, LPerBlock, LSplit: TBytes;
+  LKeyParam: IKeyParameter;
+  LParams: ICipherParameters;
+  LSlicedMode, LTableMode, LSplitMode: IBulkBlockCipherMode;
+  LCount, LI: Int32;
+begin
+  RandSeed := 13371337;
+  LCount := 20; // 8 + 8 + 4-ish batching in SIC, plus a non-multiple-of-8 residue
+  System.SetLength(LKey, 16);
+  for LI := 0 to 15 do
+    LKey[LI] := Byte(Random(256));
+  System.SetLength(LIv, 16);
+  for LI := 0 to 15 do
+    LIv[LI] := Byte(Random(256));
+  System.SetLength(LInput, LCount * 16);
+  for LI := 0 to System.Length(LInput) - 1 do
+    LInput[LI] := Byte(Random(256));
+
+  LKeyParam := TKeyParameter.Create(LKey);
+  LParams := TParametersWithIV.Create(LKeyParam, LIv) as ICipherParameters;
+
+  // Batched: the bit-sliced engine exposes IBulkBlockCipher, so SIC batches.
+  LSlicedMode := TSicBlockCipher.Create(TAesBitSlicedEngine.Create()
+    as IBlockCipher) as IBulkBlockCipherMode;
+  LSlicedMode.Init(True, LParams);
+  System.SetLength(LBatched, LCount * 16);
+  LSlicedMode.ProcessBlocks(LInput, 0, LCount, LBatched, 0);
+
+  // Per-block reference: the table engine lacks IBulkBlockCipher, so SIC loops.
+  LTableMode := TSicBlockCipher.Create(TAesEngine.Create() as IBlockCipher)
+    as IBulkBlockCipherMode;
+  LTableMode.Init(True, LParams);
+  System.SetLength(LPerBlock, LCount * 16);
+  LTableMode.ProcessBlocks(LInput, 0, LCount, LPerBlock, 0);
+
+  if not AreEqual(LBatched, LPerBlock) then
+    Fail('AES-CTR batched (bit-sliced) != per-block (table) keystream');
+
+  // Two bulk calls split at a non-multiple-of-8 must equal one call: the
+  // internal counter must carry across the batch boundary.
+  LSplitMode := TSicBlockCipher.Create(TAesBitSlicedEngine.Create()
+    as IBlockCipher) as IBulkBlockCipherMode;
+  LSplitMode.Init(True, LParams);
+  System.SetLength(LSplit, LCount * 16);
+  LSplitMode.ProcessBlocks(LInput, 0, 5, LSplit, 0);
+  LSplitMode.ProcessBlocks(LInput, 5 * 16, LCount - 5, LSplit, 5 * 16);
+  if not AreEqual(LSplit, LBatched) then
+    Fail('AES-CTR split bulk calls != single bulk call');
+end;
+
+procedure TTestAesBitSliced.DoGcmParity(APlainLen, AKeyLen: Int32;
+  const AAad: TBytes);
+var
+  LKey, LNonce, LPlain, LRef, LTest, LDec: TBytes;
+  LKeyParam: IKeyParameter;
+  LParams: ICipherParameters;
+  LRefGcm, LTestGcm, LDecGcm: IAeadCipher;
+  LI, LLen: Int32;
+begin
+  System.SetLength(LKey, AKeyLen);
+  for LI := 0 to AKeyLen - 1 do
+    LKey[LI] := Byte(Random(256));
+  System.SetLength(LNonce, 12);
+  for LI := 0 to 11 do
+    LNonce[LI] := Byte(Random(256));
+  System.SetLength(LPlain, APlainLen);
+  for LI := 0 to APlainLen - 1 do
+    LPlain[LI] := Byte(Random(256));
+
+  LKeyParam := TKeyParameter.Create(LKey);
+  LParams := TAeadParameters.Create(LKeyParam, 128, LNonce, AAad)
+    as ICipherParameters;
+
+  // Reference: table engine + software multiplier -> per-block GHASH path.
+  LRefGcm := TGcmBlockCipher.Create(TAesEngine.Create() as IBlockCipher,
+    TBasicGcmMultiplier.Create() as IGcmMultiplier) as IAeadCipher;
+  LRefGcm.Init(True, LParams);
+  System.SetLength(LRef, LRefGcm.GetOutputSize(APlainLen));
+  LLen := LRefGcm.ProcessBytes(LPlain, 0, APlainLen, LRef, 0);
+  LLen := LLen + LRefGcm.DoFinal(LRef, LLen);
+  System.SetLength(LRef, LLen);
+
+  // Test: bit-sliced engine -> software-bulk aggregated GHASH path.
+  LTestGcm := NewBitSlicedGcm();
+  LTestGcm.Init(True, LParams);
+  System.SetLength(LTest, LTestGcm.GetOutputSize(APlainLen));
+  LLen := LTestGcm.ProcessBytes(LPlain, 0, APlainLen, LTest, 0);
+  LLen := LLen + LTestGcm.DoFinal(LTest, LLen);
+  System.SetLength(LTest, LLen);
+
+  if not AreEqual(LRef, LTest) then
+    Fail(Format('GCM batched vs per-block mismatch (plainlen=%d, key=%d, aadlen=%d)',
+      [APlainLen, AKeyLen * 8, System.Length(AAad)]));
+
+  // Decrypt through the bit-sliced stack; recover plaintext and verify the tag.
+  LDecGcm := NewBitSlicedGcm();
+  LDecGcm.Init(False, LParams);
+  System.SetLength(LDec, LDecGcm.GetOutputSize(System.Length(LTest)));
+  LLen := LDecGcm.ProcessBytes(LTest, 0, System.Length(LTest), LDec, 0);
+  LLen := LLen + LDecGcm.DoFinal(LDec, LLen);
+  System.SetLength(LDec, LLen);
+  if not AreEqual(LDec, LPlain) then
+    Fail(Format('GCM bit-sliced decrypt mismatch (plainlen=%d)', [APlainLen]));
+end;
+
+procedure TTestAesBitSliced.TestGcmBatchedVsSingle;
+const
+  CBlk: array [0 .. 7] of Int32 = (0, 1, 15, 16, 17, 63, 64, 65);
+var
+  LI: Int32;
+  LAad: TBytes;
+begin
+  RandSeed := 55667788;
+  System.SetLength(LAad, 20);
+  for LI := 0 to 19 do
+    LAad[LI] := Byte(LI * 7 + 1);
+  for LI := 0 to High(CBlk) do
+  begin
+    DoGcmParity(CBlk[LI] * 16, 16, nil);  // whole blocks, no AAD, AES-128
+    DoGcmParity(CBlk[LI] * 16, 32, LAad); // whole blocks, AAD, AES-256
+  end;
+  // Partial tails exercise ProcessPartial after the 4-block bulk path.
+  DoGcmParity(16 * 4 + 7, 16, nil);
+  DoGcmParity(16 * 17 + 9, 32, LAad);
+  DoGcmParity(16 * 65 + 15, 24, LAad);
+end;
+
+procedure TTestAesBitSliced.TestAggregatedGhashParity;
+var
+  LH, LY1, LY2: TBytes;
+  LMult: IGcmMultiplier;
+  LH1, LH2, LH3, LH4, LYf, LX1, LX2, LX3, LX4, LTmp, LHc: TFieldElement;
+  LTrial, LI, LNumBlocks, LBlk, LGroups, LTail, LOff: Int32;
+  LBlocks: TBytes;
+begin
+  RandSeed := 909090;
+  for LTrial := 0 to 40 do
+  begin
+    System.SetLength(LH, 16);
+    for LI := 0 to 15 do
+      LH[LI] := Byte(Random(256));
+    LNumBlocks := LTrial mod 11; // 0..10 blocks: groups of 4 plus a 0..2 tail
+    System.SetLength(LBlocks, LNumBlocks * 16);
+    for LI := 0 to System.Length(LBlocks) - 1 do
+      LBlocks[LI] := Byte(Random(256));
+
+    LMult := TBasicGcmMultiplier.Create() as IGcmMultiplier;
+    LMult.Init(LH);
+
+    // Reference: per-block Y := (Y xor B) * H.
+    System.SetLength(LY1, 16);
+    System.FillChar(LY1[0], 16, 0);
+    for LBlk := 0 to LNumBlocks - 1 do
+    begin
+      for LI := 0 to 15 do
+        LY1[LI] := LY1[LI] xor LBlocks[LBlk * 16 + LI];
+      LMult.MultiplyH(LY1);
+    end;
+
+    // Aggregated: groups of 4 via AggregateGhash4, tail per-block via Multiply.
+    TGcmUtilities.ComputePowers1To4(LH, LH1, LH2, LH3, LH4);
+    LYf.N0 := 0;
+    LYf.N1 := 0;
+    LGroups := LNumBlocks div 4;
+    for LBlk := 0 to LGroups - 1 do
+    begin
+      LOff := LBlk * 64;
+      LX1.N0 := TPack.BE_To_UInt64(LBlocks, LOff);
+      LX1.N1 := TPack.BE_To_UInt64(LBlocks, LOff + 8);
+      LX2.N0 := TPack.BE_To_UInt64(LBlocks, LOff + 16);
+      LX2.N1 := TPack.BE_To_UInt64(LBlocks, LOff + 24);
+      LX3.N0 := TPack.BE_To_UInt64(LBlocks, LOff + 32);
+      LX3.N1 := TPack.BE_To_UInt64(LBlocks, LOff + 40);
+      LX4.N0 := TPack.BE_To_UInt64(LBlocks, LOff + 48);
+      LX4.N1 := TPack.BE_To_UInt64(LBlocks, LOff + 56);
+      TGcmUtilities.AggregateGhash4(LYf, LX1, LX2, LX3, LX4, LH1, LH2, LH3, LH4);
+    end;
+    LTail := LNumBlocks mod 4;
+    for LBlk := 0 to LTail - 1 do
+    begin
+      LOff := (LGroups * 4 + LBlk) * 16;
+      LTmp.N0 := TPack.BE_To_UInt64(LBlocks, LOff);
+      LTmp.N1 := TPack.BE_To_UInt64(LBlocks, LOff + 8);
+      LYf.N0 := LYf.N0 xor LTmp.N0;
+      LYf.N1 := LYf.N1 xor LTmp.N1;
+      LHc := LH1;
+      TGcmUtilities.Multiply(LYf, LHc);
+    end;
+    System.SetLength(LY2, 16);
+    TGcmUtilities.AsBytes(LYf, LY2);
+
+    if not AreEqual(LY1, LY2) then
+      Fail(Format('Aggregated GHASH parity failed at trial %d (%d blocks)',
+        [LTrial, LNumBlocks]));
+  end;
+end;
+
+procedure TTestAesBitSliced.TestChunkedStreamingParity;
+const
+  CFrags: array [0 .. 8] of Int32 = (1, 7, 64, 3, 15, 128, 2, 100, 5);
+var
+  LKey, LNonce, LAad, LPlain, LOneShot, LChunked, LDec: TBytes;
+  LKeyParam: IKeyParameter;
+  LParams: ICipherParameters;
+  LGcm: IAeadCipher;
+  LTotal, LI, LOff, LFragIdx, LChunk, LOutOff, LLen: Int32;
+begin
+  RandSeed := 246810;
+  LTotal := 777; // not block-aligned, spans several 4-block batches
+  System.SetLength(LKey, 16);
+  for LI := 0 to 15 do
+    LKey[LI] := Byte(Random(256));
+  System.SetLength(LNonce, 12);
+  for LI := 0 to 11 do
+    LNonce[LI] := Byte(Random(256));
+  System.SetLength(LAad, 20);
+  for LI := 0 to 19 do
+    LAad[LI] := Byte(Random(256));
+  System.SetLength(LPlain, LTotal);
+  for LI := 0 to LTotal - 1 do
+    LPlain[LI] := Byte(Random(256));
+  LKeyParam := TKeyParameter.Create(LKey);
+  LParams := TAeadParameters.Create(LKeyParam, 128, LNonce, LAad)
+    as ICipherParameters;
+
+  // One-shot ciphertext + tag.
+  LGcm := NewBitSlicedGcm();
+  LGcm.Init(True, LParams);
+  System.SetLength(LOneShot, LGcm.GetOutputSize(LTotal));
+  LLen := LGcm.ProcessBytes(LPlain, 0, LTotal, LOneShot, 0);
+  LLen := LLen + LGcm.DoFinal(LOneShot, LLen);
+  System.SetLength(LOneShot, LLen);
+
+  // Chunked feed with pathological fragment sizes (some straddle batch edges).
+  LGcm := NewBitSlicedGcm();
+  LGcm.Init(True, LParams);
+  System.SetLength(LChunked, LGcm.GetOutputSize(LTotal));
+  LOff := 0;
+  LFragIdx := 0;
+  LOutOff := 0;
+  while LOff < LTotal do
+  begin
+    LChunk := CFrags[LFragIdx mod System.Length(CFrags)];
+    if LChunk > LTotal - LOff then
+      LChunk := LTotal - LOff;
+    LOutOff := LOutOff + LGcm.ProcessBytes(LPlain, LOff, LChunk, LChunked, LOutOff);
+    LOff := LOff + LChunk;
+    System.Inc(LFragIdx);
+  end;
+  LOutOff := LOutOff + LGcm.DoFinal(LChunked, LOutOff);
+  System.SetLength(LChunked, LOutOff);
+
+  if not AreEqual(LOneShot, LChunked) then
+    Fail('GCM chunked-feed ciphertext/tag != one-shot');
+
+  // Decrypt the chunked ciphertext with the same fragment pattern.
+  LGcm := NewBitSlicedGcm();
+  LGcm.Init(False, LParams);
+  System.SetLength(LDec, LGcm.GetOutputSize(System.Length(LChunked)));
+  LOff := 0;
+  LFragIdx := 0;
+  LOutOff := 0;
+  while LOff < System.Length(LChunked) do
+  begin
+    LChunk := CFrags[LFragIdx mod System.Length(CFrags)];
+    if LChunk > System.Length(LChunked) - LOff then
+      LChunk := System.Length(LChunked) - LOff;
+    LOutOff := LOutOff + LGcm.ProcessBytes(LChunked, LOff, LChunk, LDec, LOutOff);
+    LOff := LOff + LChunk;
+    System.Inc(LFragIdx);
+  end;
+  LOutOff := LOutOff + LGcm.DoFinal(LDec, LOutOff);
+  System.SetLength(LDec, LOutOff);
+  if not AreEqual(LDec, LPlain) then
+    Fail('GCM chunked-feed decrypt != original plaintext');
+end;
+
+function TTestAesBitSliced.DoGcmInPlace(APlainLen: Int32;
+  const AAad: TBytes): String;
+var
+  LKey, LNonce, LPlain, LRefCT, LBuf: TBytes;
+  LKeyParam: IKeyParameter;
+  LParams: ICipherParameters;
+  LGcm: IAeadCipher;
+  LI, LLen, LTotal: Int32;
+begin
+  Result := '';
+  System.SetLength(LKey, 16);
+  for LI := 0 to 15 do
+    LKey[LI] := Byte(Random(256));
+  System.SetLength(LNonce, 12);
+  for LI := 0 to 11 do
+    LNonce[LI] := Byte(Random(256));
+  System.SetLength(LPlain, APlainLen);
+  for LI := 0 to APlainLen - 1 do
+    LPlain[LI] := Byte(Random(256));
+
+  LKeyParam := TKeyParameter.Create(LKey);
+  LParams := TAeadParameters.Create(LKeyParam, 128, LNonce, AAad)
+    as ICipherParameters;
+
+  // Reference ciphertext||tag, produced out of place.
+  LGcm := NewBitSlicedGcm();
+  LGcm.Init(True, LParams);
+  System.SetLength(LRefCT, LGcm.GetOutputSize(APlainLen));
+  LLen := LGcm.ProcessBytes(LPlain, 0, APlainLen, LRefCT, 0);
+  LLen := LLen + LGcm.DoFinal(LRefCT, LLen);
+  System.SetLength(LRefCT, LLen);
+  LTotal := LLen;
+
+  // In-place encrypt: the buffer starts as plaintext and is encrypted over itself.
+  System.SetLength(LBuf, LTotal);
+  System.Move(LPlain[0], LBuf[0], APlainLen);
+  LGcm := NewBitSlicedGcm();
+  LGcm.Init(True, LParams);
+  try
+    LLen := LGcm.ProcessBytes(LBuf, 0, APlainLen, LBuf, 0);
+    LLen := LLen + LGcm.DoFinal(LBuf, LLen);
+  except
+    on E: Exception do
+    begin
+      Result := Format('[len=%d enc-exc %s] ', [APlainLen, E.Message]);
+      Exit;
+    end;
+  end;
+  if (LLen <> LTotal) or (not AreEqual(LBuf, LRefCT)) then
+  begin
+    Result := Format('[len=%d enc-mismatch] ', [APlainLen]);
+    Exit;
+  end;
+
+  // In-place decrypt: the buffer starts as ciphertext||tag, decrypted over itself.
+  System.SetLength(LBuf, LTotal);
+  System.Move(LRefCT[0], LBuf[0], LTotal);
+  LGcm := NewBitSlicedGcm();
+  LGcm.Init(False, LParams);
+  try
+    LLen := LGcm.ProcessBytes(LBuf, 0, LTotal, LBuf, 0);
+    LLen := LLen + LGcm.DoFinal(LBuf, LLen);
+  except
+    on E: Exception do
+    begin
+      Result := Format('[len=%d dec-exc %s] ', [APlainLen, E.Message]);
+      Exit;
+    end;
+  end;
+  if LLen <> APlainLen then
+  begin
+    Result := Format('[len=%d dec-len %d] ', [APlainLen, LLen]);
+    Exit;
+  end;
+  System.SetLength(LBuf, LLen);
+  if not AreEqual(LBuf, LPlain) then
+    Result := Format('[len=%d dec-mismatch] ', [APlainLen]);
+end;
+
+procedure TTestAesBitSliced.TestGcmInPlaceStreaming;
+var
+  LAad: TBytes;
+  LI: Int32;
+  LFails: String;
+  LLens: array [0 .. 7] of Int32;
+begin
+  RandSeed := 20260723;
+  System.SetLength(LAad, 20);
+  for LI := 0 to 19 do
+    LAad[LI] := Byte(LI * 5 + 3);
+  LLens[0] := 16;
+  LLens[1] := 48;
+  LLens[2] := 64;
+  LLens[3] := 4 * 16 + 7;
+  LLens[4] := 17 * 16 + 9;
+  LLens[5] := 22 * 16;
+  LLens[6] := 65 * 16;      // 8-way pipelined/fused GHASH (SIMD) or soft-bulk (scalar)
+  LLens[7] := 100 * 16 + 3;
+  LFails := '';
+  for LI := 0 to High(LLens) do
+    LFails := LFails + DoGcmInPlace(LLens[LI], nil);
+  for LI := 0 to High(LLens) do
+    LFails := LFails + DoGcmInPlace(LLens[LI], LAad);
+  if LFails <> '' then
+    Fail('in-place GCM: ' + LFails);
 end;
 
 initialization

--- a/CryptoLib.Tests/src/Crypto/EaxTests.pas
+++ b/CryptoLib.Tests/src/Crypto/EaxTests.pas
@@ -97,6 +97,11 @@ type
     procedure DoTestExceptionsAndRandomised;
     procedure DoTestInvalidTagLength;
     procedure DoTestValidTagLength;
+    procedure DoTestInPlace;
+    // In-place (AOutput aliases AInput) round-trip at one length; returns '' on
+    // success or a short description of the failing direction.
+    function InPlaceCase(const ARandom: ISecureRandom; APlainLen, AKeyLen: Int32;
+      const AAad: TBytes): String;
 
   published
     procedure TestVectors;
@@ -104,6 +109,7 @@ type
     procedure TestExceptionsAndRandomised;
     procedure TestInvalidTagLength;
     procedure TestValidTagLength;
+    procedure TestInPlace;
 
   end;
 
@@ -587,6 +593,109 @@ end;
 procedure TTestEax.TestValidTagLength;
 begin
   RunWithCipherKernelToggle(DoTestValidTagLength);
+end;
+
+function TTestEax.InPlaceCase(const ARandom: ISecureRandom;
+  APlainLen, AKeyLen: Int32; const AAad: TBytes): String;
+var
+  LK, LIV, LP, LRef, LBuf: TBytes;
+  LParams: IAeadParameters;
+  LCipher: IEaxBlockCipher;
+  LLen, LTotal: Int32;
+begin
+  Result := '';
+  System.SetLength(LK, AKeyLen);
+  ARandom.NextBytes(LK);
+  System.SetLength(LIV, 12);
+  ARandom.NextBytes(LIV);
+  System.SetLength(LP, APlainLen);
+  if APlainLen > 0 then
+    ARandom.NextBytes(LP);
+  LParams := TAeadParameters.Create(TKeyParameter.Create(LK) as IKeyParameter,
+    16 * 8, LIV, AAad);
+
+  // Reference ciphertext||tag, produced out of place.
+  LCipher := TEaxBlockCipher.Create(CreateEngine) as IEaxBlockCipher;
+  LCipher.Init(True, LParams as ICipherParameters);
+  System.SetLength(LRef, LCipher.GetOutputSize(APlainLen));
+  LLen := LCipher.ProcessBytes(LP, 0, APlainLen, LRef, 0);
+  LLen := LLen + LCipher.DoFinal(LRef, LLen);
+  System.SetLength(LRef, LLen);
+  LTotal := LLen;
+
+  // In-place encrypt: the buffer starts as plaintext and is encrypted over itself.
+  System.SetLength(LBuf, LTotal);
+  if APlainLen > 0 then
+    System.Move(LP[0], LBuf[0], APlainLen);
+  LCipher := TEaxBlockCipher.Create(CreateEngine) as IEaxBlockCipher;
+  LCipher.Init(True, LParams as ICipherParameters);
+  try
+    LLen := LCipher.ProcessBytes(LBuf, 0, APlainLen, LBuf, 0);
+    LLen := LLen + LCipher.DoFinal(LBuf, LLen);
+  except
+    on E: Exception do
+    begin
+      Result := Format('[enc len=%d exc %s] ', [APlainLen, E.Message]);
+      Exit;
+    end;
+  end;
+  if (LLen <> LTotal) or (not AreEqual(LBuf, LRef)) then
+  begin
+    Result := Format('[enc len=%d mismatch] ', [APlainLen]);
+    Exit;
+  end;
+
+  // In-place decrypt: the buffer starts as ciphertext||tag, decrypted over itself.
+  System.SetLength(LBuf, LTotal);
+  System.Move(LRef[0], LBuf[0], LTotal);
+  LCipher := TEaxBlockCipher.Create(CreateEngine) as IEaxBlockCipher;
+  LCipher.Init(False, LParams as ICipherParameters);
+  try
+    LLen := LCipher.ProcessBytes(LBuf, 0, LTotal, LBuf, 0);
+    LLen := LLen + LCipher.DoFinal(LBuf, LLen);
+  except
+    on E: Exception do
+    begin
+      Result := Format('[dec len=%d exc %s] ', [APlainLen, E.Message]);
+      Exit;
+    end;
+  end;
+  if LLen <> APlainLen then
+  begin
+    Result := Format('[dec len=%d got %d] ', [APlainLen, LLen]);
+    Exit;
+  end;
+  System.SetLength(LBuf, LLen);
+  if (APlainLen > 0) and (not AreEqual(LBuf, LP)) then
+    Result := Format('[dec len=%d mismatch] ', [APlainLen]);
+end;
+
+procedure TTestEax.DoTestInPlace;
+const
+  CLens: array [0 .. 10] of Int32 = (0, 16, 48, 4 * 16 + 7, 10 * 16, 17 * 16 + 9,
+    32 * 16, 33 * 16, 65 * 16, 80 * 16 + 5, 100 * 16 + 3);
+var
+  LRnd: ISecureRandom;
+  LFails: String;
+  LI: Int32;
+  LAad: TBytes;
+begin
+  LRnd := TSecureRandom.Create();
+  LRnd.SetSeed(Int64(20260723));
+  System.SetLength(LAad, 20);
+  LRnd.NextBytes(LAad);
+  LFails := '';
+  for LI := 0 to High(CLens) do
+    LFails := LFails + InPlaceCase(LRnd, CLens[LI], 16, nil);
+  for LI := 0 to High(CLens) do
+    LFails := LFails + InPlaceCase(LRnd, CLens[LI], 32, LAad);
+  if LFails <> '' then
+    Fail('in-place EAX: ' + LFails);
+end;
+
+procedure TTestEax.TestInPlace;
+begin
+  RunWithCipherKernelToggle(DoTestInPlace);
 end;
 
 initialization

--- a/CryptoLib.Tests/src/Crypto/GCMTests.pas
+++ b/CryptoLib.Tests/src/Crypto/GCMTests.pas
@@ -89,6 +89,11 @@ type
     procedure DoTestExceptionsWrapper;
     procedure DoTestFourBlockFusedGcmPath;
     procedure DoTestEightBlockFusedGcmPath;
+    procedure DoTestInPlace;
+    // In-place (AOutput aliases AInput) round-trip at one length; returns '' on
+    // success or a short description of the failing direction.
+    function InPlaceCase(const ARandom: ISecureRandom; APlainLen, AKeyLen: Int32;
+      const AAad: TBytes): String;
 
   protected
     procedure SetUp; override;
@@ -101,6 +106,7 @@ type
     procedure TestExceptions;
     procedure TestFourBlockFusedGcmPath;
     procedure TestEightBlockFusedGcmPath;
+    procedure TestInPlace;
 
   end;
 
@@ -729,6 +735,112 @@ begin
       if LP[LJ] <> LDec[LJ] then
         Fail('eight-block GCM round-trip mismatch');
   end;
+end;
+
+function TTestGcm.InPlaceCase(const ARandom: ISecureRandom;
+  APlainLen, AKeyLen: Int32; const AAad: TBytes): String;
+var
+  LK, LIV, LP, LRef, LBuf: TBytes;
+  LParams: IAeadParameters;
+  LCipher: IGcmBlockCipher;
+  LLen, LTotal: Int32;
+begin
+  Result := '';
+  System.SetLength(LK, AKeyLen);
+  ARandom.NextBytes(LK);
+  System.SetLength(LIV, 12);
+  ARandom.NextBytes(LIV);
+  System.SetLength(LP, APlainLen);
+  if APlainLen > 0 then
+    ARandom.NextBytes(LP);
+  LParams := TAeadParameters.Create(TKeyParameter.Create(LK) as IKeyParameter,
+    16 * 8, LIV, AAad);
+
+  // Reference ciphertext||tag, produced out of place.
+  LCipher := TGcmBlockCipher.Create(CreateAesEngine(),
+    TBasicGcmMultiplier.Create() as IGcmMultiplier);
+  LCipher.Init(True, LParams as ICipherParameters);
+  System.SetLength(LRef, LCipher.GetOutputSize(APlainLen));
+  LLen := LCipher.ProcessBytes(LP, 0, APlainLen, LRef, 0);
+  LLen := LLen + LCipher.DoFinal(LRef, LLen);
+  System.SetLength(LRef, LLen);
+  LTotal := LLen;
+
+  // In-place encrypt: the buffer starts as plaintext and is encrypted over itself.
+  System.SetLength(LBuf, LTotal);
+  if APlainLen > 0 then
+    System.Move(LP[0], LBuf[0], APlainLen);
+  LCipher := TGcmBlockCipher.Create(CreateAesEngine(),
+    TBasicGcmMultiplier.Create() as IGcmMultiplier);
+  LCipher.Init(True, LParams as ICipherParameters);
+  try
+    LLen := LCipher.ProcessBytes(LBuf, 0, APlainLen, LBuf, 0);
+    LLen := LLen + LCipher.DoFinal(LBuf, LLen);
+  except
+    on E: Exception do
+    begin
+      Result := Format('[enc len=%d exc %s] ', [APlainLen, E.Message]);
+      Exit;
+    end;
+  end;
+  if (LLen <> LTotal) or (not AreEqual(LBuf, LRef)) then
+  begin
+    Result := Format('[enc len=%d mismatch] ', [APlainLen]);
+    Exit;
+  end;
+
+  // In-place decrypt: the buffer starts as ciphertext||tag, decrypted over itself.
+  System.SetLength(LBuf, LTotal);
+  System.Move(LRef[0], LBuf[0], LTotal);
+  LCipher := TGcmBlockCipher.Create(CreateAesEngine(),
+    TBasicGcmMultiplier.Create() as IGcmMultiplier);
+  LCipher.Init(False, LParams as ICipherParameters);
+  try
+    LLen := LCipher.ProcessBytes(LBuf, 0, LTotal, LBuf, 0);
+    LLen := LLen + LCipher.DoFinal(LBuf, LLen);
+  except
+    on E: Exception do
+    begin
+      Result := Format('[dec len=%d exc %s] ', [APlainLen, E.Message]);
+      Exit;
+    end;
+  end;
+  if LLen <> APlainLen then
+  begin
+    Result := Format('[dec len=%d got %d] ', [APlainLen, LLen]);
+    Exit;
+  end;
+  System.SetLength(LBuf, LLen);
+  if (APlainLen > 0) and (not AreEqual(LBuf, LP)) then
+    Result := Format('[dec len=%d mismatch] ', [APlainLen]);
+end;
+
+procedure TTestGcm.DoTestInPlace;
+const
+  CLens: array [0 .. 10] of Int32 = (0, 16, 48, 64, 4 * 16 + 7, 17 * 16 + 9,
+    22 * 16, 24 * 16, 33 * 16, 65 * 16, 100 * 16 + 3);
+var
+  LRnd: ISecureRandom;
+  LFails: String;
+  LI: Int32;
+  LAad: TBytes;
+begin
+  LRnd := TSecureRandom.Create();
+  LRnd.SetSeed(TDateTimeUtilities.CurrentUnixMs);
+  System.SetLength(LAad, 20);
+  LRnd.NextBytes(LAad);
+  LFails := '';
+  for LI := 0 to High(CLens) do
+    LFails := LFails + InPlaceCase(LRnd, CLens[LI], 16, nil);
+  for LI := 0 to High(CLens) do
+    LFails := LFails + InPlaceCase(LRnd, CLens[LI], 32, LAad);
+  if LFails <> '' then
+    Fail('in-place GCM: ' + LFails);
+end;
+
+procedure TTestGcm.TestInPlace;
+begin
+  RunWithCipherKernelToggle(DoTestInPlace);
 end;
 
 initialization

--- a/CryptoLib/src/Crypto/CipherKernels/Block/ClpAesCryptoExtGcmKernel.pas
+++ b/CryptoLib/src/Crypto/CipherKernels/Block/ClpAesCryptoExtGcmKernel.pas
@@ -28,6 +28,7 @@ uses
   ClpIGcmKernel,
   ClpCipherKernelFactoryBase,
   ClpCipherKernelRegistry,
+  ClpArrayUtilities,
   ClpAesFusedAeadSimd,
   ClpAesCryptoExtFusedArmBackend,
   ClpCryptoLibTypes;
@@ -56,6 +57,7 @@ type
   public
     constructor Create(const AEngine: IAesEngineArm; AKeys: Pointer;
       ARounds: Int32; AHPow128: Pointer);
+    destructor Destroy; override;
     function MinimumBlockCount: Int32;
     function ProcessCtrGhashBatches(AInPtr, AOutPtr, APrevInit, AGhashState,
       AJ0Template: Pointer; ACounter32: UInt32; ABatchCount: NativeInt;
@@ -133,6 +135,13 @@ begin
   System.SetLength(FHPowShifted, 128);
   System.Move(AHPow128^, FHPowShifted[0], 128);
   FHPow128 := @FHPowShifted[0];
+end;
+
+destructor TAesCryptoExtGcmKernel.Destroy;
+begin
+  // Zeroize the kernel-owned H-power table (key-derived; enough to forge tags).
+  TArrayUtilities.Fill(FHPowShifted, 0, System.Length(FHPowShifted), Byte(0));
+  inherited Destroy;
 end;
 
 function TAesCryptoExtGcmKernel.MinimumBlockCount: Int32;

--- a/CryptoLib/src/Crypto/CipherKernels/Block/ClpAesNiGcmKernel.pas
+++ b/CryptoLib/src/Crypto/CipherKernels/Block/ClpAesNiGcmKernel.pas
@@ -29,6 +29,7 @@ uses
   ClpIGcmKernel,
   ClpCipherKernelFactoryBase,
   ClpCipherKernelRegistry,
+  ClpArrayUtilities,
   ClpAesFusedAeadSimd,
   ClpAesNiFusedX86Backend;
 
@@ -63,6 +64,7 @@ type
   public
     constructor Create(const AEngine: IAesEngineX86; AKeys: Pointer;
       ARounds: Int32; AHPow128, AMask: Pointer);
+    destructor Destroy; override;
     function MinimumBlockCount: Int32;
     function ProcessCtrGhashBatches(AInPtr, AOutPtr, APrevInit, AGhashState,
       AJ0Template: Pointer; ACounter32: UInt32; ABatchCount: NativeInt;
@@ -170,6 +172,13 @@ begin
   System.SetLength(FHPowShifted, 128);
   System.Move(AHPow128^, FHPowShifted[0], 128);
   FHPow128 := @FHPowShifted[0];
+end;
+
+destructor TAesNiGcmKernel.Destroy;
+begin
+  // Zeroize the kernel-owned H-power table (key-derived; enough to forge tags).
+  TArrayUtilities.Fill(FHPowShifted, 0, System.Length(FHPowShifted), Byte(0));
+  inherited Destroy;
 end;
 
 function TAesNiGcmKernel.MinimumBlockCount: Int32;

--- a/CryptoLib/src/Crypto/Engines/ClpAesBitSlicedEngine.pas
+++ b/CryptoLib/src/Crypto/Engines/ClpAesBitSlicedEngine.pas
@@ -24,10 +24,12 @@ uses
   SysUtils,
   ClpIAesEngine,
   ClpIBlockCipher,
+  ClpIBulkBlockCipher,
   ClpICipherParameters,
   ClpIKeyParameter,
   ClpCheck,
   ClpPack,
+  ClpBinaryPrimitives,
   ClpBitOperations,
   ClpArrayUtilities,
   ClpPlatformUtilities,
@@ -64,7 +66,8 @@ type
   /// Intended use is constant-time software AES on hosts without hardware AES.
   /// </para>
   /// </remarks>
-  TAesBitSlicedEngine = class sealed(TInterfacedObject, IAesEngine, IBlockCipher)
+  TAesBitSlicedEngine = class sealed(TInterfacedObject, IAesEngine, IBlockCipher,
+    IBulkBlockCipher)
 
   strict private
   const
@@ -107,6 +110,11 @@ type
     procedure BitsliceEncrypt(var AQ: TBitSliceState);
     procedure BitsliceDecrypt(var AQ: TBitSliceState);
 
+    // Transform 1..4 consecutive blocks in one bit-sliced pass: block i occupies
+    // lane (AQ[i], AQ[i+4]); unused lanes are zeroed. Pointers must be identical
+    // or fully disjoint. Reads all inputs before any write, so in-place is safe.
+    procedure ProcessLaneGroup(AInput, AOutput: PByte; ACount: Int32);
+
   strict protected
     function GetAlgorithmName: String; virtual;
 
@@ -125,6 +133,21 @@ type
     /// <exception cref="EDataLengthCryptoLibException">If the input or output buffer range is too short.</exception>
     function ProcessBlock(const AInput: TCryptoLibByteArray; AInOff: Int32;
       const AOutput: TCryptoLibByteArray; AOutOff: Int32): Int32; virtual;
+
+    // ===== IBulkBlockCipher =====
+    // Batch multiple blocks per call, four at a time (the aes_ct64 lane width),
+    // with a 1..3-block tail. Output is byte-identical to ABlockCount sequential
+    // ProcessBlock calls. Aliasing per IBulkBlockCipher: AInput/AOutput identical
+    // (in-place) or fully disjoint; partial overlap is not supported.
+    /// <summary>Transform ABlockCount consecutive 16-byte blocks.</summary>
+    /// <returns>Bytes processed (ABlockCount * 16).</returns>
+    function ProcessBlocks(const AInBuf: TCryptoLibByteArray;
+      AInOff, ABlockCount: Int32; const AOutBuf: TCryptoLibByteArray;
+      AOutOff: Int32): Int32; overload;
+    /// <summary>Pointer overload of ProcessBlocks for mode-internal buffers.</summary>
+    /// <returns>Bytes processed (ABlockCount * 16).</returns>
+    function ProcessBlocks(AInput, AOutput: PByte;
+      ABlockCount: Int32): Int32; overload;
 
     /// <summary>Return the AES block size.</summary>
     /// <returns>16 (fixed AES block size in bytes).</returns>
@@ -811,6 +834,107 @@ begin
   TPack.UInt32_To_LE(LW3, AOutput, AOutOff + 12);
 
   Result := BLOCK_SIZE;
+end;
+
+procedure TAesBitSlicedEngine.ProcessLaneGroup(AInput, AOutput: PByte;
+  ACount: Int32);
+var
+  LQ: TBitSliceState;
+  LW: array [0 .. 3] of UInt32;
+  LI, LBase: Int32;
+begin
+  System.FillChar(LQ, System.SizeOf(LQ), 0);
+
+  for LI := 0 to ACount - 1 do
+  begin
+    LBase := LI * 16;
+    LW[0] := TBinaryPrimitives.ReadUInt32LittleEndian(AInput, LBase);
+    LW[1] := TBinaryPrimitives.ReadUInt32LittleEndian(AInput, LBase + 4);
+    LW[2] := TBinaryPrimitives.ReadUInt32LittleEndian(AInput, LBase + 8);
+    LW[3] := TBinaryPrimitives.ReadUInt32LittleEndian(AInput, LBase + 12);
+    InterleaveIn(LW[0], LW[1], LW[2], LW[3], LQ[LI], LQ[LI + 4]);
+  end;
+
+  Ortho(LQ);
+  if FForEncryption then
+    BitsliceEncrypt(LQ)
+  else
+    BitsliceDecrypt(LQ);
+  Ortho(LQ);
+
+  for LI := 0 to ACount - 1 do
+  begin
+    InterleaveOut(LW[0], LW[1], LW[2], LW[3], LQ[LI], LQ[LI + 4]);
+    LBase := LI * 16;
+    TBinaryPrimitives.WriteUInt32LittleEndian(AOutput, LBase, LW[0]);
+    TBinaryPrimitives.WriteUInt32LittleEndian(AOutput, LBase + 4, LW[1]);
+    TBinaryPrimitives.WriteUInt32LittleEndian(AOutput, LBase + 8, LW[2]);
+    TBinaryPrimitives.WriteUInt32LittleEndian(AOutput, LBase + 12, LW[3]);
+  end;
+
+  System.FillChar(LQ, System.SizeOf(LQ), 0);
+end;
+
+function TAesBitSlicedEngine.ProcessBlocks(const AInBuf: TCryptoLibByteArray;
+  AInOff, ABlockCount: Int32; const AOutBuf: TCryptoLibByteArray;
+  AOutOff: Int32): Int32;
+var
+  LBytes: Int64;
+begin
+  if ABlockCount <= 0 then
+  begin
+    Result := 0;
+    Exit;
+  end;
+
+  if FSkey = nil then
+  begin
+    raise EInvalidOperationCryptoLibException.CreateRes
+      (@SAesEngineNotInitialized);
+  end;
+
+  // Int64 so a very large ABlockCount cannot wrap the byte count negative and
+  // slip past the range checks.
+  LBytes := Int64(ABlockCount) * BLOCK_SIZE;
+  if (AInOff < 0) or ((AInOff + LBytes) > System.Length(AInBuf)) then
+    raise EDataLengthCryptoLibException.CreateRes(@SInputBufferTooShort);
+  if (AOutOff < 0) or ((AOutOff + LBytes) > System.Length(AOutBuf)) then
+    raise EOutputLengthCryptoLibException.CreateRes(@SOutputBufferTooShort);
+
+  Result := ProcessBlocks(@AInBuf[AInOff], @AOutBuf[AOutOff], ABlockCount);
+end;
+
+function TAesBitSlicedEngine.ProcessBlocks(AInput, AOutput: PByte;
+  ABlockCount: Int32): Int32;
+var
+  LBytes: Int64;
+begin
+  if ABlockCount <= 0 then
+  begin
+    Result := 0;
+    Exit;
+  end;
+
+  if FSkey = nil then
+  begin
+    raise EInvalidOperationCryptoLibException.CreateRes
+      (@SAesEngineNotInitialized);
+  end;
+
+  LBytes := Int64(ABlockCount) * BLOCK_SIZE;
+
+  while ABlockCount >= 4 do
+  begin
+    ProcessLaneGroup(AInput, AOutput, 4);
+    System.Inc(AInput, 64);
+    System.Inc(AOutput, 64);
+    System.Dec(ABlockCount, 4);
+  end;
+
+  if ABlockCount > 0 then
+    ProcessLaneGroup(AInput, AOutput, ABlockCount);
+
+  Result := Int32(LBytes);
 end;
 
 end.

--- a/CryptoLib/src/Crypto/Modes/ClpEaxBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpEaxBlockCipher.pas
@@ -687,11 +687,13 @@ begin
           @FCtrBlock[0], @FOmacState[0], LMiddleBlocks);
 
         // Scalar block LBulkBlocks - 1 (new lookahead, so DoFinal can
-        // choose subkey B or P on the final block).
+        // choose subkey B or P on the final block). Capture the ciphertext
+        // into the lookahead before CtrEncryptBlock overwrites the input, so
+        // the in-place case (AOutput aliases AInput) keeps the OMAC correct.
         LLastInOff := AInOff + (LBulkBlocks - 1) * FBlockSize - FMacSize;
         LLastOutOff := AOutOff + LResultLen + (LBulkBlocks - 1) * FBlockSize;
-        CtrEncryptBlock(@AInput[LLastInOff], @AOutput[LLastOutOff]);
         System.Move(AInput[LLastInOff], FOmacLookahead[0], FBlockSize);
+        CtrEncryptBlock(@AInput[LLastInOff], @AOutput[LLastOutOff]);
         FHasOmacLookahead := True;
       end
       else
@@ -713,9 +715,13 @@ begin
         begin
           LLastInOff := AInOff + LI * FBlockSize - FMacSize;
           LLastOutOff := AOutOff + LResultLen + LI * FBlockSize;
+          // Capture the ciphertext into scratch before CtrEncryptBlock
+          // overwrites the input, so the in-place case (AOutput aliases
+          // AInput) still feeds the OMAC lookahead the ciphertext.
+          System.Move(AInput[LLastInOff], LScratch[0], FBlockSize);
           CtrEncryptBlock(@AInput[LLastInOff], @AOutput[LLastOutOff]);
           FlushOmacLookahead();
-          System.Move(AInput[LLastInOff], FOmacLookahead[0], FBlockSize);
+          System.Move(LScratch[0], FOmacLookahead[0], FBlockSize);
           FHasOmacLookahead := True;
         end;
       end;

--- a/CryptoLib/src/Crypto/Modes/ClpGcmBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpGcmBlockCipher.pas
@@ -145,6 +145,11 @@ type
     FWorkCtr: TCryptoLibByteArray;
     /// <summary>Second 128-byte keystream buffer for the pipeline-by-one path (look-ahead batch). nil if fused paths are off.</summary>
     FWorkCtrAhead: TCryptoLibByteArray;
+    /// <summary>True when the underlying cipher is bulk-capable but SIMD GHASH is unavailable:
+    /// drives the software-GHASH 4-block batch path (bulk AES + scalar aggregated GHASH).</summary>
+    FSoftBulk: Boolean;
+    /// <summary>H^1..H^4 as field elements for the scalar aggregated 4-block GHASH; set when FSoftBulk.</summary>
+    FGhH1, FGhH2, FGhH3, FGhH4: TFieldElement;
 
     // ---------------------------------------------------------------------
     // GHASH primitives and scalar triple-XOR helpers.
@@ -271,6 +276,22 @@ type
       ALimit: Int32);
 
     // ---------------------------------------------------------------------
+    // Software-GHASH 4-block batch path: bulk AES keystream (FBulkCipher) plus
+    // the scalar aggregated 4-way GHASH. Used when the cipher is bulk-capable
+    // but SIMD GHASH is unavailable (FSoftBulk). Counter keystream comes from
+    // GetNextCtrBlocks4 (GCM inc32); do NOT substitute SIC's 128-bit counter.
+    // ---------------------------------------------------------------------
+    procedure SoftAggregateGhash4(const ABuf: TCryptoLibByteArray; AOff: Int32);
+    procedure ProcessSoftBulk4(const AInBuf: TCryptoLibByteArray; AInOff: Int32;
+      const AOutBuf: TCryptoLibByteArray; AOutOff: Int32; AForEncrypt: Boolean);
+    procedure EncryptBlocksSoftBulk4(const AInBuf: TCryptoLibByteArray;
+      var AInOff: Int32; var ALen: Int32; const AOutBuf: TCryptoLibByteArray;
+      var AOutOff: Int32);
+    procedure DecryptBlocksSoftBulk4(const AInBuf: TCryptoLibByteArray;
+      var AInOff: Int32; var ALen: Int32; const AOutBuf: TCryptoLibByteArray;
+      var AOutOff: Int32; ALimit: Int32);
+
+    // ---------------------------------------------------------------------
     // CTR keystream generation helpers (scalar + 4-way + 8-way).
     // ---------------------------------------------------------------------
     procedure GetNextCtrBlock(const ABlock: TCryptoLibByteArray);
@@ -292,6 +313,9 @@ type
     // ---------------------------------------------------------------------
     procedure CheckStatus();
     procedure DoReset(AClearMac: Boolean);
+    /// <summary>Zeroize the hash subkey, H-power tables, keystream buffers, and
+    /// aggregated GHASH powers. Not called from Reset (same-key re-Init reuses them).</summary>
+    procedure WipeKeyMaterial();
 
   strict protected
     function GetAlgorithmName: String; virtual;
@@ -300,6 +324,8 @@ type
   public
     constructor Create(const ACipher: IBlockCipher); overload;
     constructor Create(const ACipher: IBlockCipher; const AMultiplier: IGcmMultiplier); overload;
+    /// <summary>Zeroize key-derived material (H, H-power tables, keystream buffers, last key).</summary>
+    destructor Destroy; override;
 
     procedure Init(AForEncryption: Boolean; const AParameters: ICipherParameters); virtual;
     function GetBlockSize(): Int32; virtual;
@@ -443,6 +469,9 @@ end;
 
 procedure TGcmBlockCipher.InitCipherAndHashSubKey(const AKeyParam: IKeyParameter);
 begin
+  // Zeroize any prior key-derived material before this rekey overwrites it.
+  WipeKeyMaterial();
+
   FCipher.Init(True, AKeyParam as ICipherParameters);
 
   TBlockCipherBulkUtilities.TryResolveBulkCipher(FCipher, FBulkCipher);
@@ -459,6 +488,7 @@ begin
   FHPow := nil;
   FWorkCtr := nil;
   FWorkCtrAhead := nil;
+  FSoftBulk := False;
   if TGcmBlockCipher.IsFourWaySupported then
   begin
     System.SetLength(FHPow, 128);
@@ -478,6 +508,13 @@ begin
         FGcmKernelMinBlocks := 0;
       end;
     end;
+  end
+  else if FBulkCipher <> nil then
+  begin
+    FSoftBulk := True;
+    System.SetLength(FWorkCtr, BlockSize * 4);
+    TArrayUtilities.Fill(FWorkCtr, 0, System.Length(FWorkCtr), Byte(0));
+    TGcmUtilities.ComputePowers1To4(FH, FGhH1, FGhH2, FGhH3, FGhH4);
   end;
 end;
 
@@ -558,6 +595,9 @@ begin
     // re-Init with the same key (fresh nonce per message) keeps them all.
     LSameKey := (FH <> nil) and (FLastKey <> nil) and
       LKeyParam.FixedTimeEquals(FLastKey);
+    // Zeroize the previous key copy before replacing it (the comparison above
+    // has already consumed it); Fill is a no-op on the first Init (nil).
+    TArrayUtilities.Fill(FLastKey, 0, System.Length(FLastKey), Byte(0));
     FLastKey := LKeyParam.GetKey();
     if not LSameKey then
       InitCipherAndHashSubKey(LKeyParam);
@@ -823,6 +863,17 @@ begin
         AOutOff := AOutOff + (BlockSize * 2);
       end;
     end
+    else if FSoftBulk and (ALen >= BlockSize * 4) then
+    begin
+      EncryptBlocksSoftBulk4(AInput, AInOff, ALen, AOutput, AOutOff);
+      if ALen >= BlockSize * 2 then
+      begin
+        CipherBlocks2(AInput, AInOff, AOutput, AOutOff, True);
+        AInOff := AInOff + (BlockSize * 2);
+        ALen := ALen - (BlockSize * 2);
+        AOutOff := AOutOff + (BlockSize * 2);
+      end;
+    end
     else
     begin
       while ALen >= BlockSize * 2 do
@@ -929,6 +980,17 @@ begin
     else if TGcmBlockCipher.IsFourWaySupported and (ALen >= LThresh4) then
     begin
       DecryptBlocks4(AInput, AInOff, ALen, AOutput, AOutOff, LThresh4);
+      if ALen >= LThresh2 then
+      begin
+        CipherBlocks2(AInput, AInOff, AOutput, AOutOff, False);
+        AInOff := AInOff + (BlockSize * 2);
+        ALen := ALen - (BlockSize * 2);
+        AOutOff := AOutOff + (BlockSize * 2);
+      end;
+    end
+    else if FSoftBulk and (ALen >= LThresh4) then
+    begin
+      DecryptBlocksSoftBulk4(AInput, AInOff, ALen, AOutput, AOutOff, LThresh4);
       if ALen >= LThresh2 then
       begin
         CipherBlocks2(AInput, AInOff, AOutput, AOutOff, False);
@@ -1100,6 +1162,25 @@ begin
   end;
 end;
 
+procedure TGcmBlockCipher.WipeKeyMaterial();
+begin
+  TArrayUtilities.Fill(FH, 0, System.Length(FH), Byte(0));
+  TArrayUtilities.Fill(FHPow, 0, System.Length(FHPow), Byte(0));
+  TArrayUtilities.Fill(FWorkCtr, 0, System.Length(FWorkCtr), Byte(0));
+  TArrayUtilities.Fill(FWorkCtrAhead, 0, System.Length(FWorkCtrAhead), Byte(0));
+  FGhH1.N0 := 0; FGhH1.N1 := 0;
+  FGhH2.N0 := 0; FGhH2.N1 := 0;
+  FGhH3.N0 := 0; FGhH3.N1 := 0;
+  FGhH4.N0 := 0; FGhH4.N1 := 0;
+end;
+
+destructor TGcmBlockCipher.Destroy;
+begin
+  WipeKeyMaterial();
+  TArrayUtilities.Fill(FLastKey, 0, System.Length(FLastKey), Byte(0));
+  inherited Destroy;
+end;
+
 // =======================================================================
 // Byte-reverse primitive and shuffled-block GHASH kernels used by the
 // fused / pipelined batch routines below. The 64-byte / 128-byte triple-
@@ -1166,15 +1247,23 @@ procedure TGcmBlockCipher.ProcessBlocks4Fused(const AInBuf: TCryptoLibByteArray;
   AInOff: Int32; const AOutBuf: TCryptoLibByteArray; AOutOff: Int32;
   AForEncrypt: Boolean);
 var
-  LPHash: PByte;
+  LPIn, LPOut: PByte;
 begin
   GetNextCtrBlocks4(FWorkCtr);
-  TByteUtilities.&Xor(64, PByte(AInBuf) + AInOff, PByte(FWorkCtr), PByte(AOutBuf) + AOutOff);
+  LPIn := PByte(AInBuf) + AInOff;
+  LPOut := PByte(AOutBuf) + AOutOff;
+  // Decrypt hashes the input ciphertext, read before the XOR overwrites it
+  // (the in-place case aliases input and output).
   if AForEncrypt then
-    LPHash := PByte(AOutBuf) + AOutOff
+  begin
+    TByteUtilities.&Xor(64, LPIn, PByte(FWorkCtr), LPOut);
+    GhashFourShuffledBlocks(LPOut, LPOut + 16, LPOut + 32, LPOut + 48);
+  end
   else
-    LPHash := PByte(AInBuf) + AInOff;
-  GhashFourShuffledBlocks(LPHash, LPHash + 16, LPHash + 32, LPHash + 48);
+  begin
+    GhashFourShuffledBlocks(LPIn, LPIn + 16, LPIn + 32, LPIn + 48);
+    TByteUtilities.&Xor(64, LPIn, PByte(FWorkCtr), LPOut);
+  end;
 end;
 
 procedure TGcmBlockCipher.GhashEightShuffledBlocks(PBase: PByte);
@@ -1198,15 +1287,23 @@ procedure TGcmBlockCipher.ProcessBlocks8Fused(const AInBuf: TCryptoLibByteArray;
   AInOff: Int32; const AOutBuf: TCryptoLibByteArray; AOutOff: Int32;
   AForEncrypt: Boolean);
 var
-  LPHash: PByte;
+  LPIn, LPOut: PByte;
 begin
   GetNextCtrBlocks8(FWorkCtr);
-  TByteUtilities.&Xor(128, PByte(AInBuf) + AInOff, PByte(FWorkCtr), PByte(AOutBuf) + AOutOff);
+  LPIn := PByte(AInBuf) + AInOff;
+  LPOut := PByte(AOutBuf) + AOutOff;
+  // Decrypt hashes the input ciphertext, read before the XOR overwrites it
+  // (the in-place case aliases input and output).
   if AForEncrypt then
-    LPHash := PByte(AOutBuf) + AOutOff
+  begin
+    TByteUtilities.&Xor(128, LPIn, PByte(FWorkCtr), LPOut);
+    GhashEightShuffledBlocks(LPOut);
+  end
   else
-    LPHash := PByte(AInBuf) + AInOff;
-  GhashEightShuffledBlocks(LPHash);
+  begin
+    GhashEightShuffledBlocks(LPIn);
+    TByteUtilities.&Xor(128, LPIn, PByte(FWorkCtr), LPOut);
+  end;
 end;
 
 // Pipeline-by-one fused four-block step. Requires ALen >= ALimit + BlockSize*4*2
@@ -1418,6 +1515,26 @@ begin
   if ALen < ALimit + (BlockSize * 8) * 2 then
     Exit;
 
+  // Non-lagged decrypt: the kernel GHASHes each batch's own input ciphertext
+  // (read before its XOR), so there is no prime batch to seed and no trailing
+  // batch to drain, and input/output may alias. Process every full batch that
+  // clears the tail hold-back and let the caller's per-batch loop mop up.
+  if not AForEncrypt then
+  begin
+    LBatches := (ALen - ALimit) div (BlockSize * 8);
+    if LBatches > 0 then
+    begin
+      LPIn := PByte(AInBuf) + AInOff;
+      LPOut := PByte(AOutBuf) + AOutOff;
+      FCounter32 := FGcmKernel.ProcessCtrGhashBatches(LPIn, LPOut, LPIn,
+        @FS[0], @FJ0[0], FCounter32, LBatches, False);
+      AInOff := AInOff + LBatches * (BlockSize * 8);
+      AOutOff := AOutOff + LBatches * (BlockSize * 8);
+      ALen := ALen - LBatches * (BlockSize * 8);
+    end;
+    Exit;
+  end;
+
   LCurrCtrs := FWorkCtr;
 
   // Prime batch 0: regular 8-wide keystream into LCurrCtrs (now holds keystream),
@@ -1543,19 +1660,21 @@ begin
   LCtrBlock := nil;
   System.SetLength(LCtrBlock, BlockSize);
   GetNextCtrBlock(LCtrBlock);
-  // Encrypt: C := keystream xor In; FS := FS xor C; Out := C.
-  // Decrypt: FS := FS xor In (= ciphertext); Out := In xor keystream.
+  // Read the input block through the three-operand XOR before it can be
+  // overwritten, so the in-place case (Out aliases In) stays correct.
   if AForEncrypt then
   begin
-    System.Move(LCtrBlock[0], AOutBuf[AOutOff], BlockSize);
-    TByteUtilities.XorTo(BlockSize, PByte(@AInBuf[AInOff]), PByte(@AOutBuf[AOutOff]));
+    // Out := In xor keystream (ciphertext); FS := FS xor Out.
+    TByteUtilities.&Xor(BlockSize, PByte(@AInBuf[AInOff]), PByte(@LCtrBlock[0]),
+      PByte(@AOutBuf[AOutOff]));
     TByteUtilities.XorTo(BlockSize, PByte(@AOutBuf[AOutOff]), PByte(@FS[0]));
   end
   else
   begin
-    System.Move(AInBuf[AInOff], AOutBuf[AOutOff], BlockSize);
-    TByteUtilities.XorTo(BlockSize, PByte(@LCtrBlock[0]), PByte(@AOutBuf[AOutOff]));
+    // FS := FS xor In (ciphertext) first; then Out := In xor keystream.
     TByteUtilities.XorTo(BlockSize, PByte(@AInBuf[AInOff]), PByte(@FS[0]));
+    TByteUtilities.&Xor(BlockSize, PByte(@AInBuf[AInOff]), PByte(@LCtrBlock[0]),
+      PByte(@AOutBuf[AOutOff]));
   end;
   FMultiplier.MultiplyH(FS);
 end;
@@ -1610,6 +1729,76 @@ begin
   end;
 end;
 
+// Scalar aggregated 4-way GHASH over four consecutive 16-byte blocks at
+// ABuf[AOff..AOff+63], folding them into the running state FS in one reduction.
+procedure TGcmBlockCipher.SoftAggregateGhash4(const ABuf: TCryptoLibByteArray;
+  AOff: Int32);
+var
+  LY, LX1, LX2, LX3, LX4: TFieldElement;
+begin
+  TGcmUtilities.AsFieldElement(FS, LY);
+  LX1.N0 := TPack.BE_To_UInt64(ABuf, AOff);
+  LX1.N1 := TPack.BE_To_UInt64(ABuf, AOff + 8);
+  LX2.N0 := TPack.BE_To_UInt64(ABuf, AOff + 16);
+  LX2.N1 := TPack.BE_To_UInt64(ABuf, AOff + 24);
+  LX3.N0 := TPack.BE_To_UInt64(ABuf, AOff + 32);
+  LX3.N1 := TPack.BE_To_UInt64(ABuf, AOff + 40);
+  LX4.N0 := TPack.BE_To_UInt64(ABuf, AOff + 48);
+  LX4.N1 := TPack.BE_To_UInt64(ABuf, AOff + 56);
+  TGcmUtilities.AggregateGhash4(LY, LX1, LX2, LX3, LX4,
+    FGhH1, FGhH2, FGhH3, FGhH4);
+  TGcmUtilities.AsBytes(LY, FS);
+end;
+
+// Single software-bulk 4-way step: bulk AES keystream via FBulkCipher, XOR,
+// then aggregated GHASH. AForEncrypt hashes the output (encrypt) or input (decrypt).
+procedure TGcmBlockCipher.ProcessSoftBulk4(const AInBuf: TCryptoLibByteArray;
+  AInOff: Int32; const AOutBuf: TCryptoLibByteArray; AOutOff: Int32;
+  AForEncrypt: Boolean);
+begin
+  GetNextCtrBlocks4(FWorkCtr);
+  // Decrypt hashes the input ciphertext, which must be read before the XOR
+  // overwrites it (the in-place case aliases input and output).
+  if AForEncrypt then
+  begin
+    TByteUtilities.&Xor(64, PByte(AInBuf) + AInOff, PByte(FWorkCtr),
+      PByte(AOutBuf) + AOutOff);
+    SoftAggregateGhash4(AOutBuf, AOutOff);
+  end
+  else
+  begin
+    SoftAggregateGhash4(AInBuf, AInOff);
+    TByteUtilities.&Xor(64, PByte(AInBuf) + AInOff, PByte(FWorkCtr),
+      PByte(AOutBuf) + AOutOff);
+  end;
+end;
+
+procedure TGcmBlockCipher.EncryptBlocksSoftBulk4(const AInBuf: TCryptoLibByteArray;
+  var AInOff: Int32; var ALen: Int32; const AOutBuf: TCryptoLibByteArray;
+  var AOutOff: Int32);
+begin
+  while ALen >= BlockSize * 4 do
+  begin
+    ProcessSoftBulk4(AInBuf, AInOff, AOutBuf, AOutOff, True);
+    AInOff := AInOff + (BlockSize * 4);
+    ALen := ALen - (BlockSize * 4);
+    AOutOff := AOutOff + (BlockSize * 4);
+  end;
+end;
+
+procedure TGcmBlockCipher.DecryptBlocksSoftBulk4(const AInBuf: TCryptoLibByteArray;
+  var AInOff: Int32; var ALen: Int32; const AOutBuf: TCryptoLibByteArray;
+  var AOutOff: Int32; ALimit: Int32);
+begin
+  while ALen >= ALimit do
+  begin
+    ProcessSoftBulk4(AInBuf, AInOff, AOutBuf, AOutOff, False);
+    AInOff := AInOff + (BlockSize * 4);
+    ALen := ALen - (BlockSize * 4);
+    AOutOff := AOutOff + (BlockSize * 4);
+  end;
+end;
+
 procedure TGcmBlockCipher.CipherBlocks2(const AInBuf: TCryptoLibByteArray;
   AInOff: Int32; const AOutBuf: TCryptoLibByteArray; AOutOff: Int32;
   AForEncrypt: Boolean);
@@ -1623,17 +1812,19 @@ begin
   for LB := 0 to 1 do
   begin
     GetNextCtrBlock(LCtrBlock);
+    // Read the input block through the three-operand XOR before it can be
+    // overwritten, so the in-place case (Out aliases In) stays correct.
     if AForEncrypt then
     begin
-      System.Move(LCtrBlock[0], AOutBuf[AOutOff], BlockSize);
-      TByteUtilities.XorTo(BlockSize, PByte(@AInBuf[AInOff]), PByte(@AOutBuf[AOutOff]));
+      TByteUtilities.&Xor(BlockSize, PByte(@AInBuf[AInOff]), PByte(@LCtrBlock[0]),
+        PByte(@AOutBuf[AOutOff]));
       TByteUtilities.XorTo(BlockSize, PByte(@AOutBuf[AOutOff]), PByte(@FS[0]));
     end
     else
     begin
-      System.Move(AInBuf[AInOff], AOutBuf[AOutOff], BlockSize);
-      TByteUtilities.XorTo(BlockSize, PByte(@LCtrBlock[0]), PByte(@AOutBuf[AOutOff]));
       TByteUtilities.XorTo(BlockSize, PByte(@AInBuf[AInOff]), PByte(@FS[0]));
+      TByteUtilities.&Xor(BlockSize, PByte(@AInBuf[AInOff]), PByte(@LCtrBlock[0]),
+        PByte(@AOutBuf[AOutOff]));
     end;
     FMultiplier.MultiplyH(FS);
     AInOff := AInOff + BlockSize;

--- a/CryptoLib/src/Crypto/Modes/Gcm/ClpGcmUtilities.pas
+++ b/CryptoLib/src/Crypto/Modes/Gcm/ClpGcmUtilities.pas
@@ -59,6 +59,22 @@ type
     class procedure Multiply(const AX, AY: TCryptoLibByteArray); overload; static;
     class procedure Multiply(var AX: TFieldElement; var AY: TFieldElement); overload; static;
 
+    /// <summary>Unreduced 256-bit carry-less product of AX and AY (four 64-bit
+    /// limbs), before the field reduction. Same primitives as Multiply.</summary>
+    class procedure MultiplyNoReduce(const AX, AY: TFieldElement;
+      out AZ0, AZ1, AZ2, AZ3: UInt64); static;
+    /// <summary>Reduce a four-limb unreduced product to a 128-bit field element.</summary>
+    class procedure ReduceProduct(AZ0, AZ1, AZ2, AZ3: UInt64;
+      out AX: TFieldElement); static;
+    /// <summary>H^1..H^4 as field elements from the 16-byte hash subkey.</summary>
+    class procedure ComputePowers1To4(const AH: TCryptoLibByteArray;
+      out AH1, AH2, AH3, AH4: TFieldElement); static;
+    /// <summary>Advance GHASH state AY over four blocks in one reduction:
+    /// AY := (AY xor AX1)*H4 xor AX2*H3 xor AX3*H2 xor AX4*H1. AX1 is the oldest
+    /// block. Result equals four sequential (AY xor Xi)*H1 steps.</summary>
+    class procedure AggregateGhash4(var AY: TFieldElement;
+      const AX1, AX2, AX3, AX4, AH1, AH2, AH3, AH4: TFieldElement); static;
+
     class procedure MultiplyP7(var AX: TFieldElement); static;
     class procedure MultiplyP8(var AX: TFieldElement; out AY: TFieldElement); static;
 
@@ -137,14 +153,22 @@ end;
 
 class procedure TGcmUtilities.Multiply(var AX: TFieldElement; var AY: TFieldElement);
 var
-  LX0, LX1, LY0, LY1: UInt64;
-  LX0R, LX1R, LY0R, LY1R: UInt64;
   LZ0, LZ1, LZ2, LZ3: UInt64;
-  LH0, LH1, LH2, LH3, LH4, LH5: UInt64;
 begin
   if TGhashSimd.TryMultiply(@AX, @AY) then
     Exit;
 
+  MultiplyNoReduce(AX, AY, LZ0, LZ1, LZ2, LZ3);
+  ReduceProduct(LZ0, LZ1, LZ2, LZ3, AX);
+end;
+
+class procedure TGcmUtilities.MultiplyNoReduce(const AX, AY: TFieldElement;
+  out AZ0, AZ1, AZ2, AZ3: UInt64);
+var
+  LX0, LX1, LY0, LY1: UInt64;
+  LX0R, LX1R, LY0R, LY1R: UInt64;
+  LH0, LH1, LH2, LH3, LH4, LH5: UInt64;
+begin
   LX0 := AX.N0;
   LX1 := AX.N1;
   LY0 := AY.N0;
@@ -161,19 +185,52 @@ begin
   LH4 := TInt64Utilities.Reverse(ImplMul64(LX0R xor LX1R, LY0R xor LY1R));
   LH5 := ImplMul64(LX0 xor LX1, LY0 xor LY1) shl 1;
 
-  LZ0 := LH0;
-  LZ1 := LH1 xor LH0 xor LH2 xor LH4;
-  LZ2 := LH2 xor LH1 xor LH3 xor LH5;
-  LZ3 := LH3;
+  AZ0 := LH0;
+  AZ1 := LH1 xor LH0 xor LH2 xor LH4;
+  AZ2 := LH2 xor LH1 xor LH3 xor LH5;
+  AZ3 := LH3;
+end;
 
-  LZ1 := LZ1 xor LZ3 xor (LZ3 shr 1) xor (LZ3 shr 2) xor (LZ3 shr 7);
-  LZ2 := LZ2 xor (LZ3 shl 62) xor (LZ3 shl 57);
+class procedure TGcmUtilities.ReduceProduct(AZ0, AZ1, AZ2, AZ3: UInt64;
+  out AX: TFieldElement);
+begin
+  AZ1 := AZ1 xor AZ3 xor (AZ3 shr 1) xor (AZ3 shr 2) xor (AZ3 shr 7);
+  AZ2 := AZ2 xor (AZ3 shl 62) xor (AZ3 shl 57);
 
-  LZ0 := LZ0 xor LZ2 xor (LZ2 shr 1) xor (LZ2 shr 2) xor (LZ2 shr 7);
-  LZ1 := LZ1 xor (LZ2 shl 63) xor (LZ2 shl 62) xor (LZ2 shl 57);
+  AZ0 := AZ0 xor AZ2 xor (AZ2 shr 1) xor (AZ2 shr 2) xor (AZ2 shr 7);
+  AZ1 := AZ1 xor (AZ2 shl 63) xor (AZ2 shl 62) xor (AZ2 shl 57);
 
-  AX.N0 := LZ0;
-  AX.N1 := LZ1;
+  AX.N0 := AZ0;
+  AX.N1 := AZ1;
+end;
+
+class procedure TGcmUtilities.ComputePowers1To4(const AH: TCryptoLibByteArray;
+  out AH1, AH2, AH3, AH4: TFieldElement);
+var
+  LT, LY: TFieldElement;
+begin
+  AsFieldElement(AH, AH1);
+  LT := AH1; LY := AH1; Multiply(LT, LY); AH2 := LT;
+  LT := AH2; LY := AH1; Multiply(LT, LY); AH3 := LT;
+  LT := AH2; LY := AH2; Multiply(LT, LY); AH4 := LT;
+end;
+
+class procedure TGcmUtilities.AggregateGhash4(var AY: TFieldElement;
+  const AX1, AX2, AX3, AX4, AH1, AH2, AH3, AH4: TFieldElement);
+var
+  LT: TFieldElement;
+  LZ0, LZ1, LZ2, LZ3, LW0, LW1, LW2, LW3: UInt64;
+begin
+  LT.N0 := AY.N0 xor AX1.N0;
+  LT.N1 := AY.N1 xor AX1.N1;
+  MultiplyNoReduce(LT, AH4, LZ0, LZ1, LZ2, LZ3);
+  MultiplyNoReduce(AX2, AH3, LW0, LW1, LW2, LW3);
+  LZ0 := LZ0 xor LW0; LZ1 := LZ1 xor LW1; LZ2 := LZ2 xor LW2; LZ3 := LZ3 xor LW3;
+  MultiplyNoReduce(AX3, AH2, LW0, LW1, LW2, LW3);
+  LZ0 := LZ0 xor LW0; LZ1 := LZ1 xor LW1; LZ2 := LZ2 xor LW2; LZ3 := LZ3 xor LW3;
+  MultiplyNoReduce(AX4, AH1, LW0, LW1, LW2, LW3);
+  LZ0 := LZ0 xor LW0; LZ1 := LZ1 xor LW1; LZ2 := LZ2 xor LW2; LZ3 := LZ3 xor LW3;
+  ReduceProduct(LZ0, LZ1, LZ2, LZ3, AY);
 end;
 
 class procedure TGcmUtilities.MultiplyP7(var AX: TFieldElement);

--- a/CryptoLib/src/Include/Simd/Aes/Gcm/AesGcmFusedCtrGhashEight_aarch64.inc
+++ b/CryptoLib/src/Include/Simd/Aes/Gcm/AesGcmFusedCtrGhashEight_aarch64.inc
@@ -7,11 +7,12 @@
 // Loops over BatchCount pipelined batches. Each batch AES-encrypts eight
 // counter blocks (generated in-register from Counter32 + PJ0Template) to
 // produce a keystream, XORs it with PXorIn to produce POut, and concurrently
-// GHASHes the PREVIOUS batch's 8 ciphertext blocks into the running
-// authentication state (the pipeline lags by one batch). AES inside GCM is
-// always CTR keystream construction; GhashFromOutput picks which buffer feeds
-// GHASH (output on encrypt, input on decrypt). The mode primes batch 0 and
-// drains the last.
+// GHASHes 8 ciphertext blocks into the running authentication state. AES inside
+// GCM is always CTR keystream construction; GhashFromOutput selects the GHASH
+// source: encrypt folds the PREVIOUS batch's output ciphertext (the pipeline
+// lags by one batch, so the mode primes batch 0 and drains the last); decrypt
+// folds THIS batch's input ciphertext, read before the XOR overwrites it (no
+// lag, no prime/drain, and PXorIn/POut may alias for in-place decrypt).
 //
 // PHPow128 holds the kernel-owned H^8..H^1 table PRE-MULTIPLIED BY x in the
 // reflected representation, so the batch product reduces with two
@@ -113,6 +114,8 @@
   add w6, w6, #8
   mov x10, x1
   mov x11, x2
+  cmp x9, #0
+  .long 0x9a8a1084                    // csel x4, x4, x10, ne
   .long 0x4e284a00                    // aese v0.16b, v16.16b
   .long 0x3dc0008b                    // ldr q11, [x4]
   .long 0x4e286800                    // aesmc v0.16b, v0.16b
@@ -485,6 +488,8 @@
   add w6, w6, #8
   mov x10, x1
   mov x11, x2
+  cmp x9, #0
+  .long 0x9a8a1084                    // csel x4, x4, x10, ne
   .long 0x4e284a00                    // aese v0.16b, v16.16b
   .long 0x3dc0008b                    // ldr q11, [x4]
   .long 0x4e286800                    // aesmc v0.16b, v0.16b
@@ -890,6 +895,8 @@
   add w6, w6, #8
   mov x10, x1
   mov x11, x2
+  cmp x9, #0
+  .long 0x9a8a1084                    // csel x4, x4, x10, ne
   .long 0x4e284a00                    // aese v0.16b, v16.16b
   .long 0x4e286800                    // aesmc v0.16b, v0.16b
   .long 0x3dc0008b                    // ldr q11, [x4]

--- a/CryptoLib/src/Include/Simd/Aes/Gcm/AesGcmFusedCtrGhashEight_i386.inc
+++ b/CryptoLib/src/Include/Simd/Aes/Gcm/AesGcmFusedCtrGhashEight_i386.inc
@@ -8,11 +8,12 @@
 // Loops over BatchCount pipelined batches. Each batch AES-encrypts eight
 // counter blocks (generated in-register from Counter32 + PJ0Template) to
 // produce a keystream, XORs it with PXorIn to produce POut, and concurrently
-// GHASHes the PREVIOUS batch's 8 ciphertext blocks into the running
-// authentication state (the pipeline lags by one batch). AES inside GCM is
-// always CTR keystream construction; GhashFromOutput picks which buffer feeds
-// GHASH (output on encrypt, input on decrypt). The mode primes batch 0 and
-// drains the last.
+// GHASHes 8 ciphertext blocks into the running authentication state. AES
+// inside GCM is always CTR keystream construction; GhashFromOutput selects the
+// GHASH source: encrypt folds the PREVIOUS batch's output ciphertext (the
+// pipeline lags by one batch, so the mode primes batch 0 and drains the last);
+// decrypt folds THIS batch's input ciphertext, read before the XOR overwrites
+// it (no lag, no prime/drain, and PXorIn/POut may alias for in-place decrypt).
 //
 // PHPow128 holds the kernel-owned H^8..H^1 table PRE-MULTIPLIED BY x in the
 // reflected representation, so the batch product reduces with two
@@ -40,9 +41,9 @@
 //   [ebx + 32]  PJ0Template                      [ebx + 36]  BatchCount
 //   [ebx + 40]  GhashFromOutput (1 = encrypt)
 //
-// GPR: ebx=PCtx, edi=Keys (pinned), ebp=HPow (pinned), esi=PPrevCipher
-//   (rotates per batch), ecx=counter32 (in-register across the call),
-//   eax/edx=scratch.
+// GPR: ebx=PCtx, edi=Keys (pinned), ebp=HPow (pinned), esi=GHASH source
+//   (previous output on encrypt, this batch's input on decrypt; set per
+//   batch), ecx=counter32 (in-register across the call), eax/edx=scratch.
 //
 // XMM: xmm0..xmm3 = 4 AES keystream lanes (per half); xmm4 = GHASH block;
 //   xmm5 = H-power limb; xmm6/xmm7 = pclmul product scratch.
@@ -94,6 +95,15 @@
   movdqa    [esp + 16], xmm0                   // Z1 = 0
   movdqa    [esp + 32], xmm0                   // Z2 = 0
 
+  // --- GHASH source for this batch: encrypt keeps the lagged esi (the
+  //     previous batch's output, set by the advance below); decrypt points
+  //     esi at this batch's own input so it is read before the post-AES XOR
+  //     overwrites it (safe when input and output alias). ---
+  cmp       dword ptr [ebx + 40], 0             // GHASH-from-output flag
+  jne       @@GcmGhashSrcSet                     // encrypt: keep lagged esi
+  mov       esi, [ebx + 0]                       // decrypt: esi = this input
+@@GcmGhashSrcSet:
+
   // --- Build 4 counter blocks for HALF 1 (blocks 0..3): J0[0..11] ||
   //     BE(counter32+1..+4); the counter holds the last-used value. ---
   mov       eax, [ebx + 32]                     // PJ0Template
@@ -131,7 +141,7 @@
   db $66, $0F, $38, $DC, $57, $10               // aesenc xmm2, [edi+0x10]
   db $66, $0F, $38, $DC, $5F, $10               // aesenc xmm3, [edi+0x10]
 
-  movdqu    xmm4, [esi + 0]                   // prev cipher block 0
+  movdqu    xmm4, [esi + 0]                   // GHASH source block 0
   db $66, $0F, $38, $00, $64, $24, $40          // pshufb xmm4, [esp+64] (byte-reverse)
   pxor      xmm4, [esp + 48]                  // fold carried state
   movdqu    xmm5, [ebp + 0]                   // H^8 (x-shifted)
@@ -158,7 +168,7 @@
   db $66, $0F, $38, $DC, $57, $20               // aesenc xmm2, [edi+0x20]
   db $66, $0F, $38, $DC, $5F, $20               // aesenc xmm3, [edi+0x20]
 
-  movdqu    xmm4, [esi + 16]                   // prev cipher block 1
+  movdqu    xmm4, [esi + 16]                   // GHASH source block 1
   db $66, $0F, $38, $00, $64, $24, $40          // pshufb xmm4, [esp+64] (byte-reverse)
   movdqu    xmm5, [ebp + 16]                   // H^7 (x-shifted)
 
@@ -184,7 +194,7 @@
   db $66, $0F, $38, $DC, $57, $30               // aesenc xmm2, [edi+0x30]
   db $66, $0F, $38, $DC, $5F, $30               // aesenc xmm3, [edi+0x30]
 
-  movdqu    xmm4, [esi + 32]                   // prev cipher block 2
+  movdqu    xmm4, [esi + 32]                   // GHASH source block 2
   db $66, $0F, $38, $00, $64, $24, $40          // pshufb xmm4, [esp+64] (byte-reverse)
   movdqu    xmm5, [ebp + 32]                   // H^6 (x-shifted)
 
@@ -210,7 +220,7 @@
   db $66, $0F, $38, $DC, $57, $40               // aesenc xmm2, [edi+0x40]
   db $66, $0F, $38, $DC, $5F, $40               // aesenc xmm3, [edi+0x40]
 
-  movdqu    xmm4, [esi + 48]                   // prev cipher block 3
+  movdqu    xmm4, [esi + 48]                   // GHASH source block 3
   db $66, $0F, $38, $00, $64, $24, $40          // pshufb xmm4, [esp+64] (byte-reverse)
   movdqu    xmm5, [ebp + 48]                   // H^5 (x-shifted)
 
@@ -353,7 +363,7 @@
   db $66, $0F, $38, $DC, $57, $10               // aesenc xmm2, [edi+0x10]
   db $66, $0F, $38, $DC, $5F, $10               // aesenc xmm3, [edi+0x10]
 
-  movdqu    xmm4, [esi + 64]                   // prev cipher block 4
+  movdqu    xmm4, [esi + 64]                   // GHASH source block 4
   db $66, $0F, $38, $00, $64, $24, $40          // pshufb xmm4, [esp+64] (byte-reverse)
   movdqu    xmm5, [ebp + 64]                   // H^4 (x-shifted)
 
@@ -379,7 +389,7 @@
   db $66, $0F, $38, $DC, $57, $20               // aesenc xmm2, [edi+0x20]
   db $66, $0F, $38, $DC, $5F, $20               // aesenc xmm3, [edi+0x20]
 
-  movdqu    xmm4, [esi + 80]                   // prev cipher block 5
+  movdqu    xmm4, [esi + 80]                   // GHASH source block 5
   db $66, $0F, $38, $00, $64, $24, $40          // pshufb xmm4, [esp+64] (byte-reverse)
   movdqu    xmm5, [ebp + 80]                   // H^3 (x-shifted)
 
@@ -405,7 +415,7 @@
   db $66, $0F, $38, $DC, $57, $30               // aesenc xmm2, [edi+0x30]
   db $66, $0F, $38, $DC, $5F, $30               // aesenc xmm3, [edi+0x30]
 
-  movdqu    xmm4, [esi + 96]                   // prev cipher block 6
+  movdqu    xmm4, [esi + 96]                   // GHASH source block 6
   db $66, $0F, $38, $00, $64, $24, $40          // pshufb xmm4, [esp+64] (byte-reverse)
   movdqu    xmm5, [ebp + 96]                   // H^2 (x-shifted)
 
@@ -431,7 +441,7 @@
   db $66, $0F, $38, $DC, $57, $40               // aesenc xmm2, [edi+0x40]
   db $66, $0F, $38, $DC, $5F, $40               // aesenc xmm3, [edi+0x40]
 
-  movdqu    xmm4, [esi + 112]                   // prev cipher block 7
+  movdqu    xmm4, [esi + 112]                   // GHASH source block 7
   db $66, $0F, $38, $00, $64, $24, $40          // pshufb xmm4, [esp+64] (byte-reverse)
   movdqu    xmm5, [ebp + 112]                   // H^1 (x-shifted)
 

--- a/CryptoLib/src/Include/Simd/Aes/Gcm/AesGcmFusedCtrGhashEight_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Aes/Gcm/AesGcmFusedCtrGhashEight_x86_64.inc
@@ -8,11 +8,12 @@
 // Loops over BatchCount pipelined batches. Each batch AES-encrypts eight
 // counter blocks (generated in-register from Counter32 + PJ0Template) to
 // produce a keystream, XORs it with PXorIn to produce POut, and concurrently
-// GHASHes the PREVIOUS batch's 8 ciphertext blocks into the running
-// authentication state (the pipeline lags by one batch). AES inside GCM is
-// always CTR keystream construction; GhashFromOutput picks which buffer feeds
-// GHASH (output on encrypt, input on decrypt). The mode primes batch 0 and
-// drains the last.
+// GHASHes 8 ciphertext blocks into the running authentication state. AES
+// inside GCM is always CTR keystream construction; GhashFromOutput selects the
+// GHASH source: encrypt folds the PREVIOUS batch's output ciphertext (the
+// pipeline lags by one batch, so the mode primes batch 0 and drains the last);
+// decrypt folds THIS batch's input ciphertext, read before the XOR overwrites
+// it (no lag, no prime/drain, and PXorIn/POut may alias for in-place decrypt).
 //
 // PHPow128 holds the kernel-owned H^8..H^1 table PRE-MULTIPLIED BY x in the
 // reflected representation, so the batch product reduces with two
@@ -36,6 +37,7 @@
 // All loop-carried state lives in registers - no context memory is
 // touched inside the batch loop:
 //   rsi/rdi = PXorIn/POut (advance)   r10 = PPrevCipher (rotates)
+//   r9 = GHASH source base (r10 on encrypt, rsi on decrypt; set per batch)
 //   rdx = PRoundKeys   r11 = PHPow128   r8d = counter32
 //   rbx = batch count   ebp = GHASH-from-output flag   rax = scratch
 //
@@ -163,8 +165,17 @@
   db $66, $45, $0F, $EF, $D2                    // pxor xmm10, xmm10   (Z1=0)
   db $66, $45, $0F, $EF, $DB                    // pxor xmm11, xmm11   (Z2=0)
 
+  // --- GHASH source pointer for this batch: r10 (previous output,
+  //     encrypt lags by one batch) or rsi (this batch's input, decrypt
+  //     reads the input before the post-AES XOR overwrites it). ---
+  mov       r9, rsi
+  test      ebp, ebp                            // GHASH-from-output flag
+  jz        @@GcmGhashSrcSet                     // decrypt: source = input
+  mov       r9, r10                              // encrypt: source = prev output
+@@GcmGhashSrcSet:
+
   // --- Round 1 + GHASH iter 0 (with carried-state fold). ---
-  movdqu    xmm12, [r10 + 0]                 // prev cipher block 0
+  movdqu    xmm12, [r9 + 0]                  // GHASH source block 0
   pshufb    xmm12, xmm15                       // byte-reverse
   db $66, $45, $0F, $EF, $E1                    // pxor xmm12, xmm9 (fold carried state)
   db $66, $45, $0F, $EF, $C9                    // pxor xmm9, xmm9  (Z0=0)
@@ -192,7 +203,7 @@
   db $66, $45, $0F, $EF, $DE                    // pxor xmm11, xmm14  (Z2 +=)
 
   // --- Round 2 + GHASH iter 1. ---
-  movdqu    xmm12, [r10 + 16]                 // prev cipher block 1
+  movdqu    xmm12, [r9 + 16]                  // GHASH source block 1
   pshufb    xmm12, xmm15                       // byte-reverse
   movdqu    xmm13, [r11 + 16]                 // H^7 (x-shifted)
 
@@ -218,7 +229,7 @@
   db $66, $45, $0F, $EF, $DE                    // pxor xmm11, xmm14  (Z2 +=)
 
   // --- Round 3 + GHASH iter 2. ---
-  movdqu    xmm12, [r10 + 32]                 // prev cipher block 2
+  movdqu    xmm12, [r9 + 32]                  // GHASH source block 2
   pshufb    xmm12, xmm15                       // byte-reverse
   movdqu    xmm13, [r11 + 32]                 // H^6 (x-shifted)
 
@@ -244,7 +255,7 @@
   db $66, $45, $0F, $EF, $DE                    // pxor xmm11, xmm14  (Z2 +=)
 
   // --- Round 4 + GHASH iter 3. ---
-  movdqu    xmm12, [r10 + 48]                 // prev cipher block 3
+  movdqu    xmm12, [r9 + 48]                  // GHASH source block 3
   pshufb    xmm12, xmm15                       // byte-reverse
   movdqu    xmm13, [r11 + 48]                 // H^5 (x-shifted)
 
@@ -270,7 +281,7 @@
   db $66, $45, $0F, $EF, $DE                    // pxor xmm11, xmm14  (Z2 +=)
 
   // --- Round 5 + GHASH iter 4. ---
-  movdqu    xmm12, [r10 + 64]                 // prev cipher block 4
+  movdqu    xmm12, [r9 + 64]                  // GHASH source block 4
   pshufb    xmm12, xmm15                       // byte-reverse
   movdqu    xmm13, [r11 + 64]                 // H^4 (x-shifted)
 
@@ -296,7 +307,7 @@
   db $66, $45, $0F, $EF, $DE                    // pxor xmm11, xmm14  (Z2 +=)
 
   // --- Round 6 + GHASH iter 5. ---
-  movdqu    xmm12, [r10 + 80]                 // prev cipher block 5
+  movdqu    xmm12, [r9 + 80]                  // GHASH source block 5
   pshufb    xmm12, xmm15                       // byte-reverse
   movdqu    xmm13, [r11 + 80]                 // H^3 (x-shifted)
 
@@ -322,7 +333,7 @@
   db $66, $45, $0F, $EF, $DE                    // pxor xmm11, xmm14  (Z2 +=)
 
   // --- Round 7 + GHASH iter 6. ---
-  movdqu    xmm12, [r10 + 96]                 // prev cipher block 6
+  movdqu    xmm12, [r9 + 96]                  // GHASH source block 6
   pshufb    xmm12, xmm15                       // byte-reverse
   movdqu    xmm13, [r11 + 96]                 // H^2 (x-shifted)
 
@@ -348,7 +359,7 @@
   db $66, $45, $0F, $EF, $DE                    // pxor xmm11, xmm14  (Z2 +=)
 
   // --- Round 8 + GHASH iter 7. ---
-  movdqu    xmm12, [r10 + 112]                 // prev cipher block 7
+  movdqu    xmm12, [r9 + 112]                  // GHASH source block 7
   pshufb    xmm12, xmm15                       // byte-reverse
   movdqu    xmm13, [r11 + 112]                 // H^1 (x-shifted)
 

--- a/CryptoLib/src/Interfaces/Crypto/CipherKernels/Block/ClpIGcmKernel.pas
+++ b/CryptoLib/src/Interfaces/Crypto/CipherKernels/Block/ClpIGcmKernel.pas
@@ -45,12 +45,13 @@ type
     ///   Process ABatchCount consecutive 8-block batches in one call: generate
     ///   the GCM keystream (32-bit counter starting at ACounter32, J0 upper 96
     ///   bits from AJ0Template), XOR AInPtr into AOutPtr, and fold each batch's
-    ///   ciphertext into the running GHASH state (AGhashState). APrevInit is the
-    ///   ciphertext of the batch immediately before this run (the prime batch);
-    ///   the pipeline GHASHes it first and lags by one, leaving the final batch
-    ///   for the caller's drain. AForEncrypt selects whether the GHASHed
-    ///   ciphertext is the output (encrypt) or the input (decrypt). Returns the
-    ///   advanced 32-bit counter (ACounter32 + 8*ABatchCount).
+    ///   ciphertext into the running GHASH state (AGhashState). AForEncrypt
+    ///   selects the GHASH source: encrypt folds the previous batch's OUTPUT
+    ///   ciphertext (the pipeline lags by one batch, so APrevInit seeds the first
+    ///   fold and the caller primes batch 0 / drains the last); decrypt folds
+    ///   each batch's own INPUT ciphertext (no lag, APrevInit unused, and AInPtr
+    ///   may alias AOutPtr). Returns the advanced 32-bit counter
+    ///   (ACounter32 + 8*ABatchCount).
     /// </summary>
     function ProcessCtrGhashBatches(AInPtr, AOutPtr, APrevInit, AGhashState,
       AJ0Template: Pointer; ACounter32: UInt32; ABatchCount: NativeInt;

--- a/CryptoLib/src/Math/Raw/ClpBits.pas
+++ b/CryptoLib/src/Math/Raw/ClpBits.pas
@@ -26,14 +26,14 @@ uses
 type
   TBits = class sealed
   public
-    class function BitPermuteStep(AX: UInt32; AM: UInt32; &AS: Int32): UInt32; overload; static;
-    class function BitPermuteStep(AX: UInt64; AM: UInt64; &AS: Int32): UInt64; overload; static;
+    class function BitPermuteStep(AX: UInt32; AM: UInt32; &AS: Int32): UInt32; overload; static; inline;
+    class function BitPermuteStep(AX: UInt64; AM: UInt64; &AS: Int32): UInt64; overload; static; inline;
 
-    class procedure BitPermuteStep2(var AHi: UInt32; var ALo: UInt32; AM: UInt32; &AS: Int32); overload; static;
-    class procedure BitPermuteStep2(var AHi: UInt64; var ALo: UInt64; AM: UInt64; &AS: Int32); overload; static;
+    class procedure BitPermuteStep2(var AHi: UInt32; var ALo: UInt32; AM: UInt32; &AS: Int32); overload; static; inline;
+    class procedure BitPermuteStep2(var AHi: UInt64; var ALo: UInt64; AM: UInt64; &AS: Int32); overload; static; inline;
 
-    class function BitPermuteStepSimple(AX: UInt32; AM: UInt32; &AS: Int32): UInt32; overload; static;
-    class function BitPermuteStepSimple(AX: UInt64; AM: UInt64; &AS: Int32): UInt64; overload; static;
+    class function BitPermuteStepSimple(AX: UInt32; AM: UInt32; &AS: Int32): UInt32; overload; static; inline;
+    class function BitPermuteStepSimple(AX: UInt64; AM: UInt64; &AS: Int32): UInt64; overload; static; inline;
   end;
 
 implementation


### PR DESCRIPTION
Constant-time AES-GCM bulk batching, mode-wide in-place AEAD correctness, and non-lagged fused decrypt

Bulk batching (constant-time software AES-GCM):
- TAesBitSlicedEngine implements IBulkBlockCipher, transforming four blocks per pass (the aes_ct64 lane width) with a 1..3-block tail; bit-exact with N sequential ProcessBlock calls. SIC/CTR over it now batches automatically.
- GCM gains a software-bulk 4-block path (bulk AES keystream + scalar GHASH) gated on the engine being bulk-capable rather than on SIMD GHASH, so the bitsliced + software-multiplier stack batches even without hardware GHASH.
- Scalar aggregated 4-way GHASH: split the field multiply into MultiplyNoReduce + ReduceProduct and fold four blocks with a single reduction (reduction is XOR-linear); H^1..H^4 precomputed per key.
- TGcmBlockCipher gains a destructor and zeroizes the hash subkey, H-power tables, keystream buffers and last key on teardown/rekey.

In-place AEAD correctness (out buffer aliasing in buffer):
- In-place GCM was broken mode-wide in both directions. Fixed uniformly: CipherBlock/CipherBlocks2 use the three-operand XOR (read both sources before writing), and every block step orders GHASH so decrypt folds the input before the XOR overwrites it and encrypt folds the output after.
- EAX (the only other affected mode) captures each block's ciphertext into the OMAC look-ahead before the in-place counter transform overwrites it.
- The other block-cipher modes were reviewed and are already in-place safe.

Non-lagged fused decrypt (x86_64, i386, aarch64):
- The fused CTR + 8-way GHASH kernel lagged GHASH by one batch, so in-place decrypt read overwritten memory. Encrypt still lags (its ciphertext is the output); decrypt now GHASHes each batch's own input during that batch's AES rounds, before the XOR, with identical instruction-level parallelism and no prime/drain. In-place GCM decrypt now runs at full fused speed on all three architectures with no aliasing fallback.

Also: TAesBitSlicedEngine.ProcessBlocks (pointer form) computes its byte count in Int64 to avoid a 32-bit overflow on very large block counts.

Tests: in-place round-trip coverage (both directions, sizes crossing the fused thresholds, cipher-kernel on/off) added to the GCM, EAX and bitsliced suites; ProcessBlocks parity, CTR batched-vs-single, aggregated-GHASH parity, and chunked-stream parity.