### PR TITLE
Remove unused extended-multiply / 3-limb-reduce GHASH field ops

### DIFF
--- a/CryptoLib/src/Crypto/CipherKernels/Block/ClpAesNiGcmKernel.pas
+++ b/CryptoLib/src/Crypto/CipherKernels/Block/ClpAesNiGcmKernel.pas
@@ -87,14 +87,14 @@ implementation
 type
   // Context handed to the fused AES-NI CTR keystream + 8-way GHASH loop kernel.
   // Natural pointer-sized alignment, no padding: the field offsets match the
-  // [rcx + N] / [ebx + N] accesses in AesGcmFusedCtrGhashEight_x86_64.inc and
-  // AesGcmFusedCtrGhashEight_i386.inc (they differ with pointer / NativeUInt
-  // width: 8-byte fields on x86_64, 4-byte on i386). The kernel holds the loop
-  // state in registers across the batch run, writing only Counter32 back, and
-  // builds each batch's counter blocks in-register from Counter32 + PJ0Template
-  // (both arches); the GHASH-from-output flag is 1 for encrypt (fold the output
-  // ciphertext) and 0 for decrypt (fold the input). PHPow128 points at the
-  // kernel-owned x-pre-multiplied H-power table (see TAesNiGcmKernel.Create).
+  // [rcx + N] / [ebx + N] accesses in the fused kernel loop (they differ with
+  // pointer / NativeUInt width: 8-byte fields on x86_64, 4-byte on i386). The
+  // kernel holds the loop state in registers across the batch run, writing only
+  // Counter32 back, and builds each batch's counter blocks in-register from
+  // Counter32 + PJ0Template (both arches); the GHASH-from-output flag is 1 for
+  // encrypt (fold the output ciphertext) and 0 for decrypt (fold the input).
+  // PHPow128 points at the kernel-owned x-pre-multiplied H-power table (see
+  // TAesNiGcmKernel.Create).
   TGcmFusedCtx = record
     PXorIn: Pointer;
     POut: Pointer;

--- a/CryptoLib/src/Crypto/Modes/Gcm/ClpGcmUtilities.pas
+++ b/CryptoLib/src/Crypto/Modes/Gcm/ClpGcmUtilities.pas
@@ -24,15 +24,10 @@ uses
   ClpBitOperations,
   ClpInt64Utilities,
   ClpPack,
-  ClpBinaryPrimitives,
   ClpInterleave,
   ClpGhashSimd,
   ClpCryptoLibTypes,
-  ClpCryptoLibExceptions,
   ClpByteUtilities;
-
-resourcestring
-  SCarrylessMultiplyExtIsNotAvailable = 'Carryless multiply-ext is not available on this target';
 
 type
   TFieldElement = record
@@ -86,12 +81,6 @@ type
 
     class procedure Square(var AX: TFieldElement); static;
 
-    /// <summary>Carryless multiply: three 128-bit limbs (48 bytes). Operands 16 bytes each as two little-endian UInt64 halves.</summary>
-    class procedure MultiplyExt(PX, PY, POut48: PByte); static;
-    /// <summary>Fold middle limb Z1 into Z0 and Z2, then reduce to one 128-bit block.</summary>
-    class procedure Reduce3(PZ0, PZ1, PZ2, PSVector16: PByte); static;
-    /// <summary>Xor three 16-byte limbs with three 16-byte slices from a 48-byte MultiplyExt output.</summary>
-    class procedure XorMultiplyExtLimbs48(PA0, PA1, PA2, PSrc48: PByte); static;
     /// <summary>HPow[0..7] = H^8..H^1 as 16-byte limbs at offsets 0,16,...,112 (index 0 = H^8),
     /// each PRE-MULTIPLIED BY x in the reflected representation (DivideP) to match the
     /// carry-less-multiply folding reduction in the fused GHASH / POLYVAL kernels.
@@ -357,64 +346,6 @@ begin
   LZ3 := LZ3 and UInt64($8888888888888888);
 
   Result := LZ0 or LZ1 or LZ2 or LZ3;
-end;
-
-class procedure TGcmUtilities.MultiplyExt(PX, PY, POut48: PByte);
-begin
-  if TGhashSimd.TryMultiplyExt(PX, PY, POut48) then
-    Exit;
-  raise EInvalidOperationCryptoLibException.CreateRes(@SCarrylessMultiplyExtIsNotAvailable);
-end;
-
-class procedure TGcmUtilities.XorMultiplyExtLimbs48(PA0, PA1, PA2, PSrc48: PByte);
-var
-  LK: Int32;
-begin
-  if TGhashSimd.TryXorMultiplyExtLimbs48(PA0, PA1, PA2, PSrc48) then
-    Exit;
-
-  for LK := 0 to 1 do
-  begin
-    TByteUtilities.XorTo(8, PSrc48 + LK * 8, PA0 + LK * 8);
-    TByteUtilities.XorTo(8, PSrc48 + 16 + LK * 8, PA1 + LK * 8);
-    TByteUtilities.XorTo(8, PSrc48 + 32 + LK * 8, PA2 + LK * 8);
-  end;
-end;
-
-class procedure TGcmUtilities.Reduce3(PZ0, PZ1, PZ2, PSVector16: PByte);
-var
-  B0, B1, B2: array[0..15] of Byte;
-  SL, SR: array[0..15] of Byte;
-  LI: Int32;
-  LT3, LT2, LT1, LT0, LZ0, LZ1, LZ2: UInt64;
-begin
-  if TGhashSimd.TryReduce3(PZ0, PZ1, PZ2, PSVector16) then
-    Exit;
-
-  System.Move(PZ0^, B0[0], 16);
-  System.Move(PZ1^, B1[0], 16);
-  System.Move(PZ2^, B2[0], 16);
-  System.FillChar(SL[0], 16, 0);
-  System.Move(B1[0], SL[8], 8);
-  for LI := 0 to 15 do
-    B0[LI] := B0[LI] xor SL[LI];
-  System.FillChar(SR[0], 16, 0);
-  System.Move(B1[8], SR[0], 8);
-  for LI := 0 to 15 do
-    B2[LI] := B2[LI] xor SR[LI];
-  LT3 := TBinaryPrimitives.ReadUInt64LittleEndian(PByte(@B0[0]), 0);
-  LT2 := TBinaryPrimitives.ReadUInt64LittleEndian(PByte(@B0[0]), 8);
-  LT1 := TBinaryPrimitives.ReadUInt64LittleEndian(PByte(@B2[0]), 0);
-  LT0 := TBinaryPrimitives.ReadUInt64LittleEndian(PByte(@B2[0]), 8);
-  LT1 := LT1 xor LT3 xor (LT3 shr 1) xor (LT3 shr 2) xor (LT3 shr 7);
-  LT2 := LT2 xor (LT3 shl 63) xor (LT3 shl 62) xor (LT3 shl 57);
-  LZ0 := (LT0 shl 1) or (LT1 shr 63);
-  LZ1 := (LT1 shl 1) or (LT2 shr 63);
-  LZ2 := LT2 shl 1;
-  LZ0 := LZ0 xor LZ2 xor (LZ2 shr 1) xor (LZ2 shr 2) xor (LZ2 shr 7);
-  LZ1 := LZ1 xor (LT2 shl 63) xor (LT2 shl 58);
-  TBinaryPrimitives.WriteUInt64LittleEndian(PSVector16, 0, LZ1);
-  TBinaryPrimitives.WriteUInt64LittleEndian(PSVector16, 8, LZ0);
 end;
 
 class procedure TGcmUtilities.InitEightWayHPowFromH(const AH: TCryptoLibByteArray;

--- a/CryptoLib/src/Include/Simd/Gcm/GcmFieldOps_aarch64.inc
+++ b/CryptoLib/src/Include/Simd/Gcm/GcmFieldOps_aarch64.inc
@@ -1,7 +1,7 @@
 // GHASH field-op kernels, merged (aarch64).
 // -------------------------------------------------------------------
 //
-// Five small GHASH field primitives merged under one selector; exactly one
+// Two small GHASH field primitives merged under one selector; exactly one
 // of the following must be defined before including this file:
 //
 //   CRYPTOLIB_GCMFIELD_PARTIAL       (ClpSimdProc3Begin: x0 = @X, x1 = @Y,
@@ -9,19 +9,6 @@
 //     Z2) of two GHASH field elements before degree reduction. X.N0, X.N1
 //     and Y.N0, Y.N1 are UInt64 GHASH field limbs (TFieldElement); each
 //     element is packed into a vector as low qword = N1, high qword = N0.
-//   CRYPTOLIB_GCMFIELD_MULTIPLY_EXT  (ClpSimdProc3Begin: x0 = PX, x1 = PY,
-//     x2 = POut48) - carryless multiply without reduction; operands are
-//     16-byte limbs (LE UInt64 pair each), output Z0, Z1, Z2 (48 bytes;
-//     no Z1 merge / reduction).
-//   CRYPTOLIB_GCMFIELD_REDUCE3       (ClpSimdProc4Begin: x0 = PZ0, x1 = PZ1,
-//     x2 = PZ2, x3 = POut) - fold Z1 into (Z0, Z2), then reduce the (Z0, Z2)
-//     pair modulo the GCM polynomial x^128 + x^7 + x^2 + x + 1, writing the
-//     16-byte field element to POut. Z0/Z1/Z2 are the three 128-bit limbs
-//     carried across a batch of carry-less GHASH products; the folded
-//     Z0/Z2 are stored back in place (matching the x86 kernel).
-//   CRYPTOLIB_GCMFIELD_XOR_LIMBS48   (ClpSimdProc4Begin: x0 = PA0, x1 = PA1,
-//     x2 = PA2, x3 = PSrc48) - xor 16-byte limbs in place:
-//     *PA0 ^= PSrc[0..15], *PA1 ^= PSrc[16..31], *PA2 ^= PSrc[32..47].
 //   CRYPTOLIB_GCMFIELD_BLOCK_REVERSE (ClpSimdProc2Begin: x0 = PDst,
 //     x1 = PSrc) - [x0] := byte-reverse([x1]) (rev64 + half swap; no
 //     shuffle mask needed on AArch64).
@@ -55,95 +42,13 @@
   .long 0x3d800444                    // str q4, [x2, #16]
   ret
 {$ELSE}
-  {$IFDEF CRYPTOLIB_GCMFIELD_MULTIPLY_EXT}
-  .long 0x3dc00000                    // ldr q0, [x0]
-  .long 0x3dc00021                    // ldr q1, [x1]
-  .long 0x6e004005                    // ext v5.16b, v0.16b, v0.16b, #8
-  .long 0x0ee1e002                    // pmull v2.1q, v0.1d, v1.1d
-  .long 0x4ee1e004                    // pmull2 v4.1q, v0.2d, v1.2d
-  .long 0x0ee1e0a3                    // pmull v3.1q, v5.1d, v1.1d
-  .long 0x4ee1e0a5                    // pmull2 v5.1q, v5.2d, v1.2d
-  .long 0x6e251c63                    // eor v3.16b, v3.16b, v5.16b
-  .long 0x3d800042                    // str q2, [x2]
-  .long 0x3d800443                    // str q3, [x2, #16]
-  .long 0x3d800844                    // str q4, [x2, #32]
-  ret
-  {$ELSE}
-    {$IFDEF CRYPTOLIB_GCMFIELD_REDUCE3}
-  .long 0x3dc00000                    // ldr q0, [x0]
-  .long 0x3dc00042                    // ldr q2, [x2]
-  .long 0x3dc00021                    // ldr q1, [x1]
-  .long 0x4f00e406                    // movi v6.16b, #0
-  .long 0x6e0140c4                    // ext v4.16b, v6.16b, v1.16b, #8
-  .long 0x6e064025                    // ext v5.16b, v1.16b, v6.16b, #8
-  .long 0x6e241c00                    // eor v0.16b, v0.16b, v4.16b
-  .long 0x6e251c42                    // eor v2.16b, v2.16b, v5.16b
-  .long 0x3d800000                    // str q0, [x0]
-  .long 0x3d800042                    // str q2, [x2]
-  .long 0x1e604003                    // fmov d3, d0
-  .long 0x1e604044                    // fmov d4, d2
-  .long 0x6f7f0465                    // ushr v5.2d, v3.2d, #1
-  .long 0x6e231c84                    // eor v4.16b, v4.16b, v3.16b
-  .long 0x6e251c84                    // eor v4.16b, v4.16b, v5.16b
-  .long 0x6f7e0465                    // ushr v5.2d, v3.2d, #2
-  .long 0x6e251c84                    // eor v4.16b, v4.16b, v5.16b
-  .long 0x6f790465                    // ushr v5.2d, v3.2d, #7
-  .long 0x6e251c84                    // eor v4.16b, v4.16b, v5.16b
-  .long 0x6e064001                    // ext v1.16b, v0.16b, v6.16b, #8
-  .long 0x4f7f5465                    // shl v5.2d, v3.2d, #63
-  .long 0x6e251c21                    // eor v1.16b, v1.16b, v5.16b
-  .long 0x4f7e5465                    // shl v5.2d, v3.2d, #62
-  .long 0x6e251c21                    // eor v1.16b, v1.16b, v5.16b
-  .long 0x4f795465                    // shl v5.2d, v3.2d, #57
-  .long 0x6e251c21                    // eor v1.16b, v1.16b, v5.16b
-  .long 0x6e064045                    // ext v5.16b, v2.16b, v6.16b, #8
-  .long 0x4f4154a2                    // shl v2.2d, v5.2d, #1
-  .long 0x6f410485                    // ushr v5.2d, v4.2d, #63
-  .long 0x4ea51c42                    // orr v2.16b, v2.16b, v5.16b
-  .long 0x4f415483                    // shl v3.2d, v4.2d, #1
-  .long 0x6f410425                    // ushr v5.2d, v1.2d, #63
-  .long 0x4ea51c63                    // orr v3.16b, v3.16b, v5.16b
-  .long 0x4f415420                    // shl v0.2d, v1.2d, #1
-  .long 0x6f7f0405                    // ushr v5.2d, v0.2d, #1
-  .long 0x6e201c42                    // eor v2.16b, v2.16b, v0.16b
-  .long 0x6e251c42                    // eor v2.16b, v2.16b, v5.16b
-  .long 0x6f7e0405                    // ushr v5.2d, v0.2d, #2
-  .long 0x6e251c42                    // eor v2.16b, v2.16b, v5.16b
-  .long 0x6f790405                    // ushr v5.2d, v0.2d, #7
-  .long 0x6e251c42                    // eor v2.16b, v2.16b, v5.16b
-  .long 0x4f7f5425                    // shl v5.2d, v1.2d, #63
-  .long 0x6e251c63                    // eor v3.16b, v3.16b, v5.16b
-  .long 0x4f7a5425                    // shl v5.2d, v1.2d, #58
-  .long 0x6e251c63                    // eor v3.16b, v3.16b, v5.16b
-  .long 0xfd000063                    // str d3, [x3]
-  .long 0xfd000462                    // str d2, [x3, #8]
-  ret
-    {$ELSE}
-      {$IFDEF CRYPTOLIB_GCMFIELD_XOR_LIMBS48}
-  .long 0x3dc00000                    // ldr q0, [x0]
-  .long 0x3dc00061                    // ldr q1, [x3]
-  .long 0x6e211c00                    // eor v0.16b, v0.16b, v1.16b
-  .long 0x3d800000                    // str q0, [x0]
-  .long 0x3dc00020                    // ldr q0, [x1]
-  .long 0x3dc00461                    // ldr q1, [x3, #16]
-  .long 0x6e211c00                    // eor v0.16b, v0.16b, v1.16b
-  .long 0x3d800020                    // str q0, [x1]
-  .long 0x3dc00040                    // ldr q0, [x2]
-  .long 0x3dc00861                    // ldr q1, [x3, #32]
-  .long 0x6e211c00                    // eor v0.16b, v0.16b, v1.16b
-  .long 0x3d800040                    // str q0, [x2]
-  ret
-      {$ELSE}
-        {$IFDEF CRYPTOLIB_GCMFIELD_BLOCK_REVERSE}
+  {$IFDEF CRYPTOLIB_GCMFIELD_BLOCK_REVERSE}
   .long 0x3dc00020                    // ldr q0, [x1]
   .long 0x4e200800                    // rev64 v0.16b, v0.16b
   .long 0x6e004000                    // ext v0.16b, v0.16b, v0.16b, #8
   .long 0x3d800000                    // str q0, [x0]
   ret
-        {$ELSE}
-        {$FATAL Exactly one of CRYPTOLIB_GCMFIELD_PARTIAL, CRYPTOLIB_GCMFIELD_MULTIPLY_EXT, CRYPTOLIB_GCMFIELD_REDUCE3, CRYPTOLIB_GCMFIELD_XOR_LIMBS48, CRYPTOLIB_GCMFIELD_BLOCK_REVERSE must be defined before including this file}
-        {$ENDIF}
-      {$ENDIF}
-    {$ENDIF}
+  {$ELSE}
+  {$FATAL Exactly one of CRYPTOLIB_GCMFIELD_PARTIAL, CRYPTOLIB_GCMFIELD_BLOCK_REVERSE must be defined before including this file}
   {$ENDIF}
 {$ENDIF}

--- a/CryptoLib/src/Include/Simd/Gcm/GcmFieldOps_i386.inc
+++ b/CryptoLib/src/Include/Simd/Gcm/GcmFieldOps_i386.inc
@@ -1,7 +1,7 @@
 // GHASH field-op kernels, merged (i386).
 // -------------------------------------------------------------------
 //
-// Five small GHASH field primitives merged under one selector; exactly one
+// Two small GHASH field primitives merged under one selector; exactly one
 // of the following must be defined before including this file:
 //
 //   CRYPTOLIB_GCMFIELD_PARTIAL       (ClpSimdProc3Begin: ebx = @X, esi = @Y,
@@ -10,18 +10,6 @@
 //     X.N0, X.N1 and Y.N0, Y.N1 are UInt64 GHASH field limbs (TFieldElement);
 //     each limb is packed into xmm as high qword then low
 //     (movq + punpcklqdq), little-endian 128-bit layout.
-//   CRYPTOLIB_GCMFIELD_MULTIPLY_EXT  (ClpSimdProc3Begin: ebx = PX, esi = PY,
-//     edi = POut48) - Karatsuba-style carryless multiply without reduction;
-//     operands are 16-byte limbs (LE UInt64 pair each), output Z0, Z1, Z2
-//     (48 bytes; no Z1 merge / reduction).
-//   CRYPTOLIB_GCMFIELD_REDUCE3       (ClpSimdProc4Begin: ebx = PZ0, esi = PZ1,
-//     edi = PZ2, eax = POut) - fold Z1 into (Z0, Z2), then reduce the (Z0, Z2)
-//     pair modulo the GCM polynomial x^128 + x^7 + x^2 + x + 1, writing the
-//     16-byte field element to POut. Z0/Z1/Z2 are the three 128-bit limbs
-//     carried across a batch of Karatsuba-style PCLMULQDQ GHASH products.
-//   CRYPTOLIB_GCMFIELD_XOR_LIMBS48   (ClpSimdProc4Begin: ebx = PA0, esi = PA1,
-//     edi = PA2, eax = PSrc48) - xor 16-byte limbs in place:
-//     [ebx] ^= [eax + 0], [esi] ^= [eax + 16], [edi] ^= [eax + 32].
 //   CRYPTOLIB_GCMFIELD_BLOCK_REVERSE (ClpSimdProc3Begin: ebx = PDst,
 //     esi = PSrc, edi = PShuffleCtrl) - [ebx] := pshufb([esi], [edi])
 //     (SSSE3 16-byte byte reverse).
@@ -72,122 +60,13 @@
   psrldq    xmm5, 8
   movq      qword ptr [edi + 24], xmm5
 {$ELSE}
-  {$IFDEF CRYPTOLIB_GCMFIELD_MULTIPLY_EXT}
-  movdqu    xmm0, [ebx]
-  movdqu    xmm1, [esi]
-
-  movdqu    xmm2, xmm0
-  db $66, $0F, $3A, $44, $D1, $00  // pclmulqdq xmm2, xmm1, 0
-
-  movdqu    xmm3, xmm0
-  db $66, $0F, $3A, $44, $D9, $01  // pclmulqdq xmm3, xmm1, 1
-  movdqu    xmm4, xmm0
-  db $66, $0F, $3A, $44, $E1, $10  // pclmulqdq xmm4, xmm1, 16
-  pxor      xmm3, xmm4
-
-  movdqu    xmm4, xmm0
-  db $66, $0F, $3A, $44, $E1, $11  // pclmulqdq xmm4, xmm1, 17
-
-  movdqu    [edi + 0], xmm2
-  movdqu    [edi + 16], xmm3
-  movdqu    [edi + 32], xmm4
-  {$ELSE}
-    {$IFDEF CRYPTOLIB_GCMFIELD_REDUCE3}
-  movdqu    xmm0, [ebx]
-  movdqu    xmm2, [edi]
-  movdqu    xmm1, [esi]
-  movdqa    xmm4, xmm1
-  movdqa    xmm5, xmm1
-  pslldq    xmm4, 8
-  psrldq    xmm5, 8
-  pxor      xmm0, xmm4
-  pxor      xmm2, xmm5
-  movdqu    [ebx], xmm0
-  movdqu    [edi], xmm2
-  movdqu    xmm0, [ebx]
-  movdqu    xmm2, [edi]
-  movq      xmm3, xmm0
-  movq      xmm4, xmm2
-  movdqa    xmm5, xmm3
-  psrlq     xmm5, 1
-  movdqa    xmm6, xmm3
-  psrlq     xmm6, 2
-  movdqa    xmm7, xmm3
-  psrlq     xmm7, 7
-  pxor      xmm4, xmm3
-  pxor      xmm4, xmm5
-  pxor      xmm4, xmm6
-  pxor      xmm4, xmm7
-  movdqa    xmm1, xmm0
-  psrldq    xmm1, 8
-  movdqa    xmm5, xmm3
-  psllq     xmm5, 63
-  movdqa    xmm6, xmm3
-  psllq     xmm6, 62
-  movdqa    xmm7, xmm3
-  psllq     xmm7, 57
-  pxor      xmm1, xmm5
-  pxor      xmm1, xmm6
-  pxor      xmm1, xmm7
-  movdqa    xmm5, xmm2
-  psrldq    xmm5, 8
-  movdqa    xmm6, xmm5
-  psllq     xmm6, 1
-  movdqa    xmm7, xmm4
-  psrlq     xmm7, 63
-  por       xmm6, xmm7
-  movdqa    xmm7, xmm4
-  psllq     xmm7, 1
-  movdqa    xmm3, xmm1
-  psrlq     xmm3, 63
-  por       xmm7, xmm3
-  movdqa    xmm0, xmm1
-  psllq     xmm0, 1
-  movdqa    xmm3, xmm0
-  psrlq     xmm3, 1
-  movdqa    xmm2, xmm0
-  psrlq     xmm2, 2
-  movdqa    xmm5, xmm0
-  psrlq     xmm5, 7
-  pxor      xmm6, xmm0
-  pxor      xmm6, xmm3
-  pxor      xmm6, xmm2
-  pxor      xmm6, xmm5
-  movdqa    xmm3, xmm1
-  psllq     xmm3, 63
-  movdqa    xmm2, xmm1
-  psllq     xmm2, 58
-  pxor      xmm7, xmm3
-  pxor      xmm7, xmm2
-  movq      qword ptr [eax], xmm7
-  movq      qword ptr [eax + 8], xmm6
-    {$ELSE}
-      {$IFDEF CRYPTOLIB_GCMFIELD_XOR_LIMBS48}
-  movdqu    xmm0, [ebx]
-  movdqu    xmm1, [eax]
-  pxor      xmm0, xmm1
-  movdqu    [ebx], xmm0
-
-  movdqu    xmm0, [esi]
-  movdqu    xmm1, [eax + 16]
-  pxor      xmm0, xmm1
-  movdqu    [esi], xmm0
-
-  movdqu    xmm0, [edi]
-  movdqu    xmm1, [eax + 32]
-  pxor      xmm0, xmm1
-  movdqu    [edi], xmm0
-      {$ELSE}
-        {$IFDEF CRYPTOLIB_GCMFIELD_BLOCK_REVERSE}
+  {$IFDEF CRYPTOLIB_GCMFIELD_BLOCK_REVERSE}
   movdqu    xmm0, [esi]
   movdqu    xmm1, [edi]
   pshufb    xmm0, xmm1
   movdqu    [ebx], xmm0
-        {$ELSE}
-        {$FATAL Exactly one of CRYPTOLIB_GCMFIELD_PARTIAL, CRYPTOLIB_GCMFIELD_MULTIPLY_EXT, CRYPTOLIB_GCMFIELD_REDUCE3, CRYPTOLIB_GCMFIELD_XOR_LIMBS48, CRYPTOLIB_GCMFIELD_BLOCK_REVERSE must be defined before including this file}
-        {$ENDIF}
-      {$ENDIF}
-    {$ENDIF}
+  {$ELSE}
+  {$FATAL Exactly one of CRYPTOLIB_GCMFIELD_PARTIAL, CRYPTOLIB_GCMFIELD_BLOCK_REVERSE must be defined before including this file}
   {$ENDIF}
 {$ENDIF}
 

--- a/CryptoLib/src/Include/Simd/Gcm/GcmFieldOps_x86_64.inc
+++ b/CryptoLib/src/Include/Simd/Gcm/GcmFieldOps_x86_64.inc
@@ -1,7 +1,7 @@
 // GHASH field-op kernels, merged (x86-64).
 // -------------------------------------------------------------------
 //
-// Five small GHASH field primitives merged under one selector; exactly one
+// Two small GHASH field primitives merged under one selector; exactly one
 // of the following must be defined before including this file:
 //
 //   CRYPTOLIB_GCMFIELD_PARTIAL       (ClpSimdProc3Begin: rcx = @X, rdx = @Y,
@@ -10,18 +10,6 @@
 //     X.N0, X.N1 and Y.N0, Y.N1 are UInt64 GHASH field limbs (TFieldElement);
 //     each limb is packed into xmm as high qword then low
 //     (movq + punpcklqdq), little-endian 128-bit layout.
-//   CRYPTOLIB_GCMFIELD_MULTIPLY_EXT  (ClpSimdProc3Begin: rcx = PX, rdx = PY,
-//     r8 = POut48) - Karatsuba-style carryless multiply without reduction;
-//     operands are 16-byte limbs (LE UInt64 pair each), output Z0, Z1, Z2
-//     (48 bytes; no Z1 merge / reduction).
-//   CRYPTOLIB_GCMFIELD_REDUCE3       (ClpSimdProc4Begin: rcx = PZ0, rdx = PZ1,
-//     r8 = PZ2, r9 = POut) - fold Z1 into (Z0, Z2), then reduce the (Z0, Z2)
-//     pair modulo the GCM polynomial x^128 + x^7 + x^2 + x + 1, writing the
-//     16-byte field element to POut. Z0/Z1/Z2 are the three 128-bit limbs
-//     carried across a batch of Karatsuba-style PCLMULQDQ GHASH products.
-//   CRYPTOLIB_GCMFIELD_XOR_LIMBS48   (ClpSimdProc4Begin: rcx = PA0, rdx = PA1,
-//     r8 = PA2, r9 = PSrc48) - xor 16-byte limbs in place:
-//     *PA0 ^= PSrc[0..15], *PA1 ^= PSrc[16..31], *PA2 ^= PSrc[32..47].
 //   CRYPTOLIB_GCMFIELD_BLOCK_REVERSE (ClpSimdProc3Begin: rcx = PDst,
 //     rdx = PSrc, r8 = PShuffleCtrl) - [rcx] := pshufb([rdx], [r8])
 //     (SSSE3 16-byte byte reverse).
@@ -71,123 +59,12 @@
   psrldq    xmm5, 8
   movq      qword ptr [r8 + 24], xmm5
 {$ELSE}
-  {$IFDEF CRYPTOLIB_GCMFIELD_MULTIPLY_EXT}
-  movdqu    xmm0, [rcx]
-  movdqu    xmm1, [rdx]
-
-  movdqu    xmm2, xmm0
-  db $66, $0F, $3A, $44, $D1, $00  // pclmulqdq xmm2, xmm1, 0
-
-  movdqu    xmm3, xmm0
-  db $66, $0F, $3A, $44, $D9, $01  // pclmulqdq xmm3, xmm1, 1
-  movdqu    xmm4, xmm0
-  db $66, $0F, $3A, $44, $E1, $10  // pclmulqdq xmm4, xmm1, 16
-  pxor      xmm3, xmm4
-
-  movdqu    xmm4, xmm0
-  db $66, $0F, $3A, $44, $E1, $11  // pclmulqdq xmm4, xmm1, 17
-
-  movdqu    [r8 + 0], xmm2
-  movdqu    [r8 + 16], xmm3
-  movdqu    [r8 + 32], xmm4
-  {$ELSE}
-    {$IFDEF CRYPTOLIB_GCMFIELD_REDUCE3}
-{$I ..\..\Include\Simd\Common\ClpSimdNonVolatileSave_x86_64.inc}
-  movdqu    xmm0, [rcx]
-  movdqu    xmm2, [r8]
-  movdqu    xmm1, [rdx]
-  movdqa    xmm4, xmm1
-  movdqa    xmm5, xmm1
-  pslldq    xmm4, 8
-  psrldq    xmm5, 8
-  pxor      xmm0, xmm4
-  pxor      xmm2, xmm5
-  movdqu    [rcx], xmm0
-  movdqu    [r8], xmm2
-  movdqu    xmm0, [rcx]
-  movdqu    xmm2, [r8]
-  movq      xmm3, xmm0
-  movq      xmm4, xmm2
-  movdqa    xmm5, xmm3
-  psrlq     xmm5, 1
-  movdqa    xmm6, xmm3
-  psrlq     xmm6, 2
-  movdqa    xmm7, xmm3
-  psrlq     xmm7, 7
-  pxor      xmm4, xmm3
-  pxor      xmm4, xmm5
-  pxor      xmm4, xmm6
-  pxor      xmm4, xmm7
-  movdqa    xmm1, xmm0
-  psrldq    xmm1, 8
-  movdqa    xmm5, xmm3
-  psllq     xmm5, 63
-  movdqa    xmm6, xmm3
-  psllq     xmm6, 62
-  movdqa    xmm7, xmm3
-  psllq     xmm7, 57
-  pxor      xmm1, xmm5
-  pxor      xmm1, xmm6
-  pxor      xmm1, xmm7
-  movdqa    xmm5, xmm2
-  psrldq    xmm5, 8
-  movdqa    xmm6, xmm5
-  psllq     xmm6, 1
-  movdqa    xmm7, xmm4
-  psrlq     xmm7, 63
-  por       xmm6, xmm7
-  movdqa    xmm7, xmm4
-  psllq     xmm7, 1
-  movdqa    xmm3, xmm1
-  psrlq     xmm3, 63
-  por       xmm7, xmm3
-  movdqa    xmm0, xmm1
-  psllq     xmm0, 1
-  movdqa    xmm3, xmm0
-  psrlq     xmm3, 1
-  movdqa    xmm2, xmm0
-  psrlq     xmm2, 2
-  movdqa    xmm5, xmm0
-  psrlq     xmm5, 7
-  pxor      xmm6, xmm0
-  pxor      xmm6, xmm3
-  pxor      xmm6, xmm2
-  pxor      xmm6, xmm5
-  movdqa    xmm3, xmm1
-  psllq     xmm3, 63
-  movdqa    xmm2, xmm1
-  psllq     xmm2, 58
-  pxor      xmm7, xmm3
-  pxor      xmm7, xmm2
-  movq      qword ptr [r9], xmm7
-  movq      qword ptr [r9 + 8], xmm6
-{$I ..\..\Include\Simd\Common\ClpSimdNonVolatileRestore_x86_64.inc}
-    {$ELSE}
-      {$IFDEF CRYPTOLIB_GCMFIELD_XOR_LIMBS48}
-  movdqu    xmm0, [rcx]
-  movdqu    xmm1, [r9]
-  pxor      xmm0, xmm1
-  movdqu    [rcx], xmm0
-
-  movdqu    xmm0, [rdx]
-  movdqu    xmm1, [r9 + 16]
-  pxor      xmm0, xmm1
-  movdqu    [rdx], xmm0
-
-  movdqu    xmm0, [r8]
-  movdqu    xmm1, [r9 + 32]
-  pxor      xmm0, xmm1
-  movdqu    [r8], xmm0
-      {$ELSE}
-        {$IFDEF CRYPTOLIB_GCMFIELD_BLOCK_REVERSE}
+  {$IFDEF CRYPTOLIB_GCMFIELD_BLOCK_REVERSE}
   movdqu    xmm0, [rdx]
   movdqu    xmm1, [r8]
   pshufb    xmm0, xmm1
   movdqu    [rcx], xmm0
-        {$ELSE}
-        {$FATAL Exactly one of CRYPTOLIB_GCMFIELD_PARTIAL, CRYPTOLIB_GCMFIELD_MULTIPLY_EXT, CRYPTOLIB_GCMFIELD_REDUCE3, CRYPTOLIB_GCMFIELD_XOR_LIMBS48, CRYPTOLIB_GCMFIELD_BLOCK_REVERSE must be defined before including this file}
-        {$ENDIF}
-      {$ENDIF}
-    {$ENDIF}
+  {$ELSE}
+  {$FATAL Exactly one of CRYPTOLIB_GCMFIELD_PARTIAL, CRYPTOLIB_GCMFIELD_BLOCK_REVERSE must be defined before including this file}
   {$ENDIF}
 {$ENDIF}

--- a/CryptoLib/src/Simd/Backend/ClpGhashArmBackend.pas
+++ b/CryptoLib/src/Simd/Backend/ClpGhashArmBackend.pas
@@ -39,12 +39,6 @@ type
   public
     /// <summary>PMULL carryless multiply-reduce: <c>PX := PX * PY</c> in GF(2^128).</summary>
     class function TryMultiply(PX, PY: Pointer): Boolean; static;
-    /// <summary>PMULL carryless multiply to three 128-bit limbs (48 bytes).</summary>
-    class function TryMultiplyExt(PX, PY, POut48: PByte): Boolean; static;
-    /// <summary>SIMD fold + reduce of three 128-bit limbs into one block.</summary>
-    class function TryReduce3(PZ0, PZ1, PZ2, PSVector16: PByte): Boolean; static;
-    /// <summary>SIMD xor of three 16-byte limbs with three slices of a 48-byte MultiplyExt output.</summary>
-    class function TryXorMultiplyExtLimbs48(PA0, PA1, PA2, PSrc48: PByte): Boolean; static;
     /// <summary>PMULL fused 4-way GHASH over ABatchCount 64-byte batches.</summary>
     class function TryFusedFourShuffledGhash(PFS, PC0, PHPow64: PByte;
       ABatchCount: NativeInt): Boolean; static;
@@ -82,27 +76,6 @@ procedure GcmPmullFieldPartial(PX, PY, POut: Pointer);
 {$I ..\..\Include\Simd\Common\ClpSimdProc3Begin_aarch64.inc}
 {$I ..\..\Include\Simd\Gcm\GcmFieldOps_aarch64.inc}
 {$UNDEF CRYPTOLIB_GCMFIELD_PARTIAL}
-end;
-
-procedure GcmPmullMultiplyExtBytes(PX, PY, POut48: Pointer);
-{$DEFINE CRYPTOLIB_GCMFIELD_MULTIPLY_EXT}
-{$I ..\..\Include\Simd\Common\ClpSimdProc3Begin_aarch64.inc}
-{$I ..\..\Include\Simd\Gcm\GcmFieldOps_aarch64.inc}
-{$UNDEF CRYPTOLIB_GCMFIELD_MULTIPLY_EXT}
-end;
-
-procedure GcmReduce3FoldNeon(PZ0, PZ1, PZ2, POut: Pointer);
-{$DEFINE CRYPTOLIB_GCMFIELD_REDUCE3}
-{$I ..\..\Include\Simd\Common\ClpSimdProc4Begin_aarch64.inc}
-{$I ..\..\Include\Simd\Gcm\GcmFieldOps_aarch64.inc}
-{$UNDEF CRYPTOLIB_GCMFIELD_REDUCE3}
-end;
-
-procedure GcmXorMultiplyExtLimbs48Neon(PA0, PA1, PA2, PSrc48: Pointer);
-{$DEFINE CRYPTOLIB_GCMFIELD_XOR_LIMBS48}
-{$I ..\..\Include\Simd\Common\ClpSimdProc4Begin_aarch64.inc}
-{$I ..\..\Include\Simd\Gcm\GcmFieldOps_aarch64.inc}
-{$UNDEF CRYPTOLIB_GCMFIELD_XOR_LIMBS48}
 end;
 
 procedure GcmGhashFourFull(PFS, PC0, PHPow64: Pointer; ABatchCount: NativeInt);
@@ -164,42 +137,6 @@ begin
   begin
     GcmPmullFieldPartial(PX, PY, @LPartial);
     GcmPmullReducePartial(LPartial, PGcmFieldRaw(PX)^);
-    Exit(True);
-  end;
-{$ENDIF}
-  Result := False;
-end;
-
-class function TGhashArmBackend.TryMultiplyExt(PX, PY, POut48: PByte): Boolean;
-begin
-{$IFDEF CRYPTOLIB_AARCH64_ASM}
-  if TCpuFeatures.Arm.HasPMULL() then
-  begin
-    GcmPmullMultiplyExtBytes(PX, PY, POut48);
-    Exit(True);
-  end;
-{$ENDIF}
-  Result := False;
-end;
-
-class function TGhashArmBackend.TryReduce3(PZ0, PZ1, PZ2, PSVector16: PByte): Boolean;
-begin
-{$IFDEF CRYPTOLIB_AARCH64_ASM}
-  if TCpuFeatures.Arm.HasNEON() then
-  begin
-    GcmReduce3FoldNeon(PZ0, PZ1, PZ2, PSVector16);
-    Exit(True);
-  end;
-{$ENDIF}
-  Result := False;
-end;
-
-class function TGhashArmBackend.TryXorMultiplyExtLimbs48(PA0, PA1, PA2, PSrc48: PByte): Boolean;
-begin
-{$IFDEF CRYPTOLIB_AARCH64_ASM}
-  if TCpuFeatures.Arm.HasNEON() then
-  begin
-    GcmXorMultiplyExtLimbs48Neon(PA0, PA1, PA2, PSrc48);
     Exit(True);
   end;
 {$ENDIF}

--- a/CryptoLib/src/Simd/Backend/ClpGhashX86Backend.pas
+++ b/CryptoLib/src/Simd/Backend/ClpGhashX86Backend.pas
@@ -38,12 +38,6 @@ type
   public
     /// <summary>PCLMULQDQ carryless multiply-reduce: <c>PX := PX * PY</c> in GF(2^128).</summary>
     class function TryMultiply(PX, PY: Pointer): Boolean; static;
-    /// <summary>PCLMULQDQ carryless multiply to three 128-bit limbs (48 bytes).</summary>
-    class function TryMultiplyExt(PX, PY, POut48: PByte): Boolean; static;
-    /// <summary>SIMD fold + reduce of three 128-bit limbs into one block.</summary>
-    class function TryReduce3(PZ0, PZ1, PZ2, PSVector16: PByte): Boolean; static;
-    /// <summary>SIMD xor of three 16-byte limbs with three slices of a 48-byte MultiplyExt output.</summary>
-    class function TryXorMultiplyExtLimbs48(PA0, PA1, PA2, PSrc48: PByte): Boolean; static;
     /// <summary>PCLMULQDQ fused 4-way GHASH over ABatchCount 64-byte batches (requires packed vector layout). Uses the backend's own byte-reverse mask.</summary>
     class function TryFusedFourShuffledGhash(PFS, PC0, PHPow64: PByte;
       ABatchCount: NativeInt): Boolean; static;
@@ -87,45 +81,6 @@ procedure GcmPclmulFieldPartial(PX, PY, POut: Pointer);
 {$I ..\..\Include\Simd\Gcm\GcmFieldOps_i386.inc}
 {$ENDIF}
 {$UNDEF CRYPTOLIB_GCMFIELD_PARTIAL}
-end;
-
-procedure GcmPclmulMultiplyExtBytes(PX, PY, POut48: Pointer);
-{$DEFINE CRYPTOLIB_GCMFIELD_MULTIPLY_EXT}
-{$IFDEF CRYPTOLIB_X86_64_ASM}
-{$I ..\..\Include\Simd\Common\ClpSimdProc3Begin_x86_64.inc}
-{$I ..\..\Include\Simd\Gcm\GcmFieldOps_x86_64.inc}
-{$ENDIF}
-{$IFDEF CRYPTOLIB_I386_ASM}
-{$I ..\..\Include\Simd\Common\ClpSimdProc3Begin_i386.inc}
-{$I ..\..\Include\Simd\Gcm\GcmFieldOps_i386.inc}
-{$ENDIF}
-{$UNDEF CRYPTOLIB_GCMFIELD_MULTIPLY_EXT}
-end;
-
-procedure GcmReduce3FoldSse2(PZ0, PZ1, PZ2, POut: Pointer);
-{$DEFINE CRYPTOLIB_GCMFIELD_REDUCE3}
-{$IFDEF CRYPTOLIB_X86_64_ASM}
-{$I ..\..\Include\Simd\Common\ClpSimdProc4Begin_x86_64.inc}
-{$I ..\..\Include\Simd\Gcm\GcmFieldOps_x86_64.inc}
-{$ENDIF}
-{$IFDEF CRYPTOLIB_I386_ASM}
-{$I ..\..\Include\Simd\Common\ClpSimdProc4Begin_i386.inc}
-{$I ..\..\Include\Simd\Gcm\GcmFieldOps_i386.inc}
-{$ENDIF}
-{$UNDEF CRYPTOLIB_GCMFIELD_REDUCE3}
-end;
-
-procedure GcmXorMultiplyExtLimbs48Sse2(PA0, PA1, PA2, PSrc48: Pointer);
-{$DEFINE CRYPTOLIB_GCMFIELD_XOR_LIMBS48}
-{$IFDEF CRYPTOLIB_X86_64_ASM}
-{$I ..\..\Include\Simd\Common\ClpSimdProc4Begin_x86_64.inc}
-{$I ..\..\Include\Simd\Gcm\GcmFieldOps_x86_64.inc}
-{$ENDIF}
-{$IFDEF CRYPTOLIB_I386_ASM}
-{$I ..\..\Include\Simd\Common\ClpSimdProc4Begin_i386.inc}
-{$I ..\..\Include\Simd\Gcm\GcmFieldOps_i386.inc}
-{$ENDIF}
-{$UNDEF CRYPTOLIB_GCMFIELD_XOR_LIMBS48}
 end;
 
 procedure GcmGhashFourFull(PFS, PC0, PHPow64, PMask: Pointer; ABatchCount: NativeInt);
@@ -211,42 +166,6 @@ begin
   begin
     GcmPclmulFieldPartial(PX, PY, @LPartial);
     GcmPclmulReducePartial(LPartial, PGcmFieldRaw(PX)^);
-    Exit(True);
-  end;
-{$ENDIF}
-  Result := False;
-end;
-
-class function TGhashX86Backend.TryMultiplyExt(PX, PY, POut48: PByte): Boolean;
-begin
-{$IFDEF CRYPTOLIB_X86_SIMD}
-  if TCpuFeatures.X86.HasPCLMULQDQ() then
-  begin
-    GcmPclmulMultiplyExtBytes(PX, PY, POut48);
-    Exit(True);
-  end;
-{$ENDIF}
-  Result := False;
-end;
-
-class function TGhashX86Backend.TryReduce3(PZ0, PZ1, PZ2, PSVector16: PByte): Boolean;
-begin
-{$IFDEF CRYPTOLIB_X86_SIMD}
-  if TCpuFeatures.X86.HasSSE2() then
-  begin
-    GcmReduce3FoldSse2(PZ0, PZ1, PZ2, PSVector16);
-    Exit(True);
-  end;
-{$ENDIF}
-  Result := False;
-end;
-
-class function TGhashX86Backend.TryXorMultiplyExtLimbs48(PA0, PA1, PA2, PSrc48: PByte): Boolean;
-begin
-{$IFDEF CRYPTOLIB_X86_SIMD}
-  if TCpuFeatures.X86.HasSSE2() then
-  begin
-    GcmXorMultiplyExtLimbs48Sse2(PA0, PA1, PA2, PSrc48);
     Exit(True);
   end;
 {$ENDIF}

--- a/CryptoLib/src/Simd/Facade/ClpGhashSimd.pas
+++ b/CryptoLib/src/Simd/Facade/ClpGhashSimd.pas
@@ -42,12 +42,6 @@ type
   public
     /// <summary>Carryless multiply-reduce: <c>PX := PX * PY</c> in GF(2^128).</summary>
     class function TryMultiply(PX, PY: Pointer): Boolean; static;
-    /// <summary>Carryless multiply to three 128-bit limbs (48 bytes).</summary>
-    class function TryMultiplyExt(PX, PY, POut48: PByte): Boolean; static;
-    /// <summary>Fold + reduce of three 128-bit limbs into one block.</summary>
-    class function TryReduce3(PZ0, PZ1, PZ2, PSVector16: PByte): Boolean; static;
-    /// <summary>Xor three 16-byte limbs with three slices of a 48-byte MultiplyExt output.</summary>
-    class function TryXorMultiplyExtLimbs48(PA0, PA1, PA2, PSrc48: PByte): Boolean; static;
     /// <summary>Fused 4-way GHASH over ABatchCount contiguous 64-byte batches.</summary>
     class function TryFusedFourShuffledGhash(PFS, PC0, PHPow64: PByte;
       ABatchCount: NativeInt): Boolean; static;
@@ -73,39 +67,6 @@ begin
   Result := TGhashX86Backend.TryMultiply(PX, PY);
 {$ELSEIF DEFINED(CRYPTOLIB_AARCH64_ASM)}
   Result := TGhashArmBackend.TryMultiply(PX, PY);
-{$ELSE}
-  Result := False;
-{$IFEND}
-end;
-
-class function TGhashSimd.TryMultiplyExt(PX, PY, POut48: PByte): Boolean;
-begin
-{$IF DEFINED(CRYPTOLIB_X86_SIMD)}
-  Result := TGhashX86Backend.TryMultiplyExt(PX, PY, POut48);
-{$ELSEIF DEFINED(CRYPTOLIB_AARCH64_ASM)}
-  Result := TGhashArmBackend.TryMultiplyExt(PX, PY, POut48);
-{$ELSE}
-  Result := False;
-{$IFEND}
-end;
-
-class function TGhashSimd.TryReduce3(PZ0, PZ1, PZ2, PSVector16: PByte): Boolean;
-begin
-{$IF DEFINED(CRYPTOLIB_X86_SIMD)}
-  Result := TGhashX86Backend.TryReduce3(PZ0, PZ1, PZ2, PSVector16);
-{$ELSEIF DEFINED(CRYPTOLIB_AARCH64_ASM)}
-  Result := TGhashArmBackend.TryReduce3(PZ0, PZ1, PZ2, PSVector16);
-{$ELSE}
-  Result := False;
-{$IFEND}
-end;
-
-class function TGhashSimd.TryXorMultiplyExtLimbs48(PA0, PA1, PA2, PSrc48: PByte): Boolean;
-begin
-{$IF DEFINED(CRYPTOLIB_X86_SIMD)}
-  Result := TGhashX86Backend.TryXorMultiplyExtLimbs48(PA0, PA1, PA2, PSrc48);
-{$ELSEIF DEFINED(CRYPTOLIB_AARCH64_ASM)}
-  Result := TGhashArmBackend.TryXorMultiplyExtLimbs48(PA0, PA1, PA2, PSrc48);
 {$ELSE}
   Result := False;
 {$IFEND}


### PR DESCRIPTION
The MultiplyExt / Reduce3 / XorMultiplyExtLimbs48 family (the 48-byte extended product plus 3-limb reduction from the Karatsuba GHASH multiply that was tried and reverted) has no remaining callers. Remove it across every layer: the TGcmUtilities facade, the ClpGhashSimd Try* facade, both SIMD backends and their per-arch GcmFieldOps kernels, and the stale references in the AES-NI GCM kernel.

Dead-code removal only; the live 8-way aggregated GHASH path is untouched.