### PR TITLE
Fix IPv6 netmask parsing for prefixes that end mid-word

### DIFF
--- a/CryptoLib.Tests/src/Asn1/X509/GeneralNameTests.pas
+++ b/CryptoLib.Tests/src/Asn1/X509/GeneralNameTests.pas
@@ -51,6 +51,8 @@ type
       FIpv6f: TCryptoLibByteArray;
       FIpv6g: TCryptoLibByteArray;
       FIpv6h: TCryptoLibByteArray;
+      FIpv6i: TCryptoLibByteArray;
+      FIpv6j: TCryptoLibByteArray;
 
     procedure SetUpTestData;
     procedure CheckIPAddressEncoding(const AInputIP: String;
@@ -83,6 +85,9 @@ begin
   FIpv6f := DecodeHex('872020010db885a3000000008a2e0a090800ffffffffffff00000000000000000000');
   FIpv6g := DecodeHex('872020010db885a3000000008a2e0a090800ffffffffffffffffffffffffffffffff');
   FIpv6h := DecodeHex('872020010db885a300000000000000000000ffffffffffff00000000000000000000');
+  // prefix lengths that are not a multiple of 16, so the mask ends mid-word
+  FIpv6i := DecodeHex('872020010db885a300000000000000000000fffffffffffe00000000000000000000');
+  FIpv6j := DecodeHex('872020010db885a300000000000000000000ffffffffffff80000000000000000000');
 end;
 
 procedure TGeneralNameTest.SetUp;
@@ -121,6 +126,8 @@ begin
   CheckIPAddressEncoding('2001:0db8:85a3::8a2e:10.9.8.0/ffff:ffff:ffff::0000', FIpv6f, 'ipv6f failed');
   CheckIPAddressEncoding('2001:0db8:85a3::8a2e:10.9.8.0/128', FIpv6g, 'ipv6g failed');
   CheckIPAddressEncoding('2001:0db8:85a3::/48', FIpv6h, 'ipv6h failed');
+  CheckIPAddressEncoding('2001:0db8:85a3::/47', FIpv6i, 'ipv6i failed');
+  CheckIPAddressEncoding('2001:0db8:85a3::/49', FIpv6j, 'ipv6j failed');
 end;
 
 initialization

--- a/CryptoLib.Tests/src/Asn1/X509/TbsCertificateIssuerTests.pas
+++ b/CryptoLib.Tests/src/Asn1/X509/TbsCertificateIssuerTests.pas
@@ -40,6 +40,7 @@ uses
   ClpIX509Asn1Generators,
   ClpCryptoLibTypes,
   ClpCryptoLibExceptions,
+  ClpCryptoLibConfig,
   CryptoLibTestBase;
 
 type
@@ -54,16 +55,36 @@ type
     function NotAfter: ITime;
     function BuildValidity: IValidity;
     function Spki: ISubjectPublicKeyInfo;
+    function CreateEmptyIssuerTbs: TCryptoLibByteArray;
+    procedure ImplPublicConstructorRejectsEmptyIssuer;
+    procedure ImplV1GeneratorRejectsEmptyIssuer;
+    procedure ImplV3GeneratorRejectsEmptyIssuer;
+  protected
+    procedure SetUp; override;
+    procedure TearDown; override;
   published
     procedure TestParseRejectsEmptyIssuer;
     procedure TestPublicConstructorRejectsEmptyIssuer;
     procedure TestV1GeneratorRejectsEmptyIssuer;
     procedure TestV3GeneratorRejectsEmptyIssuer;
+    procedure TestParseAcceptsEmptyIssuerWhenAllowed;
   end;
 
 implementation
 
 { TTbsCertificateIssuerTest }
+
+procedure TTbsCertificateIssuerTest.SetUp;
+begin
+  inherited SetUp;
+  TCryptoLibConfig.X509.ResetToDefaults();
+end;
+
+procedure TTbsCertificateIssuerTest.TearDown;
+begin
+  TCryptoLibConfig.X509.ResetToDefaults();
+  inherited TearDown;
+end;
 
 function TTbsCertificateIssuerTest.SigAlg: IAlgorithmIdentifier;
 begin
@@ -103,11 +124,10 @@ begin
     TDerBitString.Create(TCryptoLibByteArray.Create(0)) as IDerBitString);
 end;
 
-procedure TTbsCertificateIssuerTest.TestParseRejectsEmptyIssuer;
+function TTbsCertificateIssuerTest.CreateEmptyIssuerTbs: TCryptoLibByteArray;
 var
   LVec: IAsn1EncodableVector;
   LSeq: IDerSequence;
-  LEncoded: TCryptoLibByteArray;
 begin
   // v1 TBSCertificate carrying an empty issuer DN
   LVec := TAsn1EncodableVector.Create();
@@ -118,7 +138,14 @@ begin
   LVec.Add(SubjectName);
   LVec.Add(Spki);
   LSeq := TDerSequence.Create(LVec);
-  LEncoded := LSeq.GetEncoded(TAsn1Encodable.Der);
+  Result := LSeq.GetEncoded(TAsn1Encodable.Der);
+end;
+
+procedure TTbsCertificateIssuerTest.TestParseRejectsEmptyIssuer;
+var
+  LEncoded: TCryptoLibByteArray;
+begin
+  LEncoded := CreateEmptyIssuerTbs;
 
   try
     TTbsCertificateStructure.GetInstance(LEncoded);
@@ -129,7 +156,42 @@ begin
   end;
 end;
 
+procedure TTbsCertificateIssuerTest.TestParseAcceptsEmptyIssuerWhenAllowed;
+var
+  LEncoded: TCryptoLibByteArray;
+  LTbs: ITbsCertificateStructure;
+begin
+  LEncoded := CreateEmptyIssuerTbs;
+
+  TCryptoLibConfig.X509.AllowEmptyIssuerCert := True;
+
+  // the read-side concession: the parse accepts the empty issuer and preserves the encoding
+  LTbs := TTbsCertificateStructure.GetInstance(LEncoded);
+  CheckTrue(LTbs.Issuer.IsEmpty, 'issuer not empty');
+  CheckTrue(AreEqual(LEncoded, LTbs.GetEncoded(TAsn1Encodable.Der)), 'encoding not preserved');
+
+  // generation stays strict regardless of the switch
+  ImplPublicConstructorRejectsEmptyIssuer;
+  ImplV1GeneratorRejectsEmptyIssuer;
+  ImplV3GeneratorRejectsEmptyIssuer;
+end;
+
 procedure TTbsCertificateIssuerTest.TestPublicConstructorRejectsEmptyIssuer;
+begin
+  ImplPublicConstructorRejectsEmptyIssuer;
+end;
+
+procedure TTbsCertificateIssuerTest.TestV1GeneratorRejectsEmptyIssuer;
+begin
+  ImplV1GeneratorRejectsEmptyIssuer;
+end;
+
+procedure TTbsCertificateIssuerTest.TestV3GeneratorRejectsEmptyIssuer;
+begin
+  ImplV3GeneratorRejectsEmptyIssuer;
+end;
+
+procedure TTbsCertificateIssuerTest.ImplPublicConstructorRejectsEmptyIssuer;
 begin
   try
     TTbsCertificateStructure.Create(TDerInteger.Two, TDerInteger.One, SigAlg,
@@ -141,7 +203,7 @@ begin
   end;
 end;
 
-procedure TTbsCertificateIssuerTest.TestV1GeneratorRejectsEmptyIssuer;
+procedure TTbsCertificateIssuerTest.ImplV1GeneratorRejectsEmptyIssuer;
 var
   LGen: IV1TbsCertificateGenerator;
 begin
@@ -163,7 +225,7 @@ begin
   end;
 end;
 
-procedure TTbsCertificateIssuerTest.TestV3GeneratorRejectsEmptyIssuer;
+procedure TTbsCertificateIssuerTest.ImplV3GeneratorRejectsEmptyIssuer;
 var
   LGen: IV3TbsCertificateGenerator;
 begin

--- a/CryptoLib.Tests/src/Pkcs/Pkcs12StoreTests.pas
+++ b/CryptoLib.Tests/src/Pkcs/Pkcs12StoreTests.pas
@@ -159,6 +159,7 @@ type
     procedure TestWrongPassword;
     procedure TestEmptyInputRejectedCleanly;
     procedure TestChainCycle;
+    procedure TestPkcs12Store_CertificateAliasConsistency;
   end;
 
 implementation
@@ -1184,6 +1185,51 @@ begin
   else
     raise;
   end;
+end;
+
+procedure TTestPkcs12Store.TestPkcs12Store_CertificateAliasConsistency;
+const
+  CertCount = Int32(16);
+var
+  LKeyPair: IAsymmetricCipherKeyPair;
+  LCerts: TCryptoLibGenericArray<IX509Certificate>;
+  LAbsent: IX509Certificate;
+  LStore, LInStore: IPkcs12Store;
+  LSaved: TBytes;
+  LI: Int32;
+begin
+  LKeyPair := TCertTestUtilities.GenerateRsaKeyPair(1024);
+
+  // enough entries that an alias lookup pairing keys with values by position would go wrong
+  System.SetLength(LCerts, CertCount);
+  for LI := 0 to CertCount - 1 do
+    LCerts[LI] := TCertTestUtilities.GenerateRootCert(LKeyPair,
+      TX509Name.Create('CN=alias-cert-' + IntToStr(LI)) as IX509Name);
+
+  LAbsent := TCertTestUtilities.GenerateRootCert(LKeyPair,
+    TX509Name.Create('CN=alias-cert-absent') as IX509Name);
+
+  LStore := BuildPkcs12Store;
+  for LI := 0 to CertCount - 1 do
+    LStore.SetCertificateEntry('cert-' + IntToStr(LI),
+      TX509CertificateEntry.Create(LCerts[LI]) as IX509CertificateEntry);
+
+  for LI := 0 to CertCount - 1 do
+    CheckEquals('cert-' + IntToStr(LI), LStore.GetCertificateAlias(LCerts[LI]), 'alias mismatch');
+
+  CheckEquals('', LStore.GetCertificateAlias(LAbsent), 'alias found for absent certificate');
+
+  LSaved := SaveStoreToBytes(LStore, FPasswd);
+
+  LInStore := BuildPkcs12Store;
+  LoadStoreFromBytes(LInStore, LSaved, FPasswd);
+
+  for LI := 0 to CertCount - 1 do
+    CheckEquals('cert-' + IntToStr(LI), LInStore.GetCertificateAlias(LCerts[LI]),
+      'alias mismatch after reload');
+
+  CheckEquals('', LInStore.GetCertificateAlias(LAbsent),
+    'alias found for absent certificate after reload');
 end;
 
 initialization

--- a/CryptoLib/src/Asn1/ClpAsn1Objects.pas
+++ b/CryptoLib/src/Asn1/ClpAsn1Objects.pas
@@ -968,6 +968,10 @@ type
     /// </summary>
     function HasTagClass(ATagClass: Int32): Boolean; virtual;
     /// <summary>
+    /// Check if this has the specified tag number.
+    /// </summary>
+    function HasTagNo(ATagNo: Int32): Boolean; virtual;
+    /// <summary>
     /// Check if this is explicitly tagged.
     /// </summary>
     function IsExplicit(): Boolean; virtual;
@@ -3545,6 +3549,11 @@ end;
 function TAsn1TaggedObject.HasTagClass(ATagClass: Int32): Boolean;
 begin
   Result := FTagClass = ATagClass;
+end;
+
+function TAsn1TaggedObject.HasTagNo(ATagNo: Int32): Boolean;
+begin
+  Result := FTagNo = ATagNo;
 end;
 
 function TAsn1TaggedObject.ParseBaseUniversal(ADeclaredExplicit: Boolean; ABaseTagNo: Int32): IAsn1Convertible;

--- a/CryptoLib/src/Asn1/X509/ClpX509Asn1Objects.pas
+++ b/CryptoLib/src/Asn1/X509/ClpX509Asn1Objects.pas
@@ -4417,7 +4417,7 @@ begin
   TAsn1Utilities.RequireEndOfSequence(ASeq, LPos);
 
   // RFC 5280 sec. 4.1.2.4: certificate issuer MUST be a non-empty DN.
-  if FIssuer.IsEmpty then
+  if FIssuer.IsEmpty and not TCryptoLibConfig.X509.AllowEmptyIssuerCert then
     raise EArgumentCryptoLibException.CreateRes(@SCertificateIssuerEmptyDN);
 
   FSeq := ASeq;
@@ -5418,7 +5418,8 @@ begin
   end;
   if LBits > 0 then
   begin
-    LRes[LResPos] := $FFFF shr (16 - LBits);
+    // the trailing word keeps its leading LBits set, so invert the low (16 - LBits) run
+    LRes[LResPos] := ($FFFF shr LBits) xor $FFFF;
   end;
   Result := LRes;
 end;

--- a/CryptoLib/src/Interfaces/Asn1/ClpIAsn1Objects.pas
+++ b/CryptoLib/src/Interfaces/Asn1/ClpIAsn1Objects.pas
@@ -400,6 +400,7 @@ type
     function HasContextTag(ATagNo: Int32): Boolean; overload;
     function HasTag(ATagClass, ATagNo: Int32): Boolean;
     function HasTagClass(ATagClass: Int32): Boolean;
+    function HasTagNo(ATagNo: Int32): Boolean;
     function IsExplicit(): Boolean;
     function IsParsed(): Boolean;
     function GetObject(): IAsn1Object;

--- a/CryptoLib/src/Math/ClpBigInteger.pas
+++ b/CryptoLib/src/Math/ClpBigInteger.pas
@@ -113,7 +113,7 @@ type
     function GetMQuote(): UInt32;
     function CheckProbablePrime(const ACertainty: Int32; const ARandom: IRandom;
       const ARandomlySelected: Boolean): Boolean;
-    function GetLowestSetBitMaskFirst(const AFirstWordMaskX: UInt32): Int32;
+    function GetLowestSetBitMaskFirst(const AFirstWordMask: UInt32): Int32;
     function &Inc(): TBigInteger;
     function AddToMagnitude(const AMagToAdd: TCryptoLibUInt32Array): TBigInteger;
     constructor Create(const ASignum: Int32; const AMag: TCryptoLibUInt32Array; const ACheckMag: Boolean); overload;
@@ -2633,7 +2633,7 @@ begin
   Result := GetLowestSetBitMaskFirst(UInt32.MaxValue);
 end;
 
-function TBigInteger.GetLowestSetBitMaskFirst(const AFirstWordMaskX: UInt32): Int32;
+function TBigInteger.GetLowestSetBitMaskFirst(const AFirstWordMask: UInt32): Int32;
 var
   LW, LOffset: Int32;
   LWord: UInt32;
@@ -2644,7 +2644,7 @@ begin
   System.Assert(FMagnitude[0] <> 0);
 {$ENDIF DEBUG}
   System.Dec(LW);
-  LWord := FMagnitude[LW] and AFirstWordMaskX;
+  LWord := FMagnitude[LW] and AFirstWordMask;
 
   while LWord = 0 do
   begin

--- a/CryptoLib/src/Misc/ClpCryptoLibConfig.pas
+++ b/CryptoLib/src/Misc/ClpCryptoLibConfig.pas
@@ -114,6 +114,7 @@ type
     FAllowLenientRfc822Name: Boolean;
     FAllowLenientIPAddressMask: Boolean;
     FAllowNonDerTbsCertificate: Boolean;
+    FAllowEmptyIssuerCert: Boolean;
 
     class function GetMaxPolicyNodes: Int32; static;
     class procedure SetMaxPolicyNodes(AValue: Int32); static;
@@ -125,6 +126,8 @@ type
     class procedure SetAllowLenientIPAddressMask(AValue: Boolean); static;
     class function GetAllowNonDerTbsCertificate: Boolean; static;
     class procedure SetAllowNonDerTbsCertificate(AValue: Boolean); static;
+    class function GetAllowEmptyIssuerCert: Boolean; static;
+    class procedure SetAllowEmptyIssuerCert(AValue: Boolean); static;
 
   public
     /// <summary>Restores this area's settings to their defaults.</summary>
@@ -164,6 +167,16 @@ type
     /// </summary>
     class property AllowNonDerTbsCertificate: Boolean read GetAllowNonDerTbsCertificate
       write SetAllowNonDerTbsCertificate;
+
+    /// <summary>
+    /// Parses a certificate whose issuer is an empty distinguished name, rather than rejecting it.
+    /// RFC 5280 sec. 4.1.2.4 requires a non-empty issuer, but profiles that use a self-signed
+    /// certificate purely as an identity carrier place no requirement on the field and such
+    /// certificates are in circulation. Generating a certificate still demands a non-empty issuer
+    /// unconditionally. Off by default.
+    /// </summary>
+    class property AllowEmptyIssuerCert: Boolean read GetAllowEmptyIssuerCert
+      write SetAllowEmptyIssuerCert;
   end;
 
   /// <summary>Class reference, so the settings are reachable without an instance.</summary>
@@ -521,6 +534,7 @@ begin
   FAllowLenientRfc822Name := False;
   FAllowLenientIPAddressMask := False;
   FAllowNonDerTbsCertificate := False;
+  FAllowEmptyIssuerCert := False;
 end;
 
 class function TX509Config.GetMaxPolicyNodes: Int32;
@@ -578,6 +592,16 @@ end;
 class procedure TX509Config.SetAllowNonDerTbsCertificate(AValue: Boolean);
 begin
   FAllowNonDerTbsCertificate := AValue;
+end;
+
+class function TX509Config.GetAllowEmptyIssuerCert: Boolean;
+begin
+  Result := FAllowEmptyIssuerCert;
+end;
+
+class procedure TX509Config.SetAllowEmptyIssuerCert(AValue: Boolean);
+begin
+  FAllowEmptyIssuerCert := AValue;
 end;
 
 { TDHConfig }


### PR DESCRIPTION
TGeneralName.ParseIPv6Mask built the trailing partial word as $FFFF shr (16 - LBits), which sets the low bits rather than the leading ones. Any prefix length that is not a multiple of 16 therefore produced an inverted mask word: /47 encoded 0x7FFF where 0xFFFE was required, and /49 encoded 0x0001 instead of 0x8000. The full words ahead of it were already correct, so the resulting iPAddress GeneralName is wrong only in the boundary word — quiet enough to survive unnoticed.

It survived because every existing case used /48, /128 or a literal colon-form mask, all of which either skip the partial-word branch or bypass it entirely. Shift the other way and invert instead, and add /47 and /49 cases so the branch is actually exercised.

Also in this change:

- TCryptoLibConfig.X509.AllowEmptyIssuerCert: RFC 5280 sec. 4.1.2.4 requires a non-empty issuer DN and the parser rejects an empty one, but profiles that use a self-signed certificate purely as an identity carrier place no requirement on the field, and such certificates are in circulation. The switch is off by default and read-side only — it gates the TTbsCertificateStructure parse constructor alone; the public constructor and both TBS generators stay unconditional. The new test asserts the parse round-trips the original DER byte-identically and re-runs the three rejection paths with the switch on to prove generation is still strict.

- IAsn1TaggedObject.HasTagNo, for symmetry with the existing HasTag / HasTagClass / HasContextTag trio. No consumers yet.

- Regression test for Pkcs12Store.GetCertificateAlias: 16 certificate entries, each asserted to map back to its own alias before and after a save/reload, plus an absent certificate yielding no alias. The lookup walks key and value together so it was never at risk of pairing them positionally; the test locks that in.

- Rename the private TBigInteger.GetLowestSetBitMaskFirst parameter AFirstWordMaskX to AFirstWordMask. Cosmetic.