### PR TITLE
Register RIPEMD and SHA3 RSA-PSS signature algorithms

### DIFF
--- a/CryptoLib.Tests/src/Crypto/PssTests.pas
+++ b/CryptoLib.Tests/src/Crypto/PssTests.pas
@@ -99,6 +99,7 @@ type
     procedure DoSignerUtilitiesSha256;
     procedure DoSignerUtilitiesSha384;
     procedure DoSignerUtilitiesSha512;
+    procedure DoSignerUtilitiesExtraPss;
     procedure DoRawSignerTest;
 
   published
@@ -111,6 +112,7 @@ type
     procedure TestSignerUtilitiesSha256;
     procedure TestSignerUtilitiesSha384;
     procedure TestSignerUtilitiesSha512;
+    procedure TestSignerUtilitiesExtraPss;
     procedure TestRawSigner;
 
   end;
@@ -312,7 +314,7 @@ var
 begin
   kpGen := TRsaKeyPairGenerator.Create();
   kpParams := TRsaKeyGenerationParameters.Create(
-    TBigInteger.ValueOf(65537), TSecureRandom.Create(), 2048, 100);
+    TBigInteger.ValueOf(65537), TSecureRandom.Create() as ISecureRandom, 2048, 100);
   kpGen.Init(kpParams);
   keyPair := kpGen.GenerateKeyPair();
 
@@ -344,7 +346,7 @@ var
 begin
   kpGen := TRsaKeyPairGenerator.Create();
   kpParams := TRsaKeyGenerationParameters.Create(
-    TBigInteger.ValueOf(65537), TSecureRandom.Create(), 2048, 100);
+    TBigInteger.ValueOf(65537), TSecureRandom.Create() as ISecureRandom, 2048, 100);
   kpGen.Init(kpParams);
   keyPair := kpGen.GenerateKeyPair();
 
@@ -384,7 +386,7 @@ var
 begin
   kpGen := TRsaKeyPairGenerator.Create();
   kpParams := TRsaKeyGenerationParameters.Create(
-    TBigInteger.ValueOf(65537), TSecureRandom.Create(), 2048, 100);
+    TBigInteger.ValueOf(65537), TSecureRandom.Create() as ISecureRandom, 2048, 100);
   kpGen.Init(kpParams);
   keyPair := kpGen.GenerateKeyPair();
 
@@ -416,7 +418,7 @@ var
 begin
   kpGen := TRsaKeyPairGenerator.Create();
   kpParams := TRsaKeyGenerationParameters.Create(
-    TBigInteger.ValueOf(65537), TSecureRandom.Create(), 2048, 100);
+    TBigInteger.ValueOf(65537), TSecureRandom.Create() as ISecureRandom, 2048, 100);
   kpGen.Init(kpParams);
   keyPair := kpGen.GenerateKeyPair();
 
@@ -437,6 +439,47 @@ begin
   CheckTrue(verified, 'PSS SHA-512 signature verification failed');
 end;
 
+procedure TTestPss.DoSignerUtilitiesExtraPss;
+const
+  AlgNames: array [0 .. 6] of String = ('RIPEMD128withRSAandMGF1',
+    'RIPEMD160withRSAandMGF1', 'RIPEMD256withRSAandMGF1',
+    'SHA3-224withRSAandMGF1', 'SHA3-256withRSAandMGF1',
+    'SHA3-384withRSAandMGF1', 'SHA3-512withRSAandMGF1');
+var
+  kpGen: IRsaKeyPairGenerator;
+  kpParams: IRsaKeyGenerationParameters;
+  keyPair: IAsymmetricCipherKeyPair;
+  signer: ISigner;
+  &message, signature: TCryptoLibByteArray;
+  i: Integer;
+begin
+  // One 2048-bit key is large enough for every RIPEMD/SHA3 salt length here
+  kpGen := TRsaKeyPairGenerator.Create();
+  kpParams := TRsaKeyGenerationParameters.Create(
+    TBigInteger.ValueOf(65537), TSecureRandom.Create() as ISecureRandom, 2048, 100);
+  kpGen.Init(kpParams);
+  keyPair := kpGen.GenerateKeyPair();
+
+  &message := TConverters.ConvertStringToBytes('Test PSS RIPEMD/SHA3 signature',
+    TEncoding.UTF8);
+
+  for i := Low(AlgNames) to High(AlgNames) do
+  begin
+    signer := TSignerUtilities.GetSigner(AlgNames[i]);
+    signer.Init(True, keyPair.Private);
+    signer.BlockUpdate(&message, 0, System.Length(&message));
+    signature := signer.GenerateSignature();
+
+    CheckTrue(System.Length(signature) > 0,
+      Format('PSS %s signature is empty', [AlgNames[i]]));
+
+    signer.Init(False, keyPair.Public);
+    signer.BlockUpdate(&message, 0, System.Length(&message));
+    CheckTrue(signer.VerifySignature(signature),
+      Format('PSS %s signature verification failed', [AlgNames[i]]));
+  end;
+end;
+
 procedure TTestPss.DoRawSignerTest;
 var
   kpGen: IRsaKeyPairGenerator;
@@ -449,7 +492,7 @@ var
 begin
   kpGen := TRsaKeyPairGenerator.Create();
   kpParams := TRsaKeyGenerationParameters.Create(
-    TBigInteger.ValueOf(17), TSecureRandom.Create(), 1024, 100);
+    TBigInteger.ValueOf(17), TSecureRandom.Create() as ISecureRandom, 1024, 100);
   kpGen.Init(kpParams);
   keyPair := kpGen.GenerateKeyPair();
 
@@ -529,6 +572,11 @@ end;
 procedure TTestPss.TestSignerUtilitiesSha512;
 begin
   DoSignerUtilitiesSha512;
+end;
+
+procedure TTestPss.TestSignerUtilitiesExtraPss;
+begin
+  DoSignerUtilitiesExtraPss;
 end;
 
 procedure TTestPss.TestRawSigner;

--- a/CryptoLib.Tests/src/X509/X509CertGenTests.pas
+++ b/CryptoLib.Tests/src/X509/X509CertGenTests.pas
@@ -41,7 +41,13 @@ uses
   ClpIX509Generators,
   ClpAsn1SignatureFactory,
   ClpISignatureFactory,
+  ClpIRsaGenerators,
+  ClpRsaGenerators,
+  ClpISecureRandom,
+  ClpSecureRandom,
+  ClpIAsymmetricCipherKeyPair,
   ClpIRsaParameters,
+  ClpRsaParameters,
   ClpIDsaParameters,
   ClpIECParameters,
   ClpECParameters,
@@ -80,6 +86,7 @@ type
     procedure TestCreationRSA;
     procedure TestCreationDSA;
     procedure TestCreationECDSA;
+    procedure TestCreationRsaPss;
 
   end;
 
@@ -233,6 +240,50 @@ begin
   LExtOids := LCert.CertificateStructure.Extensions.GetCriticalExtensionOids();
   if System.Length(LExtOids) <> 1 then
     Fail('wrong number of oids');
+end;
+
+procedure TX509CertGenTest.TestCreationRsaPss;
+const
+  AlgNames: array [0 .. 6] of String = ('RIPEMD128withRSAandMGF1',
+    'RIPEMD160withRSAandMGF1', 'RIPEMD256withRSAandMGF1',
+    'SHA3-224withRSAandMGF1', 'SHA3-256withRSAandMGF1',
+    'SHA3-384withRSAandMGF1', 'SHA3-512withRSAandMGF1');
+var
+  LKpGen: IRsaKeyPairGenerator;
+  LKpParams: IRsaKeyGenerationParameters;
+  LKeyPair: IAsymmetricCipherKeyPair;
+  LCertGen: IX509V3CertificateGenerator;
+  LName: IX509Name;
+  LCert: IX509Certificate;
+  LSigner: ISignatureFactory;
+  LUtc: TDateTime;
+  I: Int32;
+begin
+  // 2048-bit key is large enough for every RIPEMD/SHA3 PSS salt length here
+  LKpGen := TRsaKeyPairGenerator.Create();
+  LKpParams := TRsaKeyGenerationParameters.Create(
+    TBigInteger.ValueOf(65537), TSecureRandom.Create() as ISecureRandom, 2048, 100);
+  LKpGen.Init(LKpParams);
+  LKeyPair := LKpGen.GenerateKeyPair();
+  LName := CreateX509Name;
+  LUtc := Now.ToUniversalTime();
+
+  for I := Low(AlgNames) to High(AlgNames) do
+  begin
+    LCertGen := TX509V3CertificateGenerator.Create;
+    LCertGen.SetSerialNumber(TBigInteger.One);
+    LCertGen.SetIssuerDN(LName);
+    LCertGen.SetNotBeforeUtc(IncDay(LUtc, -1));
+    LCertGen.SetNotAfterUtc(IncDay(LUtc, 1));
+    LCertGen.SetSubjectDN(LName);
+    LCertGen.SetPublicKey(LKeyPair.Public);
+
+    LSigner := TAsn1SignatureFactory.Create(AlgNames[I], LKeyPair.Private, nil);
+    LCert := LCertGen.Generate(LSigner);
+
+    LCert.CheckValidity();
+    LCert.Verify(LKeyPair.Public);
+  end;
 end;
 
 initialization

--- a/CryptoLib/src/Asn1/X509/ClpX509SignatureUtilities.pas
+++ b/CryptoLib/src/Asn1/X509/ClpX509SignatureUtilities.pas
@@ -85,6 +85,8 @@ implementation
 class constructor TX509SignatureUtilities.Create;
 var
   LSha1AlgId, LSha224AlgId, LSha256AlgId, LSha384AlgId, LSha512AlgId: IAlgorithmIdentifier;
+  LSha3_224AlgId, LSha3_256AlgId, LSha3_384AlgId, LSha3_512AlgId: IAlgorithmIdentifier;
+  LRipeMD128AlgId, LRipeMD160AlgId, LRipeMD256AlgId: IAlgorithmIdentifier;
   LParams: IMlDsaParameters;
   LSlhParams: ISlhDsaParameters;
 begin
@@ -158,6 +160,13 @@ begin
   FAlgorithms.Add('SHA256WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
   FAlgorithms.Add('SHA384WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
   FAlgorithms.Add('SHA512WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('SHA3-224WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('SHA3-256WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('SHA3-384WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('SHA3-512WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('RIPEMD128WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('RIPEMD160WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('RIPEMD256WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
 
   // RIPEMD algorithms
   FAlgorithms.Add('RIPEMD160WITHRSAENCRYPTION', TTeleTrusTObjectIdentifiers.RsaSignatureWithRipeMD160);
@@ -265,6 +274,27 @@ begin
   LSha512AlgId := TAlgorithmIdentifier.Create(TNistObjectIdentifiers.IdSha512, TDerNull.Instance);
   FExParams.Add('SHA512WITHRSAANDMGF1', CreatePssParams(LSha512AlgId, 64));
 
+  LSha3_224AlgId := TAlgorithmIdentifier.Create(TNistObjectIdentifiers.IdSha3_224, TDerNull.Instance);
+  FExParams.Add('SHA3-224WITHRSAANDMGF1', CreatePssParams(LSha3_224AlgId, 28));
+
+  LSha3_256AlgId := TAlgorithmIdentifier.Create(TNistObjectIdentifiers.IdSha3_256, TDerNull.Instance);
+  FExParams.Add('SHA3-256WITHRSAANDMGF1', CreatePssParams(LSha3_256AlgId, 32));
+
+  LSha3_384AlgId := TAlgorithmIdentifier.Create(TNistObjectIdentifiers.IdSha3_384, TDerNull.Instance);
+  FExParams.Add('SHA3-384WITHRSAANDMGF1', CreatePssParams(LSha3_384AlgId, 48));
+
+  LSha3_512AlgId := TAlgorithmIdentifier.Create(TNistObjectIdentifiers.IdSha3_512, TDerNull.Instance);
+  FExParams.Add('SHA3-512WITHRSAANDMGF1', CreatePssParams(LSha3_512AlgId, 64));
+
+  LRipeMD128AlgId := TAlgorithmIdentifier.Create(TTeleTrusTObjectIdentifiers.RipeMD128, TDerNull.Instance);
+  FExParams.Add('RIPEMD128WITHRSAANDMGF1', CreatePssParams(LRipeMD128AlgId, 16));
+
+  LRipeMD160AlgId := TAlgorithmIdentifier.Create(TTeleTrusTObjectIdentifiers.RipeMD160, TDerNull.Instance);
+  FExParams.Add('RIPEMD160WITHRSAANDMGF1', CreatePssParams(LRipeMD160AlgId, 20));
+
+  LRipeMD256AlgId := TAlgorithmIdentifier.Create(TTeleTrusTObjectIdentifiers.RipeMD256, TDerNull.Instance);
+  FExParams.Add('RIPEMD256WITHRSAANDMGF1', CreatePssParams(LRipeMD256AlgId, 32));
+
   //
   // DSA with SHA3
   //
@@ -333,6 +363,14 @@ begin
     Result := 'SHA512(224)'
   else if TNistObjectIdentifiers.IdSha512_256.Equals(ADigestAlgOid) then
     Result := 'SHA512(256)'
+  else if TNistObjectIdentifiers.IdSha3_224.Equals(ADigestAlgOid) then
+    Result := 'SHA3-224'
+  else if TNistObjectIdentifiers.IdSha3_256.Equals(ADigestAlgOid) then
+    Result := 'SHA3-256'
+  else if TNistObjectIdentifiers.IdSha3_384.Equals(ADigestAlgOid) then
+    Result := 'SHA3-384'
+  else if TNistObjectIdentifiers.IdSha3_512.Equals(ADigestAlgOid) then
+    Result := 'SHA3-512'
   else if TTeleTrusTObjectIdentifiers.RipeMD128.Equals(ADigestAlgOid) then
     Result := 'RIPEMD128'
   else if TTeleTrusTObjectIdentifiers.RipeMD160.Equals(ADigestAlgOid) then

--- a/CryptoLib/src/Crypto/Operators/ClpDefaultSignatureAlgorithmFinder.pas
+++ b/CryptoLib/src/Crypto/Operators/ClpDefaultSignatureAlgorithmFinder.pas
@@ -99,6 +99,7 @@ class constructor TDefaultSignatureAlgorithmFinder.Create;
 var
   LSha1AlgId, LSha224AlgId, LSha256AlgId, LSha384AlgId, LSha512AlgId: IAlgorithmIdentifier;
   LSha3_224AlgId, LSha3_256AlgId, LSha3_384AlgId, LSha3_512AlgId: IAlgorithmIdentifier;
+  LRipeMD128AlgId, LRipeMD160AlgId, LRipeMD256AlgId: IAlgorithmIdentifier;
   LParams: IMlDsaParameters;
   LSlhParams: ISlhDsaParameters;
 begin
@@ -154,6 +155,9 @@ begin
   AddAlgorithm('SHA3-256WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
   AddAlgorithm('SHA3-384WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
   AddAlgorithm('SHA3-512WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  AddAlgorithm('RIPEMD128WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  AddAlgorithm('RIPEMD160WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  AddAlgorithm('RIPEMD256WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
   AddAlgorithm('RIPEMD160WITHRSAENCRYPTION', TTeleTrusTObjectIdentifiers.RsaSignatureWithRipeMD160);
   AddAlgorithm('RIPEMD160WITHRSA', TTeleTrusTObjectIdentifiers.RsaSignatureWithRipeMD160);
   AddAlgorithm('RIPEMD128WITHRSAENCRYPTION', TTeleTrusTObjectIdentifiers.RsaSignatureWithRipeMD128);
@@ -345,6 +349,15 @@ begin
 
   LSha3_512AlgId := TAlgorithmIdentifier.Create(TNistObjectIdentifiers.IdSha3_512, TDerNull.Instance);
   AddParameters('SHA3-512WITHRSAANDMGF1', CreatePssParams(LSha3_512AlgId, 64));
+
+  LRipeMD128AlgId := TAlgorithmIdentifier.Create(TTeleTrusTObjectIdentifiers.RipeMD128, TDerNull.Instance);
+  AddParameters('RIPEMD128WITHRSAANDMGF1', CreatePssParams(LRipeMD128AlgId, 16));
+
+  LRipeMD160AlgId := TAlgorithmIdentifier.Create(TTeleTrusTObjectIdentifiers.RipeMD160, TDerNull.Instance);
+  AddParameters('RIPEMD160WITHRSAANDMGF1', CreatePssParams(LRipeMD160AlgId, 20));
+
+  LRipeMD256AlgId := TAlgorithmIdentifier.Create(TTeleTrusTObjectIdentifiers.RipeMD256, TDerNull.Instance);
+  AddParameters('RIPEMD256WITHRSAANDMGF1', CreatePssParams(LRipeMD256AlgId, 32));
 
   //
   // digests

--- a/CryptoLib/src/Crypto/Signers/ClpPssSigner.pas
+++ b/CryptoLib/src/Crypto/Signers/ClpPssSigner.pas
@@ -35,6 +35,7 @@ uses
   ClpParameterUtilities,
   ClpBigInteger,
   ClpArrayUtilities,
+  ClpBinaryPrimitives,
   ClpCryptoLibTypes,
   ClpCryptoLibExceptions;
 
@@ -73,7 +74,6 @@ type
     FTrailer: Byte;
 
     procedure ClearBlock(const ABlock: TCryptoLibByteArray);
-    procedure ItoOSP(AI: Int32; const ASP: TCryptoLibByteArray);
     function MaskGeneratorFunction(const AZ: TCryptoLibByteArray;
       AZOff, AZLen, ALength: Int32): TCryptoLibByteArray;
     function MaskGeneratorFunction1(const AZ: TCryptoLibByteArray;
@@ -465,14 +465,6 @@ begin
   FContentDigest1.Reset();
 end;
 
-procedure TPssSigner.ItoOSP(AI: Int32; const ASP: TCryptoLibByteArray);
-begin
-  ASP[0] := Byte(UInt32(AI) shr 24);
-  ASP[1] := Byte(UInt32(AI) shr 16);
-  ASP[2] := Byte(UInt32(AI) shr 8);
-  ASP[3] := Byte(UInt32(AI) shr 0);
-end;
-
 function TPssSigner.MaskGeneratorFunction(const AZ: TCryptoLibByteArray;
   AZOff, AZLen, ALength: Int32): TCryptoLibByteArray;
 var
@@ -496,37 +488,37 @@ function TPssSigner.MaskGeneratorFunction1(const AZ: TCryptoLibByteArray;
   AZOff, AZLen, ALength: Int32): TCryptoLibByteArray;
 var
   LMask, LHashBuf, LC: TCryptoLibByteArray;
-  LCounter: Int32;
+  LCounter, LPos: Int32;
 begin
   SetLength(LMask, ALength);
-  SetLength(LHashBuf, FMgfhLen);
   SetLength(LC, 4);
   LCounter := 0;
+  LPos := 0;
 
   FMgfDigest.Reset();
 
-  while LCounter < (ALength div FMgfhLen) do
+  // full blocks are finalized straight into the mask; only the tail needs a temp buffer
+  while LPos <= ALength - FMgfhLen do
   begin
-    ItoOSP(LCounter, LC);
+    TBinaryPrimitives.WriteUInt32BigEndian(LC, 0, UInt32(LCounter));
+    Inc(LCounter);
 
     FMgfDigest.BlockUpdate(AZ, AZOff, AZLen);
     FMgfDigest.BlockUpdate(LC, 0, System.Length(LC));
-    FMgfDigest.DoFinal(LHashBuf, 0);
-
-    System.Move(LHashBuf[0], LMask[LCounter * FMgfhLen], System.Length(LHashBuf));
-    Inc(LCounter);
+    FMgfDigest.DoFinal(LMask, LPos);
+    Inc(LPos, FMgfhLen);
   end;
 
-  if (LCounter * FMgfhLen) < ALength then
+  if LPos < ALength then
   begin
-    ItoOSP(LCounter, LC);
+    TBinaryPrimitives.WriteUInt32BigEndian(LC, 0, UInt32(LCounter));
 
     FMgfDigest.BlockUpdate(AZ, AZOff, AZLen);
     FMgfDigest.BlockUpdate(LC, 0, System.Length(LC));
-    FMgfDigest.DoFinal(LHashBuf, 0);
 
-    System.Move(LHashBuf[0], LMask[LCounter * FMgfhLen],
-      System.Length(LMask) - (LCounter * FMgfhLen));
+    SetLength(LHashBuf, FMgfhLen);
+    FMgfDigest.DoFinal(LHashBuf, 0);
+    System.Move(LHashBuf[0], LMask[LPos], System.Length(LMask) - LPos);
   end;
 
   Result := LMask;

--- a/CryptoLib/src/Crypto/Signers/ClpSignerUtilities.pas
+++ b/CryptoLib/src/Crypto/Signers/ClpSignerUtilities.pas
@@ -377,6 +377,15 @@ begin
   FAlgorithmMap.AddOrSetValue('SHA512WITHRSASSA-PSS', 'SHA-512withRSAandMGF1');
   FAlgorithmMap.AddOrSetValue('SHA-512WITHRSASSA-PSS', 'SHA-512withRSAandMGF1');
 
+  FAlgorithmMap.AddOrSetValue('SHA3-224WITHRSAANDMGF1', 'SHA3-224withRSAandMGF1');
+  FAlgorithmMap.AddOrSetValue('SHA3-256WITHRSAANDMGF1', 'SHA3-256withRSAandMGF1');
+  FAlgorithmMap.AddOrSetValue('SHA3-384WITHRSAANDMGF1', 'SHA3-384withRSAandMGF1');
+  FAlgorithmMap.AddOrSetValue('SHA3-512WITHRSAANDMGF1', 'SHA3-512withRSAandMGF1');
+
+  FAlgorithmMap.AddOrSetValue('RIPEMD128WITHRSAANDMGF1', 'RIPEMD128withRSAandMGF1');
+  FAlgorithmMap.AddOrSetValue('RIPEMD160WITHRSAANDMGF1', 'RIPEMD160withRSAandMGF1');
+  FAlgorithmMap.AddOrSetValue('RIPEMD256WITHRSAANDMGF1', 'RIPEMD256withRSAandMGF1');
+
   FAlgorithmMap.AddOrSetValue('RIPEMD128WITHRSA', 'RIPEMD128withRSA');
   FAlgorithmMap.AddOrSetValue('RIPEMD128WITHRSAENCRYPTION', 'RIPEMD128withRSA');
   FAlgorithmOidMap.AddOrSetValue(TTeleTrusTObjectIdentifiers.RsaSignatureWithRipeMD128, 'RIPEMD128withRSA');
@@ -678,6 +687,15 @@ begin
   FOids.AddOrSetValue('SHA-256withRSAandMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
   FOids.AddOrSetValue('SHA-384withRSAandMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
   FOids.AddOrSetValue('SHA-512withRSAandMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+
+  FOids.AddOrSetValue('SHA3-224withRSAandMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FOids.AddOrSetValue('SHA3-256withRSAandMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FOids.AddOrSetValue('SHA3-384withRSAandMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FOids.AddOrSetValue('SHA3-512withRSAandMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+
+  FOids.AddOrSetValue('RIPEMD128withRSAandMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FOids.AddOrSetValue('RIPEMD160withRSAandMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FOids.AddOrSetValue('RIPEMD256withRSAandMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
 
   FOids.AddOrSetValue('RIPEMD128withRSA', TTeleTrusTObjectIdentifiers.RsaSignatureWithRipeMD128);
   FOids.AddOrSetValue('RIPEMD160withRSA', TTeleTrusTObjectIdentifiers.RsaSignatureWithRipeMD160);

--- a/CryptoLib/src/Pkcs/ClpPkcs10CertificationRequest.pas
+++ b/CryptoLib/src/Pkcs/ClpPkcs10CertificationRequest.pas
@@ -132,6 +132,8 @@ implementation
 class constructor TPkcs10CertificationRequest.Create;
 var
   LSha1AlgId, LSha224AlgId, LSha256AlgId, LSha384AlgId, LSha512AlgId: IAlgorithmIdentifier;
+  LSha3_224AlgId, LSha3_256AlgId, LSha3_384AlgId, LSha3_512AlgId: IAlgorithmIdentifier;
+  LRipeMD128AlgId, LRipeMD160AlgId, LRipeMD256AlgId: IAlgorithmIdentifier;
 begin
   FAlgorithms := TDictionary<String, IDerObjectIdentifier>.Create(TCryptoLibComparers.OrdinalIgnoreCaseEqualityComparer);
   FExParams := TDictionary<String, IAsn1Encodable>.Create(TCryptoLibComparers.OrdinalIgnoreCaseEqualityComparer);
@@ -177,6 +179,13 @@ begin
   FAlgorithms.Add('SHA256WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
   FAlgorithms.Add('SHA384WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
   FAlgorithms.Add('SHA512WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('SHA3-224WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('SHA3-256WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('SHA3-384WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('SHA3-512WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('RIPEMD128WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('RIPEMD160WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('RIPEMD256WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
   FAlgorithms.Add('RSAWITHSHA1', TPkcsObjectIdentifiers.Sha1WithRsaEncryption);
   FAlgorithms.Add('RIPEMD128WITHRSAENCRYPTION', TTeleTrusTObjectIdentifiers.RsaSignatureWithRipeMD128);
   FAlgorithms.Add('RIPEMD128WITHRSA', TTeleTrusTObjectIdentifiers.RsaSignatureWithRipeMD128);
@@ -275,6 +284,20 @@ begin
   FExParams.Add('SHA384WITHRSAANDMGF1', CreatePssParams(LSha384AlgId, 48));
   LSha512AlgId := TAlgorithmIdentifier.Create(TNistObjectIdentifiers.IdSha512, TDerNull.Instance);
   FExParams.Add('SHA512WITHRSAANDMGF1', CreatePssParams(LSha512AlgId, 64));
+  LSha3_224AlgId := TAlgorithmIdentifier.Create(TNistObjectIdentifiers.IdSha3_224, TDerNull.Instance);
+  FExParams.Add('SHA3-224WITHRSAANDMGF1', CreatePssParams(LSha3_224AlgId, 28));
+  LSha3_256AlgId := TAlgorithmIdentifier.Create(TNistObjectIdentifiers.IdSha3_256, TDerNull.Instance);
+  FExParams.Add('SHA3-256WITHRSAANDMGF1', CreatePssParams(LSha3_256AlgId, 32));
+  LSha3_384AlgId := TAlgorithmIdentifier.Create(TNistObjectIdentifiers.IdSha3_384, TDerNull.Instance);
+  FExParams.Add('SHA3-384WITHRSAANDMGF1', CreatePssParams(LSha3_384AlgId, 48));
+  LSha3_512AlgId := TAlgorithmIdentifier.Create(TNistObjectIdentifiers.IdSha3_512, TDerNull.Instance);
+  FExParams.Add('SHA3-512WITHRSAANDMGF1', CreatePssParams(LSha3_512AlgId, 64));
+  LRipeMD128AlgId := TAlgorithmIdentifier.Create(TTeleTrusTObjectIdentifiers.RipeMD128, TDerNull.Instance);
+  FExParams.Add('RIPEMD128WITHRSAANDMGF1', CreatePssParams(LRipeMD128AlgId, 16));
+  LRipeMD160AlgId := TAlgorithmIdentifier.Create(TTeleTrusTObjectIdentifiers.RipeMD160, TDerNull.Instance);
+  FExParams.Add('RIPEMD160WITHRSAANDMGF1', CreatePssParams(LRipeMD160AlgId, 20));
+  LRipeMD256AlgId := TAlgorithmIdentifier.Create(TTeleTrusTObjectIdentifiers.RipeMD256, TDerNull.Instance);
+  FExParams.Add('RIPEMD256WITHRSAANDMGF1', CreatePssParams(LRipeMD256AlgId, 32));
 end;
 
 class destructor TPkcs10CertificationRequest.Destroy;

--- a/CryptoLib/src/X509/ClpX509Utilities.pas
+++ b/CryptoLib/src/X509/ClpX509Utilities.pas
@@ -164,6 +164,13 @@ begin
   FAlgorithms.Add('SHA256WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
   FAlgorithms.Add('SHA384WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
   FAlgorithms.Add('SHA512WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('SHA3-224WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('SHA3-256WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('SHA3-384WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('SHA3-512WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('RIPEMD128WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('RIPEMD160WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
+  FAlgorithms.Add('RIPEMD256WITHRSAANDMGF1', TPkcsObjectIdentifiers.IdRsassaPss);
 
   // RIPEMD algorithms
   FAlgorithms.Add('RIPEMD160WITHRSAENCRYPTION', TTeleTrusTObjectIdentifiers.RsaSignatureWithRipeMD160);


### PR DESCRIPTION
Add the RIPEMD128/160/256 and SHA3-224/256/384/512 "...withRSAandMGF1" signature algorithms, with PSS parameters carrying the matching digest AlgorithmIdentifier and a salt length equal to the digest output size (16/20/32 for RIPEMD, 28/32/48/64 for SHA3). The registrations are added across every place that resolves signature algorithms:

- TSignerUtilities: algorithm-name and OID maps (enables GetSigner)
- TX509SignatureUtilities: algorithm map, explicit PSS params, and SHA3 digest-name resolution in GetDigestName
- TDefaultSignatureAlgorithmFinder: RIPEMD variants (SHA3 already present)
- TX509Utilities and TPkcs10CertificationRequest: algorithm map and, where applicable, explicit PSS params

Also refactor TPssSigner.MaskGeneratorFunction1: full digest blocks are now finalized straight into the mask buffer (only the trailing partial block uses a temporary), the block counter is packed big-endian via TBinaryPrimitives.WriteUInt32BigEndian, and the redundant ItoOSP helper is removed. This is a behaviour-preserving cleanup; the PSS known-answer vectors are unchanged.

Tests: TTestPss gains a sign/verify round-trip over all seven new algorithms, and TX509CertGenTest generates and verifies a self-signed certificate for each (a fresh 2048-bit key is used since the shared test key is too small for SHA3-512 PSS).