### PR TITLE
Unify AEAD key reuse into a two-phase init protocol

### DIFF
--- a/CryptoLib.Tests/src/Crypto/AeadEmptyInputTests.pas
+++ b/CryptoLib.Tests/src/Crypto/AeadEmptyInputTests.pas
@@ -76,6 +76,10 @@ type
       const AName: String);
     function CreateStream(AMode: Int32): IAeadCipher;
     function CreatePacket(AMode: Int32): IAeadPacketCipher;
+    function SealParams(const ACipher: IAeadCipher; AForEncryption: Boolean;
+      const AParams: ICipherParameters; const AInput: TBytes): TBytes;
+    // nil-key parameter = "reuse the established key" convention.
+    function ReuseParams(const ANonce, AAad: TBytes): ICipherParameters;
     function StreamSeal(const ACipher: IAeadCipher; AForEncryption: Boolean;
       const AKey, ANonce, AAad, AInput: TBytes): TBytes;
     function PacketSeal(const APacket: IAeadPacketCipher; AForEncryption: Boolean;
@@ -95,6 +99,12 @@ type
     procedure TestBufferedCiphersAcceptEmptyInput;
     procedure TestPacketMatchesStreaming;
     procedure TestBlockPacketMatchesBuffered;
+    // Two-phase key-reuse protocol: a nil-key re-Init reuses the established key
+    // (must match an explicit re-key), and a rekey that fails mid-Init must clear
+    // the ready flag so a following nil-key reuse raises instead of running on a
+    // half-built or wiped schedule.
+    procedure TestNilKeyReuseMatchesRekey;
+    procedure TestFailedRekeyDefends;
   end;
 
 implementation
@@ -229,13 +239,14 @@ begin
   end;
 end;
 
-function TTestAeadEmptyInput.StreamSeal(const ACipher: IAeadCipher;
-  AForEncryption: Boolean; const AKey, ANonce, AAad, AInput: TBytes): TBytes;
+function TTestAeadEmptyInput.SealParams(const ACipher: IAeadCipher;
+  AForEncryption: Boolean; const AParams: ICipherParameters;
+  const AInput: TBytes): TBytes;
 var
   LOut: TBytes;
   LLen: Int32;
 begin
-  ACipher.Init(AForEncryption, AeadParams(AKey, ANonce, AAad));
+  ACipher.Init(AForEncryption, AParams);
   System.SetLength(LOut, ACipher.GetOutputSize(System.Length(AInput)));
   LLen := 0;
   if System.Length(AInput) > 0 then
@@ -243,6 +254,19 @@ begin
   LLen := LLen + ACipher.DoFinal(LOut, LLen);
   System.SetLength(LOut, LLen);
   Result := LOut;
+end;
+
+function TTestAeadEmptyInput.ReuseParams(const ANonce,
+  AAad: TBytes): ICipherParameters;
+begin
+  Result := TAeadParameters.Create(nil, 128, ANonce, AAad) as ICipherParameters;
+end;
+
+function TTestAeadEmptyInput.StreamSeal(const ACipher: IAeadCipher;
+  AForEncryption: Boolean; const AKey, ANonce, AAad, AInput: TBytes): TBytes;
+begin
+  Result := SealParams(ACipher, AForEncryption, AeadParams(AKey, ANonce, AAad),
+    AInput);
 end;
 
 function TTestAeadEmptyInput.PacketSeal(const APacket: IAeadPacketCipher;
@@ -308,6 +332,84 @@ begin
   CheckDifferential(3, 16, 12, 'EAX');
   CheckDifferential(4, 16, 12, 'OCB');
   CheckDifferential(5, 16, 12, 'GCM-SIV');
+end;
+
+procedure TTestAeadEmptyInput.TestNilKeyReuseMatchesRekey;
+
+  procedure Once(AMode, AKeyLen, ANonceLen: Int32; const AName: String);
+  var
+    LCipher: IAeadCipher;
+    LKey, LAad, LN1, LN2, LPt1, LPt2, LReuse, LRef: TBytes;
+  begin
+    LKey := MakeBytes(AKeyLen, 10);
+    LAad := MakeBytes(13, 11);
+    LN1 := MakeBytes(ANonceLen, 1);
+    LN2 := MakeBytes(ANonceLen, 2);
+    LPt1 := MakeBytes(24, 3);
+    LPt2 := MakeBytes(40, 4);
+
+    LCipher := CreateStream(AMode);
+    // Establish the key, then reuse it for a fresh nonce via a nil-key parameter.
+    SealParams(LCipher, True, AeadParams(LKey, LN1, LAad), LPt1);
+    LReuse := SealParams(LCipher, True, ReuseParams(LN2, LAad), LPt2);
+    // A fresh instance keyed explicitly at the same nonce must produce the same.
+    LRef := SealParams(CreateStream(AMode), True, AeadParams(LKey, LN2, LAad), LPt2);
+    Check(AreEqual(LReuse, LRef),
+      AName + ': nil-key reuse must match an explicit re-key');
+  end;
+
+begin
+  Once(0, 16, 12, 'GCM');
+  Once(2, 16, 12, 'CCM');
+  Once(3, 16, 12, 'EAX');
+  Once(4, 16, 12, 'OCB');
+end;
+
+procedure TTestAeadEmptyInput.TestFailedRekeyDefends;
+
+  procedure Once(AMode, AKeyLen, ANonceLen: Int32; const AName: String);
+  var
+    LCipher: IAeadCipher;
+    LKey, LBad, LAad, LN1, LN2, LN3, LPt: TBytes;
+    LThrew: Boolean;
+  begin
+    LKey := MakeBytes(AKeyLen, 10);
+    LBad := MakeBytes(AKeyLen + 4, 12); // wrong length: engine rejects during Init
+    LAad := MakeBytes(13, 11);
+    LN1 := MakeBytes(ANonceLen, 1);
+    LN2 := MakeBytes(ANonceLen, 2);
+    LN3 := MakeBytes(ANonceLen, 3);
+    LPt := MakeBytes(32, 5);
+
+    LCipher := CreateStream(AMode);
+    SealParams(LCipher, True, AeadParams(LKey, LN1, LAad), LPt); // establish
+
+    // A rekey that fails mid-Init must clear the ready flag ...
+    LThrew := False;
+    try
+      SealParams(LCipher, True, AeadParams(LBad, LN2, LAad), LPt);
+    except
+      LThrew := True;
+    end;
+    Check(LThrew, AName + ': a bad-length rekey must raise');
+
+    // ... so a following nil-key reuse cannot silently run on the half-built
+    // (or wiped) schedule: it must raise rather than produce output.
+    LThrew := False;
+    try
+      SealParams(LCipher, True, ReuseParams(LN3, LAad), LPt);
+    except
+      LThrew := True;
+    end;
+    Check(LThrew,
+      AName + ': nil-key reuse after a failed rekey must raise, not reuse state');
+  end;
+
+begin
+  Once(0, 16, 12, 'GCM');
+  Once(2, 16, 12, 'CCM');
+  Once(3, 16, 12, 'EAX');
+  Once(4, 16, 12, 'OCB');
 end;
 
 function TTestAeadEmptyInput.BlockPacketSeal(const APacket: IBlockPacketCipher;

--- a/CryptoLib/src/Crypto/Modes/ClpAbstractAeadCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpAbstractAeadCipher.pas
@@ -60,6 +60,12 @@ type
     // Last-used key / nonce, retained for the encrypt-side nonce-reuse guard.
     FLastKey: TCryptoLibByteArray;
     FLastNonce: TCryptoLibByteArray;
+    // True only while FLastKey describes a key fully applied to the mode
+    // (schedules, subkeys, tables all rebuilt). Cleared before a destructive
+    // rekey and set again only after it succeeds, so a thrown Init never leaves
+    // the mode reusing a half-built or stale key. Mirrors the AES engine's
+    // FScheduleReady; never touched by Reset (modes reuse the cipher after Reset).
+    FKeyReady: Boolean;
 
     /// <summary>Short mode label used in exception messages (e.g. <c>EAX</c>,
     /// <c>GCM</c>). Distinct from the full <c>AlgorithmName</c>.</summary>
@@ -98,26 +104,41 @@ type
     procedure WipeKeyMaterial(); virtual;
 
     /// <summary>
-    /// Same-key detection + <c>FLastKey</c> maintenance shared by the AEAD
-    /// modes, so a re-Init under the same key does no per-message key copy.
-    /// Honors two "reuse the key" signals: (a) <c>AKeyParam = nil</c> (the
-    /// bc-csharp null-key convention) and (b) <c>AKeyParam</c> holding the same
-    /// bytes as the retained <c>FLastKey</c>. In both cases <c>FLastKey</c> is
-    /// left intact (no realloc/copy) and True is returned. When the key differs,
-    /// the old <c>FLastKey</c> is wiped, a fresh copy is stored, and False is
-    /// returned. Constant-time compare. MUST be called AFTER
+    /// The mode-level re-key gate, shared by every AEAD mode: returns True when a
+    /// destructive rebuild of the key-derived state is required for AKeyParam, and
+    /// False when the current key may be reused as-is. Reuse is granted only when
+    /// the mode is <c>FKeyReady</c> AND the key is unchanged - a nil key (the
+    /// null-key reuse convention) or bytes equal to the retained <c>FLastKey</c>
+    /// (constant-time). On any rebuild it clears <c>FKeyReady</c> first (the
+    /// rebuild is destructive) and records nothing, so an Init that then throws
+    /// leaves the mode "not ready" and <c>FLastKey</c> unchanged; the caller MUST
+    /// call <c>CommitKey</c> as the last step of a successful rebuild. Call AFTER
     /// <c>CheckNonceReuse</c> (both read the pre-update <c>FLastKey</c>).
     /// </summary>
-    function SameKeyReuse(const AKeyParam: IKeyParameter): Boolean;
+    function NeedsReKey(const AKeyParam: IKeyParameter): Boolean;
 
-    /// <summary>
-    /// Raw-key counterpart of <c>SameKeyReuse</c> for the one-shot packet path,
-    /// so the facade never has to wrap the key in an <c>IKeyParameter</c> per
-    /// message. Same contract: True (key retained as-is) when AKey is nil (reuse)
-    /// or matches the stored key; otherwise wipe + store a fresh copy and return
-    /// False. Constant-time compare; call AFTER <c>CheckNonceReuseRaw</c>.
+    /// <summary>Raw-key counterpart of <c>NeedsReKey</c> for the one-shot packet
+    /// path, so the facade need not wrap the key per message. Same contract; call
+    /// AFTER <c>CheckNonceReuseRaw</c>.</summary>
+    function NeedsReKeyRaw(const AKey: TCryptoLibByteArray): Boolean;
+
+    /// <summary>Pure same-key test against the retained <c>FLastKey</c> (a nil key
+    /// = reuse). Records nothing. Building block for <c>NeedsReKey</c>.</summary>
+    function IsSameKey(const AKeyParam: IKeyParameter): Boolean;
+
+    /// <summary>Retain <c>AKeyParam</c>'s bytes as <c>FLastKey</c> (wiping the old
+    /// copy; no realloc/copy for a nil or unchanged key) and set <c>FKeyReady</c>.
+    /// Call once, only after the key-dependent rebuild has succeeded, so a thrown
+    /// Init never commits a bad key or marks the mode ready.</summary>
+    procedure CommitKey(const AKeyParam: IKeyParameter);
+
+    /// <summary>Raw-key phase-1 test for the packet path. See <c>IsSameKey</c>.
     /// </summary>
-    function SameKeyReuseRaw(const AKey: TCryptoLibByteArray): Boolean;
+    function IsSameKeyRaw(const AKey: TCryptoLibByteArray): Boolean;
+
+    /// <summary>Raw-key phase-2 commit for the packet path. See <c>CommitKey</c>.
+    /// </summary>
+    procedure CommitKeyRaw(const AKey: TCryptoLibByteArray);
 
     /// <summary>Raw-key/raw-nonce counterpart of <c>CheckNonceReuse</c> for the
     /// one-shot packet path. Byte-identical guard: on encryption, refuse a
@@ -137,7 +158,7 @@ type
     /// Default one-shot packet init: builds an AeadParameters and defers to Init.
     /// This is NOT the zero-allocation path - modes with a small-buffer packet
     /// cipher override it with a raw InitPacket that skips the parameter objects
-    /// and routes key identity through SameKeyReuseRaw.
+    /// and routes key identity through NeedsReKeyRaw/CommitKeyRaw.
     /// </summary>
     procedure InitPacket(AForEncryption: Boolean;
       const AKey, ANonce, AAad: TCryptoLibByteArray;
@@ -199,51 +220,71 @@ begin
     AAad) as ICipherParameters);
 end;
 
-function TAbstractAeadCipher.SameKeyReuse(const AKeyParam
-  : IKeyParameter): Boolean;
+function TAbstractAeadCipher.IsSameKey(const AKeyParam: IKeyParameter): Boolean;
 begin
+  // null-key convention: reuse only makes sense once a key was established.
   if AKeyParam = nil then
-  begin
-    // null-key convention: reuse only makes sense once a key was established.
-    Result := FLastKey <> nil;
-    Exit;
-  end;
-
-  if (FLastKey <> nil) and AKeyParam.FixedTimeEquals(FLastKey) then
-  begin
-    // Same key bytes: keep FLastKey as-is (no realloc, no copy).
-    Result := True;
-    Exit;
-  end;
-
-  // Key changed: wipe the old copy, retain a fresh one for the reuse guard.
-  if FLastKey <> nil then
-    TArrayUtilities.Fill(FLastKey, 0, System.Length(FLastKey), Byte(0));
-  FLastKey := AKeyParam.GetKey();
-  Result := False;
+    Result := FLastKey <> nil
+  else
+    Result := (FLastKey <> nil) and AKeyParam.FixedTimeEquals(FLastKey);
 end;
 
-function TAbstractAeadCipher.SameKeyReuseRaw(const AKey
+function TAbstractAeadCipher.IsSameKeyRaw(const AKey
   : TCryptoLibByteArray): Boolean;
 begin
   if AKey = nil then
-  begin
-    Result := FLastKey <> nil;
-    Exit;
-  end;
+    Result := FLastKey <> nil
+  else
+    Result := (FLastKey <> nil) and
+      (System.Length(FLastKey) = System.Length(AKey)) and
+      TArrayUtilities.FixedTimeEquals(FLastKey, AKey);
+end;
 
-  if (FLastKey <> nil) and
+function TAbstractAeadCipher.NeedsReKey(const AKeyParam
+  : IKeyParameter): Boolean;
+begin
+  if FKeyReady and IsSameKey(AKeyParam) then
+    Exit(False);
+  // A destructive rebuild follows: invalidate now, record nothing until the
+  // rebuild succeeds and calls CommitKey.
+  FKeyReady := False;
+  Result := True;
+end;
+
+function TAbstractAeadCipher.NeedsReKeyRaw(const AKey
+  : TCryptoLibByteArray): Boolean;
+begin
+  if FKeyReady and IsSameKeyRaw(AKey) then
+    Exit(False);
+  FKeyReady := False;
+  Result := True;
+end;
+
+procedure TAbstractAeadCipher.CommitKey(const AKeyParam: IKeyParameter);
+begin
+  // Store a fresh copy only when the key actually changed (no realloc/copy for a
+  // nil or unchanged key), then mark the mode ready.
+  if (AKeyParam <> nil) and
+    not((FLastKey <> nil) and AKeyParam.FixedTimeEquals(FLastKey)) then
+  begin
+    if FLastKey <> nil then
+      TArrayUtilities.Fill(FLastKey, 0, System.Length(FLastKey), Byte(0));
+    FLastKey := AKeyParam.GetKey();
+  end;
+  FKeyReady := True;
+end;
+
+procedure TAbstractAeadCipher.CommitKeyRaw(const AKey: TCryptoLibByteArray);
+begin
+  if (AKey <> nil) and not((FLastKey <> nil) and
     (System.Length(FLastKey) = System.Length(AKey)) and
-    TArrayUtilities.FixedTimeEquals(FLastKey, AKey) then
+    TArrayUtilities.FixedTimeEquals(FLastKey, AKey)) then
   begin
-    Result := True;
-    Exit;
+    if FLastKey <> nil then
+      TArrayUtilities.Fill(FLastKey, 0, System.Length(FLastKey), Byte(0));
+    FLastKey := System.Copy(AKey);
   end;
-
-  if FLastKey <> nil then
-    TArrayUtilities.Fill(FLastKey, 0, System.Length(FLastKey), Byte(0));
-  FLastKey := System.Copy(AKey);
-  Result := False;
+  FKeyReady := True;
 end;
 
 procedure TAbstractAeadCipher.CheckNonceReuseRaw(AForEncryption: Boolean;

--- a/CryptoLib/src/Crypto/Modes/ClpCcmBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpCcmBlockCipher.pas
@@ -225,8 +225,7 @@ var
   LChoice: TCipherAeadChoice;
   LRequestedMacSizeBits: Int32;
   LDirection: TCipherKernelDirection;
-  LPrevKey: TCryptoLibByteArray;
-  LSameKey: Boolean;
+  LNeedReKey: Boolean;
 begin
   FForEncryption := AForEncryption;
 
@@ -239,7 +238,6 @@ begin
     raise EArgumentCryptoLibException.CreateResFmt(@SInvalidParameters, ['CCM']);
 
   CheckNonceReuse(FForEncryption, LChoice.Nonce, LChoice.KeyParameter);
-  LPrevKey := FLastKey;
 
   FLastNonce := LChoice.Nonce;
   FInitialAssociatedText := LChoice.AssociatedText;
@@ -253,7 +251,21 @@ begin
   begin
     FKeyParam := LChoice.CipherKey;
     if LChoice.KeyParameter <> nil then
-      FLastKey := LChoice.KeyParameter.GetKey();
+      LNeedReKey := NeedsReKey(LChoice.KeyParameter)
+    else
+    begin
+      // non-IKeyParameter key: cannot be compared, so always rebuild and never
+      // mark it reusable; invalidate readiness before the destructive Init.
+      FKeyReady := False;
+      LNeedReKey := True;
+    end;
+  end
+  else
+  begin
+    // nil key reuses the established schedule; require a ready one.
+    if not FKeyReady then
+      raise EArgumentCryptoLibException.CreateRes(@SKeyMustBeSpecified);
+    LNeedReKey := False;
   end;
 
   if (System.Length(FLastNonce) < 7) or (System.Length(FLastNonce) > 13) then
@@ -262,14 +274,17 @@ begin
   // Nonce-only rotation is the hot AEAD path: with the key and direction
   // unchanged the AES schedule, the CTR wrapper and the fused-kernel binding
   // all stay valid, so none of them are recomputed.
-  LSameKey := (LChoice.CipherKey = nil) or
-    ((LPrevKey <> nil) and (LChoice.KeyParameter <> nil) and
-    LChoice.KeyParameter.FixedTimeEquals(LPrevKey));
   if FKeyParam <> nil then
   begin
-    if not LSameKey then
+    if LNeedReKey then
+    begin
       FCipher.Init(True, FKeyParam);
-    if (FCcmKernel = nil) or (not LSameKey) or
+      // Commit (and mark ready) only for a comparable key; a non-IKeyParameter
+      // key stays "not ready" so the next init always rebuilds.
+      if LChoice.KeyParameter <> nil then
+        CommitKey(LChoice.KeyParameter);
+    end;
+    if (FCcmKernel = nil) or LNeedReKey or
       (FKernelForEnc <> AForEncryption) then
     begin
       FCcmKernel := nil;
@@ -296,7 +311,7 @@ procedure TCcmBlockCipher.InitPacket(AForEncryption: Boolean;
   const AKey, ANonce, AAad: TCryptoLibByteArray; AMacSizeBits: Int32);
 var
   LDirection: TCipherKernelDirection;
-  LSameKey: Boolean;
+  LNeedReKey: Boolean;
 begin
   FForEncryption := AForEncryption;
 
@@ -312,15 +327,23 @@ begin
   if (System.Length(FLastNonce) < 7) or (System.Length(FLastNonce) > 13) then
     raise EArgumentCryptoLibException.CreateRes(@SNonceLengthRange);
 
-  LSameKey := SameKeyReuseRaw(AKey);
-  if (AKey <> nil) and (not LSameKey) then
-    FKeyParam := TKeyParameter.Create(AKey) as ICipherParameters;
-  if FKeyParam = nil then
-    raise EArgumentCryptoLibException.CreateRes(@SKeyMustBeSpecified);
+  if AKey <> nil then
+    LNeedReKey := NeedsReKeyRaw(AKey)
+  else
+  begin
+    // nil key reuses the established key; there must be one.
+    if not FKeyReady then
+      raise EArgumentCryptoLibException.CreateRes(@SKeyMustBeSpecified);
+    LNeedReKey := False;
+  end;
 
-  if not LSameKey then
+  if LNeedReKey then
+  begin
+    FKeyParam := TKeyParameter.Create(AKey) as ICipherParameters;
     FCipher.Init(True, FKeyParam);
-  if (FCcmKernel = nil) or (not LSameKey) or (FKernelForEnc <> AForEncryption) then
+    CommitKeyRaw(AKey);
+  end;
+  if (FCcmKernel = nil) or LNeedReKey or (FKernelForEnc <> AForEncryption) then
   begin
     FCcmKernel := nil;
     if AForEncryption then

--- a/CryptoLib/src/Crypto/Modes/ClpChaCha20Poly1305.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpChaCha20Poly1305.pas
@@ -101,10 +101,6 @@ type
     function GetAlgorithmName: String; override;
     function GetModeName: String; override;
     procedure WipeKeyMaterial(); override;
-    // True when the engine keeps its expanded key across a nonce-only re-Init
-    // (nil-key reuse fast path). XChaCha re-derives a per-nonce subkey, so it
-    // overrides this to False and is always re-keyed from the retained FKey.
-    function EngineSupportsKeyReuse: Boolean; virtual;
 
   strict private
   const
@@ -261,11 +257,6 @@ begin
   Result := GetAlgorithmName;
 end;
 
-function TChaCha20Poly1305.EngineSupportsKeyReuse: Boolean;
-begin
-  Result := True;
-end;
-
 procedure TChaCha20Poly1305.WipeKeyMaterial;
 begin
   TArrayUtilities.Fill(FKey, 0, System.Length(FKey), Byte(0));
@@ -284,7 +275,6 @@ var
   LInitNonce: TCryptoLibByteArray;
   LChaCha20Params: ICipherParameters;
   LMacSizeBits: Int32;
-  LKeyChanged: Boolean;
 begin
   if not TCipherModeParameterUtilities.TryResolveAeadOrIv(AParameters, LChoice)
   then
@@ -325,30 +315,19 @@ begin
         [AlgorithmName]);
   end;
 
-  // Same-key fast path (determined against the old FKey, before it is
-  // overwritten): a re-Init with the same key (fresh nonce) keeps the engine's
-  // expanded key and the resolved kernel; only the nonce and the per-message
-  // Poly1305 key are refreshed. A nil key is the "reuse last key" convention.
-  LKeyChanged := (LInitKeyParam <> nil) and
-    ((TState.Uninitialized = FState) or
-    (not LInitKeyParam.FixedTimeEquals(FKey)));
-
-  if LKeyChanged then
+  // Refresh the retained key from the caller; a nil key reuses the retained one
+  // ("reuse last key" convention). The engine is always handed the real key --
+  // ChaCha key setup is only a handful of word writes, so there is nothing worth
+  // caching, and handing over the real key keeps XChaCha correct (it re-derives
+  // its per-nonce subkey on every Init). Only the nonce and the per-message
+  // Poly1305 key change between same-key messages; the resolved kernel is kept.
+  if LInitKeyParam <> nil then
     LInitKeyParam.CopyKeyTo(FKey, 0, KeySize);
 
   System.Move(LInitNonce[0], FNonce[0], FNonceBytes);
 
-  // On a key change pass the key (full re-key); otherwise pass a nil key so the
-  // engine only refreshes the IV and keeps the already-expanded key state.
-  // XChaCha cannot reuse expanded state (it re-derives its subkey per nonce),
-  // so it is always re-keyed from the retained FKey.
-  if LKeyChanged then
-    LChaCha20Params := TParametersWithIV.Create(LInitKeyParam, LInitNonce)
-  else if EngineSupportsKeyReuse then
-    LChaCha20Params := TParametersWithIV.Create(nil, LInitNonce)
-  else
-    LChaCha20Params := TParametersWithIV.Create(TKeyParameter.Create(FKey)
-      as IKeyParameter, LInitNonce);
+  LChaCha20Params := TParametersWithIV.Create(TKeyParameter.Create(FKey)
+    as IKeyParameter, LInitNonce);
   FChaCha20.Init(True, LChaCha20Params);
 
   // Kernel is direction-agnostic for the poly path, so resolve once and keep it
@@ -381,7 +360,6 @@ procedure TChaCha20Poly1305.InitPacket(AForEncryption: Boolean;
   const AKey, ANonce, AAad: TCryptoLibByteArray; AMacSizeBits: Int32);
 var
   LChaCha20Params: ICipherParameters;
-  LKeyChanged: Boolean;
 begin
   // Raw-span mirror of Init (no TryResolveAeadOrIv, no caller parameter objects).
   if ((MacSize * 8) <> AMacSizeBits) then
@@ -410,26 +388,15 @@ begin
 
   FInitialAad := AAad;
 
-  LKeyChanged := (AKey <> nil) and
-    ((TState.Uninitialized = FState) or
-    (not TArrayUtilities.FixedTimeEquals(AKey, FKey)));
-
-  if LKeyChanged then
+  // Refresh the retained key from the caller (a nil key reuses it); the engine
+  // is always handed the real key, as in Init.
+  if AKey <> nil then
     System.Move(AKey[0], FKey[0], KeySize);
 
   System.Move(ANonce[0], FNonce[0], FNonceBytes);
 
-  // Same-key -> nil-key engine re-init (IV only); a fresh TKeyParameter is
-  // created only on an actual rekey. XChaCha re-derives its subkey per nonce,
-  // so it is always re-keyed from the retained FKey instead.
-  if LKeyChanged then
-    LChaCha20Params := TParametersWithIV.Create(TKeyParameter.Create(AKey)
-      as IKeyParameter, ANonce)
-  else if EngineSupportsKeyReuse then
-    LChaCha20Params := TParametersWithIV.Create(nil, ANonce)
-  else
-    LChaCha20Params := TParametersWithIV.Create(TKeyParameter.Create(FKey)
-      as IKeyParameter, ANonce);
+  LChaCha20Params := TParametersWithIV.Create(TKeyParameter.Create(FKey)
+    as IKeyParameter, ANonce);
   FChaCha20.Init(True, LChaCha20Params);
 
   // Kernel is direction-agnostic for the poly path, so resolve once and keep it

--- a/CryptoLib/src/Crypto/Modes/ClpEaxBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpEaxBlockCipher.pas
@@ -271,8 +271,14 @@ begin
 
   CheckNonceReuse(FForEncryption, LChoice.Nonce, LChoice.KeyParameter);
   FLastNonce := System.Copy(LChoice.Nonce);
+  // A supplied key triggers a full rebuild below: invalidate readiness now and
+  // re-commit (wiping the old key copy) only once every schedule is rebuilt, so
+  // a mid-Init failure cannot leave the ready flag set over a half-built state.
+  // A nil key parameter means reuse; require an established schedule to reuse.
   if LChoice.KeyParameter <> nil then
-    FLastKey := LChoice.KeyParameter.GetKey();
+    FKeyReady := False
+  else if not FKeyReady then
+    raise EArgumentCryptoLibException.CreateRes(@SKeyMustBeSpecified);
 
   FInitialAssociatedText := LChoice.AssociatedText;
   if LChoice.IsAead then
@@ -314,6 +320,11 @@ begin
       TCipherKernelDirection.Decrypt, FEaxKernel);
   FUseFusedBody := FEaxKernel <> nil;
 
+  // Streaming always rebuilds the key schedule, so the OMAC subkeys are stale:
+  // wipe and drop them here so they never survive a rekey (re-derived below when
+  // fused, left nil for the scalar path).
+  TArrayUtilities.Fill(FOmacB, 0, System.Length(FOmacB), Byte(0));
+  FOmacB := nil;
   if FUseFusedBody then
   begin
     System.SetLength(FOmacState, FBlockSize);
@@ -322,6 +333,11 @@ begin
     DeriveOmacSubkeys();
   end;
 
+  // Every key-dependent schedule is rebuilt: commit the key (wiping the prior
+  // copy) and mark the mode ready.
+  if LChoice.KeyParameter <> nil then
+    CommitKey(LChoice.KeyParameter);
+
   Reset(True);
 end;
 
@@ -329,7 +345,7 @@ procedure TEaxBlockCipher.InitPacket(AForEncryption: Boolean;
   const AKey, ANonce, AAad: TCryptoLibByteArray; AMacSizeBits: Int32);
 var
   LTag: TCryptoLibByteArray;
-  LSameKey: Boolean;
+  LNeedReKey: Boolean;
 begin
   FForEncryption := AForEncryption;
 
@@ -341,9 +357,15 @@ begin
 
   FInitialAssociatedText := AAad;
 
-  LSameKey := SameKeyReuseRaw(AKey);
-  if (AKey = nil) and (not LSameKey) then
-    raise EArgumentCryptoLibException.CreateRes(@SKeyMustBeSpecified);
+  if AKey <> nil then
+    LNeedReKey := NeedsReKeyRaw(AKey)
+  else
+  begin
+    // nil key reuses the established key; there must be one.
+    if not FKeyReady then
+      raise EArgumentCryptoLibException.CreateRes(@SKeyMustBeSpecified);
+    LNeedReKey := False;
+  end;
 
   FMacSize := ValidateAeadMacSizeBits(AMacSizeBits, 32, FBlockSize * 8, 8);
 
@@ -356,7 +378,7 @@ begin
 
   // Key schedule / CMAC subkeys depend only on the key: re-key the CMAC on an
   // actual rekey, otherwise just clear its running state.
-  if not LSameKey then
+  if LNeedReKey then
     FMac.Init(TKeyParameter.Create(AKey) as IKeyParameter)
   else
     FMac.Reset();
@@ -377,14 +399,25 @@ begin
       TCipherKernelDirection.Decrypt, FEaxKernel);
   FUseFusedBody := FEaxKernel <> nil;
 
+  // A rekey invalidates the OMAC subkeys; wipe and drop them so they cannot
+  // survive stale even if this init runs the scalar path (no fused body).
+  if LNeedReKey then
+  begin
+    TArrayUtilities.Fill(FOmacB, 0, System.Length(FOmacB), Byte(0));
+    FOmacB := nil;
+  end;
   if FUseFusedBody then
   begin
     System.SetLength(FOmacState, FBlockSize);
     System.SetLength(FOmacLookahead, FBlockSize);
     System.SetLength(FCtrBlock, FBlockSize);
-    if (not LSameKey) or (FOmacB = nil) then
+    if FOmacB = nil then
       DeriveOmacSubkeys();
   end;
+
+  // All key-dependent schedules are rebuilt; mark the key committed and ready.
+  if LNeedReKey then
+    CommitKeyRaw(AKey);
 
   Reset(True);
 end;

--- a/CryptoLib/src/Crypto/Modes/ClpGcmBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpGcmBlockCipher.pas
@@ -465,6 +465,11 @@ begin
   // Zeroize any prior key-derived material before this rekey overwrites it.
   WipeKeyMaterial();
 
+  // Mark not-keyed before the (destructive) rekey: if FCipher.Init throws, the
+  // mode is left in a clean "needs re-Init" state (FHashSubKey = nil) instead of
+  // with a wiped H that a later same-key Init would mistake for a ready schedule.
+  FHashSubKey := nil;
+
   FCipher.Init(True, AKeyParam as ICipherParameters);
 
   TBlockCipherBulkUtilities.TryResolveBulkCipher(FCipher, FBulkCipher);
@@ -472,7 +477,6 @@ begin
   FGcmKernel := nil;
   FGcmKernelMinBlocks := 0;
 
-  FHashSubKey := nil;
   System.SetLength(FHashSubKey, BlockSize);
   FCipher.ProcessBlock(FHashSubKey, 0, FHashSubKey, 0);
 
@@ -598,15 +602,19 @@ begin
 
   // Same-key fast path: the key schedule, hash subkey, multiplier state,
   // H-power table and fused kernel all depend only on the key, so a re-Init
-  // with the same key (fresh nonce per message) keeps them all -- and, on the
-  // same-key path, SameKeyReuse leaves FLastKey intact (no per-message copy).
-  // A nil key parameter is the bc-csharp "reuse last key" convention.
+  // with the same key (fresh nonce per message) keeps them all. A nil key
+  // parameter is the "reuse last key" convention.
   if LKeyParam <> nil then
   begin
-    if not SameKeyReuse(LKeyParam) then
+    // Re-key only when the key changed or the mode is not ready (e.g. a prior
+    // rekey threw); commit the key as the final step of a successful rebuild.
+    if NeedsReKey(LKeyParam) then
+    begin
       InitCipherAndHashSubKey(LKeyParam);
+      CommitKey(LKeyParam);
+    end;
   end
-  else if FHashSubKey = nil then
+  else if not FKeyReady then
   begin
     raise EArgumentCryptoLibException.CreateRes(@SKeyMustBeSpecified);
   end;
@@ -656,10 +664,13 @@ begin
   // a fresh TKeyParameter is created only on an actual rekey. nil = reuse key.
   if AKey <> nil then
   begin
-    if not SameKeyReuseRaw(AKey) then
+    if NeedsReKeyRaw(AKey) then
+    begin
       InitCipherAndHashSubKey(TKeyParameter.Create(AKey) as IKeyParameter);
+      CommitKeyRaw(AKey);
+    end;
   end
-  else if FHashSubKey = nil then
+  else if not FKeyReady then
   begin
     raise EArgumentCryptoLibException.CreateRes(@SKeyMustBeSpecified);
   end;

--- a/CryptoLib/src/Crypto/Modes/ClpOcbBlockCipher.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpOcbBlockCipher.pas
@@ -276,8 +276,7 @@ var
   LBottom, LBits, LBytes, LI: Int32;
   LB1, LB2: UInt32;
   LFusedDirection: TCipherKernelDirection;
-  LPrevKey: TCryptoLibByteArray;
-  LSameKey, LSameKeyDir: Boolean;
+  LSameKey, LSameKeyDir, LNeedReKey: Boolean;
 begin
   LOldForEncryption := FForEncryption;
   FForEncryption := AForEncryption;
@@ -293,10 +292,7 @@ begin
 
   LN := LChoice.Nonce;
   CheckNonceReuse(FForEncryption, LN, LChoice.KeyParameter);
-  LPrevKey := FLastKey;
   FLastNonce := System.Copy(LN);
-  if LChoice.KeyParameter <> nil then
-    FLastKey := LChoice.KeyParameter.GetKey();
 
   FInitialAssociatedText := LChoice.AssociatedText;
   LKeyParameter := LChoice.KeyParameter;
@@ -304,8 +300,16 @@ begin
   // Nonce-only rotation is the hot AEAD path: when the key (and, for the main
   // cipher / fused kernel, the direction) is unchanged, the key schedules, the
   // L table and the kernel binding all stay valid and are not recomputed.
-  LSameKey := (LKeyParameter = nil) or
-    ((LPrevKey <> nil) and LKeyParameter.FixedTimeEquals(LPrevKey));
+  if LKeyParameter <> nil then
+    LNeedReKey := NeedsReKey(LKeyParameter)
+  else
+  begin
+    // nil key reuses the established key; there must be one.
+    if not FKeyReady then
+      raise EArgumentCryptoLibException.CreateRes(@SKeyMustBeSpecified);
+    LNeedReKey := False;
+  end;
+  LSameKey := not LNeedReKey;
   LSameKeyDir := LSameKey and (LOldForEncryption = AForEncryption);
 
   if LChoice.IsAead then
@@ -391,6 +395,10 @@ begin
     FLTableFlatCount := 0; // FL rebuilt for the new key; drop the flattened cache
   end;
 
+  // All key-dependent schedules are rebuilt; mark the key committed and ready.
+  if LNeedReKey then
+    CommitKey(LKeyParameter);
+
   LBottom := ProcessNonce(LN);
 
   LBits := LBottom mod 8;
@@ -433,7 +441,7 @@ end;
 procedure TOcbBlockCipher.InitPacket(AForEncryption: Boolean;
   const AKey, ANonce, AAad: TCryptoLibByteArray; AMacSizeBits: Int32);
 var
-  LOldForEncryption, LSameKey, LSameKeyDir: Boolean;
+  LOldForEncryption, LSameKey, LSameKeyDir, LNeedReKey: Boolean;
   LKeyParam: IKeyParameter;
   LMainLen, LBottom, LBits, LBytes, LI: Int32;
   LB1, LB2: UInt32;
@@ -451,11 +459,17 @@ begin
 
   FInitialAssociatedText := AAad;
 
-  LSameKey := SameKeyReuseRaw(AKey);
+  if AKey <> nil then
+    LNeedReKey := NeedsReKeyRaw(AKey)
+  else
+  begin
+    // nil key reuses the established key; there must be one.
+    if not FKeyReady then
+      raise EArgumentCryptoLibException.CreateRes(@SKeyMustBeSpecified);
+    LNeedReKey := False;
+  end;
+  LSameKey := not LNeedReKey;
   LSameKeyDir := LSameKey and (LOldForEncryption = AForEncryption);
-
-  if (AKey = nil) and (not LSameKey) then
-    raise EArgumentCryptoLibException.CreateRes(@SKeyMustBeSpecified);
 
   FMacSize := ValidateAeadMacSizeBits(AMacSizeBits, 64, 128, 8);
 
@@ -526,6 +540,10 @@ begin
     FL.Add(OCB_double(FL_Dollar));
     FLTableFlatCount := 0;
   end;
+
+  // All key-dependent schedules are rebuilt; mark the key committed and ready.
+  if LNeedReKey then
+    CommitKeyRaw(AKey);
 
   LBottom := ProcessNonce(ANonce);
 

--- a/CryptoLib/src/Crypto/Modes/ClpXChaCha20Poly1305.pas
+++ b/CryptoLib/src/Crypto/Modes/ClpXChaCha20Poly1305.pas
@@ -49,9 +49,6 @@ type
 
   strict protected
     function GetAlgorithmName: String; override;
-    // XChaCha derives a fresh per-nonce subkey via HChaCha20, so a nonce-only
-    // change is still a full re-key; the engine rejects nil-key re-init.
-    function EngineSupportsKeyReuse: Boolean; override;
 
   public
     constructor Create(); overload;
@@ -75,11 +72,6 @@ end;
 function TXChaCha20Poly1305.GetAlgorithmName: String;
 begin
   Result := 'XChaCha20Poly1305';
-end;
-
-function TXChaCha20Poly1305.EngineSupportsKeyReuse: Boolean;
-begin
-  Result := False;
 end;
 
 end.


### PR DESCRIPTION
Replace the duplicated SameKeyReuse/SameKeyReuseRaw wrappers with a single two-phase protocol on TAbstractAeadCipher, adopted by every AEAD mode:

  - FKeyReady: true only while FLastKey describes a fully-applied key
  - NeedsReKey/NeedsReKeyRaw: clear FKeyReady before a destructive rebuild
  - CommitKey/CommitKeyRaw: wipe the old key copy, store the new one, and mark ready -- called as the last step of a successful rebuild
  - IsSameKey/IsSameKeyRaw: pure constant-time comparison

This fixes two latent issues shared by the modes:

  - A rebuild that throws mid-init no longer leaves the mode reusing a half-built or zeroed schedule; FKeyReady stays false so a following nil-key reuse rebuilds or raises instead of running on corrupt state.
  - Per-message key copies are wiped before being overwritten.

Migrate GCM, OCB, CCM, and EAX (streaming Init and one-shot InitPacket); simplify ChaCha20/XChaCha20-Poly1305; GCM-SIV keeps its per-nonce re-derivation and opts out. EAX also drops its OMAC subkeys (wiped) on every rekey so they cannot survive stale.

Extend the AEAD differential tests with a nil-key-reuse leg and a failed-rekey defense leg across GCM/CCM/EAX/OCB.