### PR TITLE
Add X.509/PKIX path-builder, unsigned-certificate and EKU updates

### DIFF
--- a/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.Mobile.dpr
+++ b/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.Mobile.dpr
@@ -1092,6 +1092,7 @@ uses
   PkixNameConstraintTests in '..\src\Pkix\PkixNameConstraintTests.pas',
   PkixComparerTests in '..\src\Pkix\PkixComparerTests.pas',
   CertPathTests in '..\src\Pkix\CertPathTests.pas',
+  CertPathBuilderTests in '..\src\Pkix\CertPathBuilderTests.pas',
   CertPathValidatorTests in '..\src\Pkix\CertPathValidatorTests.pas',
   PkixPolicyMappingTests in '..\src\Pkix\PkixPolicyMappingTests.pas',
   OcspTests in '..\src\Ocsp\OcspTests.pas',

--- a/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.Mobile.dproj
+++ b/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.Mobile.dproj
@@ -1429,6 +1429,7 @@
         <DCCReference Include="..\src\Pkix\PkixNameConstraintTests.pas"/>
         <DCCReference Include="..\src\Pkix\PkixComparerTests.pas"/>
         <DCCReference Include="..\src\Pkix\CertPathTests.pas"/>
+        <DCCReference Include="..\src\Pkix\CertPathBuilderTests.pas"/>
         <DCCReference Include="..\src\Pkix\CertPathValidatorTests.pas"/>
         <DCCReference Include="..\src\Pkix\PkixPolicyMappingTests.pas"/>
         <DCCReference Include="..\src\Ocsp\OcspTests.pas"/>

--- a/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.dpr
+++ b/CryptoLib.Tests/Delphi.Tests/CryptoLib.Tests.dpr
@@ -1113,6 +1113,7 @@ uses
   PkixNameConstraintTests in '..\src\Pkix\PkixNameConstraintTests.pas',
   PkixComparerTests in '..\src\Pkix\PkixComparerTests.pas',
   CertPathTests in '..\src\Pkix\CertPathTests.pas',
+  CertPathBuilderTests in '..\src\Pkix\CertPathBuilderTests.pas',
   CertPathValidatorTests in '..\src\Pkix\CertPathValidatorTests.pas',
   PkixPolicyMappingTests in '..\src\Pkix\PkixPolicyMappingTests.pas',
   OcspTests in '..\src\Ocsp\OcspTests.pas',

--- a/CryptoLib.Tests/FreePascal.Tests/CryptoLib.Tests.lpi
+++ b/CryptoLib.Tests/FreePascal.Tests/CryptoLib.Tests.lpi
@@ -79,7 +79,7 @@
         <PackageName Value="FCL"/>
       </Item4>
     </RequiredPackages>
-    <Units Count="215">
+    <Units Count="216">
       <Unit0>
         <Filename Value="CryptoLib.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -941,6 +941,10 @@
         <Filename Value="..\src\Crypto\ChaCha20Poly1305KernelDiffTests.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit214>
+      <Unit215>
+        <Filename Value="..\src\Pkix\CertPathBuilderTests.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit215>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/CryptoLib.Tests/FreePascal.Tests/CryptoLib.lpr
+++ b/CryptoLib.Tests/FreePascal.Tests/CryptoLib.lpr
@@ -45,7 +45,7 @@ uses
   MlKemTests, MlDsaTests, PqcPkcsTests, SlhDsaTests, Lib25519Tests,
   Asn1CipherBuilderWithKeyTests, AesBitSlicedTests, ECDHPrimeConstantTimeTests,
   ECDHBinaryConstantTimeTests, CryptoLibTestBase, PkixFoundationTests,
-  PkixNameConstraintTests, PkixComparerTests, CertPathTests,
+  PkixNameConstraintTests, PkixComparerTests, CertPathTests, CertPathBuilderTests,
   CertPathValidatorTests, PkixPolicyMappingTests, OcspTests,
   CryptoLibHashSetTests, PkitsTestBase, NistCertPathTests, AttrCertPathTests,
   CtrDrbgTests, DrbgTestSupport, HashDrbgTests, HMacDrbgTests,

--- a/CryptoLib.Tests/FreePascal.Tests/CryptoLibConsole.lpi
+++ b/CryptoLib.Tests/FreePascal.Tests/CryptoLibConsole.lpi
@@ -39,7 +39,7 @@
         <PackageName Value="FCL"/>
       </Item2>
     </RequiredPackages>
-    <Units Count="215">
+    <Units Count="216">
       <Unit0>
         <Filename Value="CryptoLibConsole.lpr"/>
         <IsPartOfProject Value="True"/>
@@ -900,6 +900,10 @@
         <Filename Value="..\src\Crypto\ChaCha20Poly1305KernelDiffTests.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit214>
+      <Unit215>
+        <Filename Value="..\src\Pkix\CertPathBuilderTests.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit215>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/CryptoLib.Tests/FreePascal.Tests/CryptoLibConsole.lpr
+++ b/CryptoLib.Tests/FreePascal.Tests/CryptoLibConsole.lpr
@@ -46,7 +46,7 @@ uses
   MlKemTests, MlDsaTests, SlhDsaTests, PqcTestSampler, PqcPkcsTests,
   Lib25519Tests, Asn1CipherBuilderWithKeyTests, AesBitSlicedTests,
   CryptoLibTestBase, PkixFoundationTests, PkixNameConstraintTests,
-  PkixComparerTests, CertPathTests, CertPathValidatorTests,
+  PkixComparerTests, CertPathTests, CertPathBuilderTests, CertPathValidatorTests,
   PkixPolicyMappingTests, OcspTests, CryptoLibHashSetTests, PkitsTestBase,
   NistCertPathTests, AttrCertPathTests, CtrDrbgTests, DrbgTestSupport,
   HashDrbgTests, HMacDrbgTests, SimdSelectSlotTests, BinaryPrimitivesTests,

--- a/CryptoLib.Tests/src/Asn1/X509/KeyPurposeIDTests.pas
+++ b/CryptoLib.Tests/src/Asn1/X509/KeyPurposeIDTests.pas
@@ -67,12 +67,22 @@ end;
 
 procedure TKeyPurposeIDTest.TestKeyPurposeIDs;
 begin
+  CheckKeyPurposeID(TKeyPurposeId.IdKpSecureShellClient, '1.3.6.1.5.5.7.3.21');
+  CheckKeyPurposeID(TKeyPurposeId.IdKpSecureShellServer, '1.3.6.1.5.5.7.3.22');
+  CheckKeyPurposeID(TKeyPurposeId.IdKpCmcArchive, '1.3.6.1.5.5.7.3.29');
+  CheckKeyPurposeID(TKeyPurposeId.IdKpBundleSecurity, '1.3.6.1.5.5.7.3.35');
   CheckKeyPurposeID(TKeyPurposeId.IdKpDocumentSigning, '1.3.6.1.5.5.7.3.36');
+  CheckKeyPurposeID(TKeyPurposeId.IdKpJwt, '1.3.6.1.5.5.7.3.37');
+  CheckKeyPurposeID(TKeyPurposeId.IdKpHttpContentEncrypt, '1.3.6.1.5.5.7.3.38');
+  CheckKeyPurposeID(TKeyPurposeId.IdKpOauthAccessTokenSigning, '1.3.6.1.5.5.7.3.39');
   CheckKeyPurposeID(TKeyPurposeId.IdKpImUri, '1.3.6.1.5.5.7.3.40');
   CheckKeyPurposeID(TKeyPurposeId.IdKpConfigSigning, '1.3.6.1.5.5.7.3.41');
   CheckKeyPurposeID(TKeyPurposeId.IdKpTrustAnchorConfigSigning, '1.3.6.1.5.5.7.3.42');
   CheckKeyPurposeID(TKeyPurposeId.IdKpUpdatePackageSigning, '1.3.6.1.5.5.7.3.43');
   CheckKeyPurposeID(TKeyPurposeId.IdKpSafetyCommunication, '1.3.6.1.5.5.7.3.44');
+  // Kerberos PKINIT: id-pkinit arc rather than id-kp
+  CheckKeyPurposeID(TKeyPurposeId.IdKpPkinitClientAuth, '1.3.6.1.5.2.3.4');
+  CheckKeyPurposeID(TKeyPurposeId.IdKpPkinitKdc, '1.3.6.1.5.2.3.5');
 end;
 
 initialization

--- a/CryptoLib.Tests/src/Crypto/XChaCha20Poly1305Tests.pas
+++ b/CryptoLib.Tests/src/Crypto/XChaCha20Poly1305Tests.pas
@@ -331,8 +331,8 @@ begin
   // Regression: reusing one cipher instance with the SAME key but a fresh nonce
   // must re-derive the XChaCha subkey. A nonce-only re-Init cannot hand the
   // engine a nil key (the mode's key-reuse fast path), or XChaCha raises
-  // "doesn't support re-init with nil key". This is the throughput-benchmark
-  // pattern (one cipher, many messages, same key, incrementing nonce).
+  // "doesn't support re-init with nil key".
+  // (one cipher, many messages, same key, incrementing nonce).
   System.SetLength(LKey, 32);
   System.SetLength(LNonce1, 24);
   System.SetLength(LNonce2, 24);

--- a/CryptoLib.Tests/src/Pkix/CertPathBuilderTests.pas
+++ b/CryptoLib.Tests/src/Pkix/CertPathBuilderTests.pas
@@ -1,0 +1,322 @@
+{ *********************************************************************************** }
+{ *                              CryptoLib Library                                  * }
+{ *                           Author - Ugochukwu Mmaduekwe                          * }
+{ *                 Github Repository <https://github.com/Xor-el>                   * }
+{ *                                                                                 * }
+{ *  Distributed under the MIT software license, see the accompanying file LICENSE  * }
+{ *          or visit http://www.opensource.org/licenses/mit-license.php.           * }
+{ *                                                                                 * }
+{ *                              Acknowledgements:                                  * }
+{ *                                                                                 * }
+{ *      Thanks to Sphere 10 Software (http://www.sphere10.com/) for sponsoring     * }
+{ *                         the development of this library                         * }
+{ * ******************************************************************************* * }
+
+(* &&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&& *)
+
+unit CertPathBuilderTests;
+
+interface
+
+{$IFDEF FPC}
+{$MODE DELPHI}
+{$ENDIF FPC}
+
+uses
+  SysUtils,
+  DateUtils,
+{$IFDEF FPC}
+  fpcunit,
+  testregistry,
+{$ELSE}
+  TestFramework,
+{$ENDIF FPC}
+  ClpDateTimeHelper,
+  ClpIStore,
+  ClpCollectionStore,
+  ClpIX509StoreSelectors,
+  ClpX509StoreSelectors,
+  ClpIPkixTypes,
+  ClpTrustAnchor,
+  ClpPkixBuilderParameters,
+  ClpPkixCertPathBuilder,
+  ClpIX509Certificate,
+  ClpIX509Generators,
+  ClpX509Generators,
+  ClpIX509Asn1Objects,
+  ClpX509Asn1Objects,
+  ClpX509ObjectIdentifiers,
+  ClpBigInteger,
+  ClpIAsymmetricCipherKeyPair,
+  ClpIAsymmetricKeyParameter,
+  ClpCryptoLibConfig,
+  ClpCryptoLibTypes,
+  ClpCryptoLibExceptions,
+  CertTestUtilities,
+  CryptoLibTestBase;
+
+type
+
+  /// <summary>
+  /// PKIX path builder features: unsigned certificate generation (id-alg-unsigned), specifying the
+  /// target certificate through the selector's Certificate property, and the per-build node budget.
+  /// </summary>
+  TCertPathBuilderTest = class(TCryptoLibAlgorithmTestCase)
+  strict private
+    function AnchorsOf(const ACert: IX509Certificate): TCryptoLibGenericArray<ITrustAnchor>;
+
+  protected
+    procedure TearDown; override;
+
+  published
+    procedure TestGenerateUnsignedCertificate;
+    procedure TestBuildTargetInStore;
+    procedure TestBuildTargetViaSelector;
+    procedure TestBuildWithUnsignedTrustAnchor;
+    procedure TestNodeBudgetGuard;
+  end;
+
+implementation
+
+{ TCertPathBuilderTest }
+
+function TCertPathBuilderTest.AnchorsOf(const ACert: IX509Certificate)
+  : TCryptoLibGenericArray<ITrustAnchor>;
+begin
+  Result := TCryptoLibGenericArray<ITrustAnchor>.Create(TTrustAnchor.Create(ACert, nil) as ITrustAnchor);
+end;
+
+procedure TCertPathBuilderTest.TearDown;
+begin
+  // the node budget is a process-wide switch; restore it so a lowered value cannot leak to later tests
+  TCryptoLibConfig.X509.ResetToDefaults();
+  inherited TearDown;
+end;
+
+procedure TCertPathBuilderTest.TestGenerateUnsignedCertificate;
+var
+  LKeyPair: IAsymmetricCipherKeyPair;
+  LDn: IX509Name;
+  LUtcNow: TDateTime;
+  LV1Gen: IX509V1CertificateGenerator;
+  LV3Gen: IX509V3CertificateGenerator;
+  LCert: IX509Certificate;
+begin
+  LKeyPair := TCertTestUtilities.GenerateRsaKeyPair(1024);
+  LDn := TX509Name.Create('CN=Unsigned Certificate');
+  LUtcNow := Now.ToUniversalTime();
+
+  LV1Gen := TX509V1CertificateGenerator.Create;
+  LV1Gen.SetSerialNumber(TBigInteger.One);
+  LV1Gen.SetIssuerDN(LDn);
+  LV1Gen.SetNotBeforeUtc(IncSecond(LUtcNow, -5));
+  LV1Gen.SetNotAfterUtc(IncMinute(LUtcNow, 30));
+  LV1Gen.SetSubjectDN(LDn);
+  LV1Gen.SetPublicKey(LKeyPair.Public as IAsymmetricKeyParameter);
+  LCert := LV1Gen.GenerateUnsigned();
+
+  CheckTrue(LCert.SignatureAlgorithm.Algorithm.Equals(TX509ObjectIdentifiers.IdAlgUnsigned),
+    'the V1 unsigned certificate uses id-alg-unsigned');
+  CheckEquals(0, System.Length(LCert.GetSignature), 'the V1 unsigned certificate has an empty signature');
+
+  LV3Gen := TX509V3CertificateGenerator.Create;
+  LV3Gen.SetSerialNumber(TBigInteger.One);
+  LV3Gen.SetIssuerDN(LDn);
+  LV3Gen.SetNotBeforeUtc(IncSecond(LUtcNow, -5));
+  LV3Gen.SetNotAfterUtc(IncMinute(LUtcNow, 30));
+  LV3Gen.SetSubjectDN(LDn);
+  LV3Gen.SetPublicKey(LKeyPair.Public as IAsymmetricKeyParameter);
+  LCert := LV3Gen.GenerateUnsigned();
+
+  CheckTrue(LCert.SignatureAlgorithm.Algorithm.Equals(TX509ObjectIdentifiers.IdAlgUnsigned),
+    'the V3 unsigned certificate uses id-alg-unsigned');
+  CheckEquals(0, System.Length(LCert.GetSignature), 'the V3 unsigned certificate has an empty signature');
+end;
+
+procedure TCertPathBuilderTest.TestBuildTargetInStore;
+var
+  LRootKp, LEeKp: IAsymmetricCipherKeyPair;
+  LRoot, LEe: IX509Certificate;
+  LSelector: IX509CertStoreSelector;
+  LTarget: ISelector<IX509Certificate>;
+  LStore: IStore<IX509Certificate>;
+  LParams: IPkixBuilderParameters;
+  LBuilder: IPkixCertPathBuilder;
+  LResult: IPkixCertPathBuilderResult;
+begin
+  LRootKp := TCertTestUtilities.GenerateRsaKeyPair(1024);
+  LRoot := TCertTestUtilities.GenerateRootCert(LRootKp);
+  LEeKp := TCertTestUtilities.GenerateRsaKeyPair(1024);
+  LEe := TCertTestUtilities.GenerateEndEntityCert(LEeKp.Public as IAsymmetricKeyParameter,
+    LRootKp.Private as IAsymmetricKeyParameter, LRoot);
+
+  // target located by its subject in the store
+  LSelector := TX509CertStoreSelector.Create();
+  LSelector.Subject := LEe.SubjectDN;
+  LTarget := LSelector;
+
+  LStore := TCollectionStore<IX509Certificate>.Create(
+    TCryptoLibGenericArray<IX509Certificate>.Create(LEe));
+  LParams := TPkixBuilderParameters.Create(AnchorsOf(LRoot), LTarget) as IPkixBuilderParameters;
+  LParams.SetTargetConstraintsCert(LTarget);
+  LParams.AddStoreCert(LStore);
+  LParams.IsRevocationEnabled := False;
+
+  LBuilder := TPkixCertPathBuilder.Create() as IPkixCertPathBuilder;
+  LResult := LBuilder.Build(LParams);
+
+  CheckNotNull(LResult, 'a target found in the store yields a path');
+  CheckEquals(1, System.Length(LResult.CertPath.Certificates),
+    'the built path holds the single end-entity certificate below the trust anchor');
+end;
+
+procedure TCertPathBuilderTest.TestBuildTargetViaSelector;
+var
+  LRootKp, LEeKp: IAsymmetricCipherKeyPair;
+  LRoot, LEe: IX509Certificate;
+  LSelector: IX509CertStoreSelector;
+  LTarget: ISelector<IX509Certificate>;
+  LStore: IStore<IX509Certificate>;
+  LParams: IPkixBuilderParameters;
+  LBuilder: IPkixCertPathBuilder;
+  LResult: IPkixCertPathBuilderResult;
+begin
+  LRootKp := TCertTestUtilities.GenerateRsaKeyPair(1024);
+  LRoot := TCertTestUtilities.GenerateRootCert(LRootKp);
+  LEeKp := TCertTestUtilities.GenerateRsaKeyPair(1024);
+  LEe := TCertTestUtilities.GenerateEndEntityCert(LEeKp.Public as IAsymmetricKeyParameter,
+    LRootKp.Private as IAsymmetricKeyParameter, LRoot);
+
+  // the end-entity is NOT in the store; it is named directly on the selector instead
+  LSelector := TX509CertStoreSelector.Create();
+  LSelector.Certificate := LEe;
+  LTarget := LSelector;
+
+  LStore := TCollectionStore<IX509Certificate>.Create(
+    TCryptoLibGenericArray<IX509Certificate>.Create(LRoot));
+  LParams := TPkixBuilderParameters.Create(AnchorsOf(LRoot), LTarget) as IPkixBuilderParameters;
+  LParams.SetTargetConstraintsCert(LTarget);
+  LParams.AddStoreCert(LStore);
+  LParams.IsRevocationEnabled := False;
+
+  LBuilder := TPkixCertPathBuilder.Create() as IPkixCertPathBuilder;
+  LResult := LBuilder.Build(LParams);
+
+  CheckNotNull(LResult, 'a target specified on the selector yields a path even when absent from the stores');
+  CheckEquals(1, System.Length(LResult.CertPath.Certificates),
+    'the built path holds the single end-entity certificate below the trust anchor');
+end;
+
+procedure TCertPathBuilderTest.TestBuildWithUnsignedTrustAnchor;
+var
+  LRootKp, LEeKp: IAsymmetricCipherKeyPair;
+  LRootDn: IX509Name;
+  LUtcNow: TDateTime;
+  LRootGen: IX509V1CertificateGenerator;
+  LRoot, LEe: IX509Certificate;
+  LSelector: IX509CertStoreSelector;
+  LTarget: ISelector<IX509Certificate>;
+  LStore: IStore<IX509Certificate>;
+  LParams: IPkixBuilderParameters;
+  LBuilder: IPkixCertPathBuilder;
+  LResult: IPkixCertPathBuilderResult;
+begin
+  // an unsigned (id-alg-unsigned) self-issued root, used as the trust anchor
+  LRootKp := TCertTestUtilities.GenerateRsaKeyPair(1024);
+  LRootDn := TX509Name.Create('CN=Unsigned Root CA');
+  LUtcNow := Now.ToUniversalTime();
+
+  LRootGen := TX509V1CertificateGenerator.Create;
+  LRootGen.SetSerialNumber(TBigInteger.One);
+  LRootGen.SetIssuerDN(LRootDn);
+  LRootGen.SetNotBeforeUtc(IncSecond(LUtcNow, -5));
+  LRootGen.SetNotAfterUtc(IncMinute(LUtcNow, 30));
+  LRootGen.SetSubjectDN(LRootDn);
+  LRootGen.SetPublicKey(LRootKp.Public as IAsymmetricKeyParameter);
+  LRoot := LRootGen.GenerateUnsigned();
+
+  LEeKp := TCertTestUtilities.GenerateRsaKeyPair(1024);
+  LEe := TCertTestUtilities.GenerateEndEntityCert(LEeKp.Public as IAsymmetricKeyParameter,
+    LRootKp.Private as IAsymmetricKeyParameter, LRoot);
+
+  LSelector := TX509CertStoreSelector.Create();
+  LSelector.Subject := LEe.SubjectDN;
+  LTarget := LSelector;
+
+  LStore := TCollectionStore<IX509Certificate>.Create(
+    TCryptoLibGenericArray<IX509Certificate>.Create(LEe));
+  LParams := TPkixBuilderParameters.Create(AnchorsOf(LRoot), LTarget) as IPkixBuilderParameters;
+  LParams.SetTargetConstraintsCert(LTarget);
+  LParams.AddStoreCert(LStore);
+  LParams.IsRevocationEnabled := False;
+
+  LBuilder := TPkixCertPathBuilder.Create() as IPkixCertPathBuilder;
+  LResult := LBuilder.Build(LParams);
+
+  CheckNotNull(LResult, 'a chain anchored at an unsigned trust anchor builds and validates');
+  CheckEquals(1, System.Length(LResult.CertPath.Certificates),
+    'the built path holds the single end-entity certificate below the unsigned anchor');
+end;
+
+procedure TCertPathBuilderTest.TestNodeBudgetGuard;
+var
+  LRootKp, LInterKp, LEeKp: IAsymmetricCipherKeyPair;
+  LRoot, LInter, LEe: IX509Certificate;
+  LSelector: IX509CertStoreSelector;
+  LTarget: ISelector<IX509Certificate>;
+  LStore: IStore<IX509Certificate>;
+  LParams: IPkixBuilderParameters;
+  LBuilder: IPkixCertPathBuilder;
+  LRaised: Boolean;
+  LMessage: String;
+begin
+  LRootKp := TCertTestUtilities.GenerateRsaKeyPair(1024);
+  LRoot := TCertTestUtilities.GenerateRootCert(LRootKp);
+  LInterKp := TCertTestUtilities.GenerateRsaKeyPair(1024);
+  LInter := TCertTestUtilities.GenerateEndEntityCert(LInterKp.Public as IAsymmetricKeyParameter,
+    TX509Name.Create('CN=Intermediate') as IX509Name, LRootKp.Private as IAsymmetricKeyParameter, LRoot);
+  LEeKp := TCertTestUtilities.GenerateRsaKeyPair(1024);
+  LEe := TCertTestUtilities.GenerateEndEntityCert(LEeKp.Public as IAsymmetricKeyParameter,
+    TX509Name.Create('CN=EndEntity') as IX509Name, LInterKp.Private as IAsymmetricKeyParameter, LInter);
+
+  LSelector := TX509CertStoreSelector.Create();
+  LSelector.Subject := LEe.SubjectDN;
+  LTarget := LSelector;
+
+  LStore := TCollectionStore<IX509Certificate>.Create(
+    TCryptoLibGenericArray<IX509Certificate>.Create(LInter, LEe));
+  LParams := TPkixBuilderParameters.Create(AnchorsOf(LRoot), LTarget) as IPkixBuilderParameters;
+  LParams.SetTargetConstraintsCert(LTarget);
+  LParams.AddStoreCert(LStore);
+  LParams.IsRevocationEnabled := False;
+
+  // a budget of one is exceeded as soon as the search recurses past the target certificate
+  TCryptoLibConfig.X509.MaxCertPathBuildNodes := 1;
+
+  LRaised := False;
+  LMessage := '';
+  try
+    LBuilder := TPkixCertPathBuilder.Create() as IPkixCertPathBuilder;
+    LBuilder.Build(LParams);
+  except
+    on E: EPkixCertPathBuilderCryptoLibException do
+    begin
+      LRaised := True;
+      LMessage := E.Message;
+    end;
+  end;
+
+  CheckTrue(LRaised, 'exceeding the node budget aborts the build');
+  CheckTrue(Pos('node limit', LMessage) > 0,
+    Format('the failure names the node limit, got "%s"', [LMessage]));
+end;
+
+initialization
+
+{$IFDEF FPC}
+  RegisterTest(TCertPathBuilderTest);
+{$ELSE}
+  RegisterTest(TCertPathBuilderTest.Suite);
+{$ENDIF FPC}
+
+end.

--- a/CryptoLib/src/Asn1/ClpAsn1Streams.pas
+++ b/CryptoLib/src/Asn1/ClpAsn1Streams.pas
@@ -745,9 +745,6 @@ begin
 end;
 
 function TAsn1DefiniteLengthInputStream.ToArray: TCryptoLibByteArray;
-var
-  LBuf: TLimitedCapacityMemoryStream;
-  LThreshold: Int32;
 begin
   Result := nil;
   if FRemaining = 0 then
@@ -757,25 +754,14 @@ begin
 
   TAsn1InputStream.CheckLength(FRemaining, Limit);
 
-  LThreshold := TStreamUtilities.DefaultBufferSize * 8;
-  if FRemaining > LThreshold then
-  begin
-    LBuf := TLimitedCapacityMemoryStream.Create(FRemaining);
-    try
-      TStreamUtilities.CopyTo(Self, LBuf);
-      Result := LBuf.GetBuffer();
-    finally
-      LBuf.Free;
-    end;
+  // Read through Self so the per-read bookkeeping (FRemaining decrement, truncation raise,
+  // SetParentEofDetect) is enforced; the buffer grows incrementally rather than being sized to the
+  // claimed length up front.
+  if TStreamUtilities.TryReadExactIncremental(Self, FRemaining, Result) then
     Exit;
-  end;
 
-  System.SetLength(Result, FRemaining);
-  FRemaining := FRemaining - TStreamUtilities.ReadFully(FIn, Result, 0,
-    System.Length(Result));
-  if FRemaining <> 0 then
-    raise EEndOfStreamCryptoLibException.CreateResFmt(@SDefLengthObjectTruncated, [FOriginalLength, FRemaining]);
-  SetParentEofDetect();
+  // Unreachable in practice: an incomplete read raises inside Self.Read; kept as a guard.
+  raise EEndOfStreamCryptoLibException.CreateResFmt(@SDefLengthObjectTruncated, [FOriginalLength, FRemaining]);
 end;
 
 { TAsn1IndefiniteLengthInputStream }

--- a/CryptoLib/src/Asn1/Iana/ClpIanaObjectIdentifiers.pas
+++ b/CryptoLib/src/Asn1/Iana/ClpIanaObjectIdentifiers.pas
@@ -30,7 +30,8 @@ type
   strict private
     class var
       FInternet, FDirectory, FMgmt, FExperimental, FClsPrivate, FSecurity,
-      FSNMPv2, FMail, FSecurityMechanisms, FSecurityNametypes, FPkix, FIpsec,
+      FSNMPv2, FMail, FKerberosv5, FIdPkinit, FSecurityMechanisms,
+      FSecurityNametypes, FPkix, FIpsec,
       FIsakmpOakley, FHmacMD5, FHmacSha1, FHmacTiger, FHmacRipeMD160,
       FIdAlg, FIdRsassaPssShake128, FIdRsassaPssShake256, FIdEcdsaWithShake128,
       FIdEcdsaWithShake256, FIdAlgUnsigned: IDerObjectIdentifier;
@@ -43,6 +44,8 @@ type
     class function GetSecurity: IDerObjectIdentifier; static; inline;
     class function GetSNMPv2: IDerObjectIdentifier; static; inline;
     class function GetMail: IDerObjectIdentifier; static; inline;
+    class function GetKerberosv5: IDerObjectIdentifier; static; inline;
+    class function GetIdPkinit: IDerObjectIdentifier; static; inline;
     class function GetSecurityMechanisms: IDerObjectIdentifier; static; inline;
     class function GetSecurityNametypes: IDerObjectIdentifier; static; inline;
     class function GetPkix: IDerObjectIdentifier; static; inline;
@@ -69,6 +72,10 @@ type
     class property Security: IDerObjectIdentifier read GetSecurity;
     class property SNMPv2: IDerObjectIdentifier read GetSNMPv2;
     class property Mail: IDerObjectIdentifier read GetMail;
+    /// <summary>Kerberos V5: 1.3.6.1.5.2</summary>
+    class property Kerberosv5: IDerObjectIdentifier read GetKerberosv5;
+    /// <summary>PKINIT, RFC 4556 sec. 3.2.2: 1.3.6.1.5.2.3</summary>
+    class property IdPkinit: IDerObjectIdentifier read GetIdPkinit;
     class property SecurityMechanisms: IDerObjectIdentifier read GetSecurityMechanisms;
     class property SecurityNametypes: IDerObjectIdentifier read GetSecurityNametypes;
     class property Pkix: IDerObjectIdentifier read GetPkix;
@@ -106,6 +113,8 @@ begin
   FSecurity := FInternet.Branch('5');
   FSNMPv2 := FInternet.Branch('6');
   FMail := FInternet.Branch('7');
+  FKerberosv5 := FSecurity.Branch('2');
+  FIdPkinit := FKerberosv5.Branch('3');
   FSecurityMechanisms := FSecurity.Branch('5');
   FSecurityNametypes := FSecurity.Branch('6');
   FPkix := FSecurityMechanisms.Branch('7');
@@ -206,6 +215,16 @@ end;
 class function TIanaObjectIdentifiers.GetMail: IDerObjectIdentifier;
 begin
   Result := FMail;
+end;
+
+class function TIanaObjectIdentifiers.GetKerberosv5: IDerObjectIdentifier;
+begin
+  Result := FKerberosv5;
+end;
+
+class function TIanaObjectIdentifiers.GetIdPkinit: IDerObjectIdentifier;
+begin
+  Result := FIdPkinit;
 end;
 
 class function TIanaObjectIdentifiers.GetMgmt: IDerObjectIdentifier;

--- a/CryptoLib/src/Asn1/X509/ClpX509Asn1Objects.pas
+++ b/CryptoLib/src/Asn1/X509/ClpX509Asn1Objects.pas
@@ -38,6 +38,7 @@ uses
   ClpIX509NameTokenizer,
   ClpX509NameTokenizer,
   ClpX509ObjectIdentifiers,
+  ClpIanaObjectIdentifiers,
   ClpPkcsObjectIdentifiers,
   ClpBigInteger,
   ClpCryptoLibConfig,
@@ -1034,10 +1035,17 @@ type
     FIdKpIpsecIke: IDerObjectIdentifier;
     FIdKpCapwapAc: IDerObjectIdentifier;
     FIdKpCapwapWtp: IDerObjectIdentifier;
+    FIdKpSecureShellClient: IDerObjectIdentifier;
+    FIdKpSecureShellServer: IDerObjectIdentifier;
     FIdKpCmcCa: IDerObjectIdentifier;
     FIdKpCmcRa: IDerObjectIdentifier;
+    FIdKpCmcArchive: IDerObjectIdentifier;
     FIdKpCmKga: IDerObjectIdentifier;
+    FIdKpBundleSecurity: IDerObjectIdentifier;
     FIdKpDocumentSigning: IDerObjectIdentifier;
+    FIdKpJwt: IDerObjectIdentifier;
+    FIdKpHttpContentEncrypt: IDerObjectIdentifier;
+    FIdKpOauthAccessTokenSigning: IDerObjectIdentifier;
     FIdKpImUri: IDerObjectIdentifier;
     FIdKpConfigSigning: IDerObjectIdentifier;
     FIdKpTrustAnchorConfigSigning: IDerObjectIdentifier;
@@ -1050,8 +1058,8 @@ type
     FIdPkinitAuthData: IDerObjectIdentifier;
     FIdPkinitDHKeyData: IDerObjectIdentifier;
     FIdPkinitRkeyData: IDerObjectIdentifier;
-    FKeyPurposeClientAuth: IDerObjectIdentifier;
-    FKeyPurposeKdc: IDerObjectIdentifier;
+    FIdKpPkinitClientAuth: IDerObjectIdentifier;
+    FIdKpPkinitKdc: IDerObjectIdentifier;
     FIdKpNsSgc: IDerObjectIdentifier;
 
     class function GetAnyExtendedKeyUsage: IDerObjectIdentifier; static; inline;
@@ -1074,10 +1082,17 @@ type
     class function GetIdKpIpsecIke: IDerObjectIdentifier; static; inline;
     class function GetIdKpCapwapAc: IDerObjectIdentifier; static; inline;
     class function GetIdKpCapwapWtp: IDerObjectIdentifier; static; inline;
+    class function GetIdKpSecureShellClient: IDerObjectIdentifier; static; inline;
+    class function GetIdKpSecureShellServer: IDerObjectIdentifier; static; inline;
     class function GetIdKpCmcCa: IDerObjectIdentifier; static; inline;
     class function GetIdKpCmcRa: IDerObjectIdentifier; static; inline;
+    class function GetIdKpCmcArchive: IDerObjectIdentifier; static; inline;
     class function GetIdKpCmKga: IDerObjectIdentifier; static; inline;
+    class function GetIdKpBundleSecurity: IDerObjectIdentifier; static; inline;
     class function GetIdKpDocumentSigning: IDerObjectIdentifier; static; inline;
+    class function GetIdKpJwt: IDerObjectIdentifier; static; inline;
+    class function GetIdKpHttpContentEncrypt: IDerObjectIdentifier; static; inline;
+    class function GetIdKpOauthAccessTokenSigning: IDerObjectIdentifier; static; inline;
     class function GetIdKpImUri: IDerObjectIdentifier; static; inline;
     class function GetIdKpConfigSigning: IDerObjectIdentifier; static; inline;
     class function GetIdKpTrustAnchorConfigSigning: IDerObjectIdentifier; static; inline;
@@ -1090,8 +1105,8 @@ type
     class function GetIdPkinitAuthData: IDerObjectIdentifier; static; inline;
     class function GetIdPkinitDHKeyData: IDerObjectIdentifier; static; inline;
     class function GetIdPkinitRkeyData: IDerObjectIdentifier; static; inline;
-    class function GetKeyPurposeClientAuth: IDerObjectIdentifier; static; inline;
-    class function GetKeyPurposeKdc: IDerObjectIdentifier; static; inline;
+    class function GetIdKpPkinitClientAuth: IDerObjectIdentifier; static; inline;
+    class function GetIdKpPkinitKdc: IDerObjectIdentifier; static; inline;
     class function GetIdKpNsSgc: IDerObjectIdentifier; static; inline;
     class constructor Create;
 
@@ -1116,11 +1131,25 @@ type
     class property IdKpIpsecIke: IDerObjectIdentifier read GetIdKpIpsecIke;
     class property IdKpCapwapAc: IDerObjectIdentifier read GetIdKpCapwapAc;
     class property IdKpCapwapWtp: IDerObjectIdentifier read GetIdKpCapwapWtp;
+    /// <summary>RFC 6187 - SSH client authentication (<c>id-kp-secureShellClient</c>, <c>{ id-kp 21 }</c>).</summary>
+    class property IdKpSecureShellClient: IDerObjectIdentifier read GetIdKpSecureShellClient;
+    /// <summary>RFC 6187 - SSH server authentication (<c>id-kp-secureShellServer</c>, <c>{ id-kp 22 }</c>).</summary>
+    class property IdKpSecureShellServer: IDerObjectIdentifier read GetIdKpSecureShellServer;
     class property IdKpCmcCa: IDerObjectIdentifier read GetIdKpCmcCa;
     class property IdKpCmcRa: IDerObjectIdentifier read GetIdKpCmcRa;
+    /// <summary><c>id-kp-cmcArchive</c>, <c>{ id-kp 29 }</c>.</summary>
+    class property IdKpCmcArchive: IDerObjectIdentifier read GetIdKpCmcArchive;
     class property IdKpCmKga: IDerObjectIdentifier read GetIdKpCmKga;
+    /// <summary>RFC 9174 sec. 4.4.1 - Delay-Tolerant Networking bundle security, TCPCLv4 (<c>id-kp-bundleSecurity</c>, <c>{ id-kp 35 }</c>).</summary>
+    class property IdKpBundleSecurity: IDerObjectIdentifier read GetIdKpBundleSecurity;
     /// <summary>RFC 9336 sec. 3.1 ? signing documents (e.g. PDF, XML, JSON) for human consumption (<c>id-kp-documentSigning</c>, <c>{ id-kp 36 }</c>).</summary>
     class property IdKpDocumentSigning: IDerObjectIdentifier read GetIdKpDocumentSigning;
+    /// <summary>RFC 9509 sec. 3 - signing the JWT Claims Set of a 5G Client Credentials Assertion using JWS (<c>id-kp-jwt</c>, <c>{ id-kp 37 }</c>).</summary>
+    class property IdKpJwt: IDerObjectIdentifier read GetIdKpJwt;
+    /// <summary>RFC 9509 sec. 3 - encrypting JSON objects in HTTP messages between 5G SEPPs using JWE (<c>id-kp-httpContentEncrypt</c>, <c>{ id-kp 38 }</c>).</summary>
+    class property IdKpHttpContentEncrypt: IDerObjectIdentifier read GetIdKpHttpContentEncrypt;
+    /// <summary>RFC 9509 sec. 3 - signing OAuth 2.0 access tokens using JWS, as issued by a 5G NRF (<c>id-kp-oauthAccessTokenSigning</c>, <c>{ id-kp 39 }</c>).</summary>
+    class property IdKpOauthAccessTokenSigning: IDerObjectIdentifier read GetIdKpOauthAccessTokenSigning;
     /// <summary>RFC 9734 sec. 3 ? proving the identity of an IM client whose IM URI (RFC 3860) or XMPP URI (RFC 6121) appears in the subjectAltName (<c>id-kp-imUri</c>, <c>{ id-kp 40 }</c>).</summary>
     class property IdKpImUri: IDerObjectIdentifier read GetIdKpImUri;
     /// <summary>RFC 9809 sec. 3 ? signing general-purpose configuration files (<c>id-kp-configSigning</c>, <c>{ id-kp 41 }</c>).</summary>
@@ -1138,8 +1167,10 @@ type
     class property IdPkinitAuthData: IDerObjectIdentifier read GetIdPkinitAuthData;
     class property IdPkinitDHKeyData: IDerObjectIdentifier read GetIdPkinitDHKeyData;
     class property IdPkinitRkeyData: IDerObjectIdentifier read GetIdPkinitRkeyData;
-    class property KeyPurposeClientAuth: IDerObjectIdentifier read GetKeyPurposeClientAuth;
-    class property KeyPurposeKdc: IDerObjectIdentifier read GetKeyPurposeKdc;
+    /// <summary>Kerberos PKINIT client authentication (<c>id-pkinit-KPClientAuth</c>).</summary>
+    class property IdKpPkinitClientAuth: IDerObjectIdentifier read GetIdKpPkinitClientAuth;
+    /// <summary>Kerberos PKINIT KDC authentication (<c>id-pkinit-KPKdc</c>).</summary>
+    class property IdKpPkinitKdc: IDerObjectIdentifier read GetIdKpPkinitKdc;
     class property IdKpNsSgc: IDerObjectIdentifier read GetIdKpNsSgc;
 
   end;
@@ -6945,10 +6976,17 @@ begin
   FIdKpIpsecIke := TDerObjectIdentifier.Create(LIdKp.ID + '.17');
   FIdKpCapwapAc := TDerObjectIdentifier.Create(LIdKp.ID + '.18');
   FIdKpCapwapWtp := TDerObjectIdentifier.Create(LIdKp.ID + '.19');
+  FIdKpSecureShellClient := TDerObjectIdentifier.Create(LIdKp.ID + '.21');
+  FIdKpSecureShellServer := TDerObjectIdentifier.Create(LIdKp.ID + '.22');
   FIdKpCmcCa := TDerObjectIdentifier.Create(LIdKp.ID + '.27');
   FIdKpCmcRa := TDerObjectIdentifier.Create(LIdKp.ID + '.28');
+  FIdKpCmcArchive := TDerObjectIdentifier.Create(LIdKp.ID + '.29');
   FIdKpCmKga := TDerObjectIdentifier.Create(LIdKp.ID + '.32');
+  FIdKpBundleSecurity := TDerObjectIdentifier.Create(LIdKp.ID + '.35');
   FIdKpDocumentSigning := TDerObjectIdentifier.Create(LIdKp.ID + '.36');
+  FIdKpJwt := TDerObjectIdentifier.Create(LIdKp.ID + '.37');
+  FIdKpHttpContentEncrypt := TDerObjectIdentifier.Create(LIdKp.ID + '.38');
+  FIdKpOauthAccessTokenSigning := TDerObjectIdentifier.Create(LIdKp.ID + '.39');
   FIdKpImUri := TDerObjectIdentifier.Create(LIdKp.ID + '.40');
   FIdKpConfigSigning := TDerObjectIdentifier.Create(LIdKp.ID + '.41');
   FIdKpTrustAnchorConfigSigning := TDerObjectIdentifier.Create(LIdKp.ID + '.42');
@@ -6957,13 +6995,13 @@ begin
   FIdKpSmartcardlogon := TDerObjectIdentifier.Create('1.3.6.1.4.1.311.20.2.2');
   FIdKpMacAddress := TDerObjectIdentifier.Create('1.3.6.1.1.1.1.22');
   FIdKpMsSgc := TDerObjectIdentifier.Create('1.3.6.1.4.1.311.10.3.3');
-  LIdPkinit := '1.3.6.1.5.2.3';
+  LIdPkinit := TIanaObjectIdentifiers.IdPkinit.ID;
   FScSysNodeNumber := TDerObjectIdentifier.Create(LIdPkinit + '.0');
   FIdPkinitAuthData := TDerObjectIdentifier.Create(LIdPkinit + '.1');
   FIdPkinitDHKeyData := TDerObjectIdentifier.Create(LIdPkinit + '.2');
   FIdPkinitRkeyData := TDerObjectIdentifier.Create(LIdPkinit + '.3');
-  FKeyPurposeClientAuth := TDerObjectIdentifier.Create(LIdPkinit + '.4');
-  FKeyPurposeKdc := TDerObjectIdentifier.Create(LIdPkinit + '.5');
+  FIdKpPkinitClientAuth := TDerObjectIdentifier.Create(LIdPkinit + '.4');
+  FIdKpPkinitKdc := TDerObjectIdentifier.Create(LIdPkinit + '.5');
   FIdKpNsSgc := TDerObjectIdentifier.Create('2.16.840.1.113730.4.1');
 end;
 
@@ -7067,6 +7105,16 @@ begin
   Result := FIdKpCapwapWtp;
 end;
 
+class function TKeyPurposeId.GetIdKpSecureShellClient: IDerObjectIdentifier;
+begin
+  Result := FIdKpSecureShellClient;
+end;
+
+class function TKeyPurposeId.GetIdKpSecureShellServer: IDerObjectIdentifier;
+begin
+  Result := FIdKpSecureShellServer;
+end;
+
 class function TKeyPurposeId.GetIdKpCmcCa: IDerObjectIdentifier;
 begin
   Result := FIdKpCmcCa;
@@ -7077,14 +7125,39 @@ begin
   Result := FIdKpCmcRa;
 end;
 
+class function TKeyPurposeId.GetIdKpCmcArchive: IDerObjectIdentifier;
+begin
+  Result := FIdKpCmcArchive;
+end;
+
 class function TKeyPurposeId.GetIdKpCmKga: IDerObjectIdentifier;
 begin
   Result := FIdKpCmKga;
 end;
 
+class function TKeyPurposeId.GetIdKpBundleSecurity: IDerObjectIdentifier;
+begin
+  Result := FIdKpBundleSecurity;
+end;
+
 class function TKeyPurposeId.GetIdKpDocumentSigning: IDerObjectIdentifier;
 begin
   Result := FIdKpDocumentSigning;
+end;
+
+class function TKeyPurposeId.GetIdKpJwt: IDerObjectIdentifier;
+begin
+  Result := FIdKpJwt;
+end;
+
+class function TKeyPurposeId.GetIdKpHttpContentEncrypt: IDerObjectIdentifier;
+begin
+  Result := FIdKpHttpContentEncrypt;
+end;
+
+class function TKeyPurposeId.GetIdKpOauthAccessTokenSigning: IDerObjectIdentifier;
+begin
+  Result := FIdKpOauthAccessTokenSigning;
 end;
 
 class function TKeyPurposeId.GetIdKpImUri: IDerObjectIdentifier;
@@ -7147,14 +7220,14 @@ begin
   Result := FIdPkinitRkeyData;
 end;
 
-class function TKeyPurposeId.GetKeyPurposeClientAuth: IDerObjectIdentifier;
+class function TKeyPurposeId.GetIdKpPkinitClientAuth: IDerObjectIdentifier;
 begin
-  Result := FKeyPurposeClientAuth;
+  Result := FIdKpPkinitClientAuth;
 end;
 
-class function TKeyPurposeId.GetKeyPurposeKdc: IDerObjectIdentifier;
+class function TKeyPurposeId.GetIdKpPkinitKdc: IDerObjectIdentifier;
 begin
-  Result := FKeyPurposeKdc;
+  Result := FIdKpPkinitKdc;
 end;
 
 class function TKeyPurposeId.GetIdKpNsSgc: IDerObjectIdentifier;

--- a/CryptoLib/src/Asn1/X509/ClpX509ObjectIdentifiers.pas
+++ b/CryptoLib/src/Asn1/X509/ClpX509ObjectIdentifiers.pas
@@ -57,11 +57,14 @@ type
     FIdRsassaPssShake256: IDerObjectIdentifier;
     FIdEcdsaWithShake128: IDerObjectIdentifier;
     FIdEcdsaWithShake256: IDerObjectIdentifier;
+    FIdAlgNoSignature: IDerObjectIdentifier;
+    FIdAlgUnsigned: IDerObjectIdentifier;
     FIdPda: IDerObjectIdentifier;
     FIdAD: IDerObjectIdentifier;
     FIdADOcsp: IDerObjectIdentifier;
     FIdADCAIssuers: IDerObjectIdentifier;
     FIdCe: IDerObjectIdentifier;
+    FIdCt: IDerObjectIdentifier;
     FIdPeRelatedCert: IDerObjectIdentifier;
 
     class function GetAttributeType: IDerObjectIdentifier; static; inline;
@@ -85,11 +88,14 @@ type
     class function GetIdRsassaPssShake256: IDerObjectIdentifier; static; inline;
     class function GetIdEcdsaWithShake128: IDerObjectIdentifier; static; inline;
     class function GetIdEcdsaWithShake256: IDerObjectIdentifier; static; inline;
+    class function GetIdAlgNoSignature: IDerObjectIdentifier; static; inline;
+    class function GetIdAlgUnsigned: IDerObjectIdentifier; static; inline;
     class function GetIdPda: IDerObjectIdentifier; static; inline;
     class function GetIdAD: IDerObjectIdentifier; static; inline;
     class function GetIdADOcsp: IDerObjectIdentifier; static; inline;
     class function GetIdADCAIssuers: IDerObjectIdentifier; static; inline;
     class function GetIdCe: IDerObjectIdentifier; static; inline;
+    class function GetIdCt: IDerObjectIdentifier; static; inline;
     class function GetIdPeRelatedCert: IDerObjectIdentifier; static; inline;
     class constructor Create();
 
@@ -122,6 +128,10 @@ type
     class property IdRsassaPssShake256: IDerObjectIdentifier read GetIdRsassaPssShake256;
     class property IdEcdsaWithShake128: IDerObjectIdentifier read GetIdEcdsaWithShake128;
     class property IdEcdsaWithShake256: IDerObjectIdentifier read GetIdEcdsaWithShake256;
+    /// <summary>id-alg-noSignature: 1.3.6.1.5.5.7.6.2</summary>
+    class property IdAlgNoSignature: IDerObjectIdentifier read GetIdAlgNoSignature;
+    /// <summary>id-alg-unsigned: 1.3.6.1.5.5.7.6.36</summary>
+    class property IdAlgUnsigned: IDerObjectIdentifier read GetIdAlgUnsigned;
     class property IdPda: IDerObjectIdentifier read GetIdPda;
 
     // Authority Information Access
@@ -133,6 +143,10 @@ type
 
     // Certificate Extensions
     class property IdCe: IDerObjectIdentifier read GetIdCe;
+    /// <summary>
+    /// Google's Certificate Transparency arc (parent of the RFC 6962 OIDs): 1.3.6.1.4.1.11129.2.4.
+    /// </summary>
+    class property IdCt: IDerObjectIdentifier read GetIdCt;
 
     /// <summary>
     /// RFC 9763 sec. 3 id-pe-relatedCert ({ id-pe 36 }): RelatedCertificate certificate extension for hybrid PQ migration.
@@ -182,6 +196,8 @@ begin
   FIdRsassaPssShake256 := FPkixAlgorithms.Branch('31');
   FIdEcdsaWithShake128 := FPkixAlgorithms.Branch('32');
   FIdEcdsaWithShake256 := FPkixAlgorithms.Branch('33');
+  FIdAlgNoSignature := FPkixAlgorithms.Branch('2');
+  FIdAlgUnsigned := FPkixAlgorithms.Branch('36');
   FIdPda := FIdPkix.Branch('9');
 
   // Authority Information Access
@@ -191,6 +207,7 @@ begin
 
   // Certificate Extensions: 2.5.29
   FIdCe := TDerObjectIdentifier.Create('2.5.29');
+  FIdCt := TDerObjectIdentifier.Create('1.3.6.1.4.1.11129.2.4');
 end;
 
 class function TX509ObjectIdentifiers.GetAttributeType: IDerObjectIdentifier;
@@ -298,6 +315,16 @@ begin
   Result := FIdEcdsaWithShake256;
 end;
 
+class function TX509ObjectIdentifiers.GetIdAlgNoSignature: IDerObjectIdentifier;
+begin
+  Result := FIdAlgNoSignature;
+end;
+
+class function TX509ObjectIdentifiers.GetIdAlgUnsigned: IDerObjectIdentifier;
+begin
+  Result := FIdAlgUnsigned;
+end;
+
 class function TX509ObjectIdentifiers.GetIdPda: IDerObjectIdentifier;
 begin
   Result := FIdPda;
@@ -321,6 +348,11 @@ end;
 class function TX509ObjectIdentifiers.GetIdCe: IDerObjectIdentifier;
 begin
   Result := FIdCe;
+end;
+
+class function TX509ObjectIdentifiers.GetIdCt: IDerObjectIdentifier;
+begin
+  Result := FIdCt;
 end;
 
 class function TX509ObjectIdentifiers.GetIdPeRelatedCert: IDerObjectIdentifier;

--- a/CryptoLib/src/IO/ClpStreamUtilities.pas
+++ b/CryptoLib/src/IO/ClpStreamUtilities.pas
@@ -32,6 +32,8 @@ resourcestring
   SOffsetOutOfRange = 'offset out of range';
   SCountOutOfRange = 'count out of range';
   SOutputBufferTooSmall = 'output buffer too small';
+  SStreamCannotBeNil = 'stream cannot be nil';
+  SExactLengthNegative = 'exact length cannot be negative';
 
 type
   /// <summary>
@@ -72,6 +74,15 @@ type
       const ABuf: TCryptoLibByteArray; AOff, ALen: Int32): Int32; overload; static;
     class function ReadFully(const AInStr: TStream;
       const ABuf: TCryptoLibByteArray): Int32; overload; static;
+
+    /// <summary>
+    /// Read exactly AExactLength bytes from AStream into a freshly allocated array. The array is grown
+    /// incrementally as data arrives rather than allocated at the full length up front, so a hostile
+    /// stream claiming a large length cannot force an outsized allocation before delivering the bytes.
+    /// Returns False (with ABytes = nil) if the stream ends before AExactLength bytes are read.
+    /// </summary>
+    class function TryReadExactIncremental(const AStream: TStream; AExactLength: Int32;
+      out ABytes: TCryptoLibByteArray): Boolean; static;
 
     class procedure ValidateBufferArguments(const ABuffer: TCryptoLibByteArray;
       AOffset, ACount: Int32); static;
@@ -231,6 +242,50 @@ class function TStreamUtilities.ReadFully(const AInStr: TStream;
   const ABuf: TCryptoLibByteArray): Int32;
 begin
   Result := ReadFully(AInStr, ABuf, 0, System.Length(ABuf));
+end;
+
+class function TStreamUtilities.TryReadExactIncremental(const AStream: TStream;
+  AExactLength: Int32; out ABytes: TCryptoLibByteArray): Boolean;
+var
+  LBuf: TCryptoLibByteArray;
+  LInitialAlloc, LTotalRead, LExpandedAlloc, LNumRead: Int32;
+begin
+  if AStream = nil then
+    raise EArgumentNilCryptoLibException.CreateRes(@SStreamCannotBeNil);
+  if AExactLength < 0 then
+    raise EArgumentOutOfRangeCryptoLibException.CreateRes(@SExactLengthNegative);
+
+  // start small and grow toward AExactLength so a claimed-but-undelivered length never over-allocates
+  LInitialAlloc := AExactLength;
+  while LInitialAlloc > DefaultBufferSize do
+    LInitialAlloc := Int32((UInt32(LInitialAlloc) + 3) shr 2);
+
+  System.SetLength(LBuf, LInitialAlloc);
+  LTotalRead := 0;
+  while LTotalRead < AExactLength do
+  begin
+    if LTotalRead = System.Length(LBuf) then
+    begin
+      if Int64(4) * System.Length(LBuf) < AExactLength then
+        LExpandedAlloc := 4 * System.Length(LBuf)
+      else
+        LExpandedAlloc := AExactLength;
+      System.SetLength(LBuf, LExpandedAlloc);
+    end;
+
+    LNumRead := AStream.Read(LBuf[LTotalRead], System.Length(LBuf) - LTotalRead);
+    if LNumRead < 1 then
+    begin
+      ABytes := nil;
+      Result := False;
+      Exit;
+    end;
+
+    LTotalRead := LTotalRead + LNumRead;
+  end;
+
+  ABytes := LBuf;
+  Result := True;
 end;
 
 class procedure TStreamUtilities.ValidateBufferArguments(const ABuffer

--- a/CryptoLib/src/Interfaces/X509/ClpIX509Generators.pas
+++ b/CryptoLib/src/Interfaces/X509/ClpIX509Generators.pas
@@ -62,6 +62,8 @@ type
     /// <summary>Set the public key that this certificate identifies.</summary>
     procedure SetPublicKey(const APublicKey: IAsymmetricKeyParameter);
     function Generate(const ASignatureFactory: ISignatureFactory): IX509Certificate;
+    /// <summary>Generate an unsigned certificate carrying an empty signature under id-alg-unsigned.</summary>
+    function GenerateUnsigned(): IX509Certificate;
     function GetSignatureAlgNames: TCryptoLibStringArray;
   end;
 
@@ -128,6 +130,8 @@ type
     function Generate(const ASignatureFactory: ISignatureFactory): IX509Certificate; overload;
     function Generate(const ASignatureFactory: ISignatureFactory; AIsCritical: Boolean;
       const AAltSignatureFactory: ISignatureFactory): IX509Certificate; overload;
+    /// <summary>Generate an unsigned certificate carrying an empty signature under id-alg-unsigned.</summary>
+    function GenerateUnsigned(): IX509Certificate;
     function GetSignatureAlgNames: TCryptoLibStringArray;
   end;
 

--- a/CryptoLib/src/Interfaces/X509/Store/ClpIX509StoreSelectors.pas
+++ b/CryptoLib/src/Interfaces/X509/Store/ClpIX509StoreSelectors.pas
@@ -35,6 +35,34 @@ uses
   ClpCryptoLibTypes;
 
 type
+  /// <summary>Exposes the specific certificate a selector was built to match.</summary>
+  ISpecificCertificate = interface(IInterface)
+    ['{2F9C6A11-4D7E-4B92-8C05-1A6E3B70D941}']
+    function GetCertificate: IX509Certificate;
+    property Certificate: IX509Certificate read GetCertificate;
+  end;
+
+  /// <summary>Exposes the specific attribute certificate a selector was built to match.</summary>
+  ISpecificAttributeCert = interface(IInterface)
+    ['{3A0D7B22-5E8F-4CA3-9D16-2B7F4C81EA52}']
+    function GetAttributeCert: IX509V2AttributeCertificate;
+    property AttributeCert: IX509V2AttributeCertificate read GetAttributeCert;
+  end;
+
+  /// <summary>Exposes the certificate whose CRLs a selector is locating.</summary>
+  ICheckingCertificate = interface(IInterface)
+    ['{4B1E8C33-6F90-4DB4-AE27-3C801D92FB63}']
+    function GetCertificateChecking: IX509Certificate;
+    property CertificateChecking: IX509Certificate read GetCertificateChecking;
+  end;
+
+  /// <summary>Exposes the attribute certificate whose CRLs a selector is locating.</summary>
+  ICheckingAttrCert = interface(IInterface)
+    ['{5C2F9D44-7001-4EC5-BF38-4D912EA30C74}']
+    function GetAttrCertChecking: IX509V2AttributeCertificate;
+    property AttrCertChecking: IX509V2AttributeCertificate read GetAttrCertChecking;
+  end;
+
   /// <summary>
   /// Selects X.509 certificates from configurable criteria. An unset criterion matches anything.
   /// </summary>

--- a/CryptoLib/src/Misc/ClpCryptoLibConfig.pas
+++ b/CryptoLib/src/Misc/ClpCryptoLibConfig.pas
@@ -26,6 +26,7 @@ uses
 
 resourcestring
   SMaxPolicyNodesNotPositive = 'the valid policy tree node ceiling must be greater than zero, got %d';
+  SMaxCertPathBuildNodesNotPositive = 'the CertPath build node ceiling must be greater than zero, got %d';
   SConfigCeilingNotPositive = 'the %s must be greater than zero, got %d';
   SConfigValueNegative = 'the %s must not be negative, got %d';
 
@@ -104,12 +105,21 @@ type
     /// </summary>
     DefaultMaxPolicyNodes = Int32(8192);
 
+    /// <summary>
+    /// The ceiling on nodes the PKIX CertPath builder visits per build. The builder walks the PKI
+    /// graph depth-first; because candidate issuers are matched by subject name only, a store full of
+    /// like-named certificates that never chain to a trust anchor could otherwise be explored as a
+    /// very large number of partial paths. Read it through <see cref="MaxCertPathBuildNodes" />.
+    /// </summary>
+    DefaultMaxCertPathBuildNodes = Int32(262144);
+
   class var
     /// <summary>
     /// Nullable rather than sentinel-encoded, so no legal value has to double as "unset". The
     /// Boolean settings need no such treatment: unset and False are indistinguishable to a caller.
     /// </summary>
     FMaxPolicyNodes: TNullable<Int32>;
+    FMaxCertPathBuildNodes: TNullable<Int32>;
     FSgp22NameConstraints: Boolean;
     FAllowLenientRfc822Name: Boolean;
     FAllowLenientIPAddressMask: Boolean;
@@ -118,6 +128,8 @@ type
 
     class function GetMaxPolicyNodes: Int32; static;
     class procedure SetMaxPolicyNodes(AValue: Int32); static;
+    class function GetMaxCertPathBuildNodes: Int32; static;
+    class procedure SetMaxCertPathBuildNodes(AValue: Int32); static;
     class function GetSgp22NameConstraints: Boolean; static;
     class procedure SetSgp22NameConstraints(AValue: Boolean); static;
     class function GetAllowLenientRfc822Name: Boolean; static;
@@ -138,6 +150,12 @@ type
     /// <see cref="ResetToDefaults" /> to go back to the default.
     /// </summary>
     class property MaxPolicyNodes: Int32 read GetMaxPolicyNodes write SetMaxPolicyNodes;
+
+    /// <summary>
+    /// The ceiling on nodes the PKIX CertPath builder visits per build. Assigning less than one
+    /// raises; call <see cref="ResetToDefaults" /> to go back to the default.
+    /// </summary>
+    class property MaxCertPathBuildNodes: Int32 read GetMaxCertPathBuildNodes write SetMaxCertPathBuildNodes;
 
     /// <summary>
     /// Applies the relaxed directoryName matching that eUICC certificate profiles expect, in place
@@ -530,6 +548,7 @@ end;
 class procedure TX509Config.ResetToDefaults();
 begin
   FMaxPolicyNodes := TNullable<Int32>.None;
+  FMaxCertPathBuildNodes := TNullable<Int32>.None;
   FSgp22NameConstraints := False;
   FAllowLenientRfc822Name := False;
   FAllowLenientIPAddressMask := False;
@@ -552,6 +571,22 @@ begin
     raise EArgumentCryptoLibException.CreateResFmt(@SMaxPolicyNodesNotPositive, [AValue]);
 
   FMaxPolicyNodes := TNullable<Int32>.Some(AValue);
+end;
+
+class function TX509Config.GetMaxCertPathBuildNodes: Int32;
+begin
+  if FMaxCertPathBuildNodes.HasValue then
+    Result := FMaxCertPathBuildNodes.Value
+  else
+    Result := DefaultMaxCertPathBuildNodes;
+end;
+
+class procedure TX509Config.SetMaxCertPathBuildNodes(AValue: Int32);
+begin
+  if AValue < 1 then
+    raise EArgumentCryptoLibException.CreateResFmt(@SMaxCertPathBuildNodesNotPositive, [AValue]);
+
+  FMaxCertPathBuildNodes := TNullable<Int32>.Some(AValue);
 end;
 
 class function TX509Config.GetSgp22NameConstraints: Boolean;

--- a/CryptoLib/src/Pkix/ClpPkixCertPathBuilder.pas
+++ b/CryptoLib/src/Pkix/ClpPkixCertPathBuilder.pas
@@ -23,21 +23,19 @@ interface
 uses
   SysUtils,
   Generics.Collections,
-  ClpIStore,
   ClpIX509Certificate,
-  ClpX509Comparers,
-  ClpCryptoLibHashSet,
   ClpIPkixTypes,
   ClpPkixCertPath,
   ClpPkixCertPathValidator,
   ClpPkixCertPathValidatorResult,
   ClpPkixCertPathValidatorUtilities,
+  ClpCryptoLibConfig,
   ClpCryptoLibTypes,
   ClpCryptoLibExceptions;
 
 resourcestring
-  STargetCertSearchFailed = 'error finding target certificate: %s';
-  SNoTargetCertFound = 'no certificate found matching the target constraints';
+  SNodeBudgetExceeded = 'certification path build exceeded the node limit set by ' +
+    'TCryptoLibConfig.X509.MaxCertPathBuildNodes';
   SCertPathNotFound = 'unable to find certificate chain';
   SCertPathConstructionFailed = 'certification path could not be constructed from the certificate ' +
     'list: %s';
@@ -63,6 +61,9 @@ type
     FIsForCrlCheck: Boolean;
     /// <summary>The failure of the most recently tried chain, carried across the recursion.</summary>
     FCertPathException: String;
+    /// <summary>Per-build node-visit budget (from config) and running count, bounding the DFS.</summary>
+    FMaxNodes: Int32;
+    FNodesVisited: Int32;
 
     class function ContainsCert(const ACerts: TList<IX509Certificate>;
       const ACert: IX509Certificate): Boolean; overload; static;
@@ -86,6 +87,10 @@ type
   end;
 
 implementation
+
+type
+  /// <summary>Raised internally to abort a build once the node-visit budget is exhausted.</summary>
+  ENodeBudgetExceededCryptoLibException = class(ECryptoLibException);
 
 { TPkixCertPathBuilder }
 
@@ -170,6 +175,13 @@ var
 begin
   Result := nil;
 
+  // Bound the depth-first search: candidate issuers are matched by subject name only, so a store full
+  // of like-named certificates that never chain to a trust anchor could otherwise be explored as a very
+  // large number of partial paths (see TCryptoLibConfig.X509.MaxCertPathBuildNodes).
+  System.Inc(FNodesVisited);
+  if FNodesVisited > FMaxNodes then
+    raise ENodeBudgetExceededCryptoLibException.CreateRes(@SNodeBudgetExceeded);
+
   // the certificate is already on the path, so following it would cycle in the PKI graph
   if ContainsCert(ATbvPath, ATbvCert) then
     Exit;
@@ -234,6 +246,9 @@ begin
         Break;
     end;
   except
+    on E: ENodeBudgetExceededCryptoLibException do
+      // the whole build is over-budget; let it unwind to Build rather than trying more chains
+      raise;
     on E: Exception do
     begin
       // remembered for the caller; other candidate chains may still succeed
@@ -248,49 +263,34 @@ end;
 
 function TPkixCertPathBuilder.Build(const AParams: IPkixBuilderParameters): IPkixCertPathBuilderResult;
 var
-  LSelector: ISelector<IX509Certificate>;
-  LStores: TCryptoLibGenericArray<IStore<IX509Certificate>>;
-  LTargets: TCryptoLibHashSet<IX509Certificate>;
+  LTargets: TCryptoLibGenericArray<IX509Certificate>;
   LPath: TList<IX509Certificate>;
-  LCert: IX509Certificate;
   LIdx: Int32;
 begin
   Result := nil;
   FCertPathException := '';
+  FMaxNodes := TCryptoLibConfig.X509.MaxCertPathBuildNodes;
+  FNodesVisited := 0;
 
-  // search the target certificates
-  LSelector := AParams.GetTargetConstraintsCert();
-
-  LTargets := TCryptoLibHashSet<IX509Certificate>.Create(TX509Comparers.CertificateEqualityComparer);
+  LPath := TList<IX509Certificate>.Create();
   try
     try
-      LStores := AParams.GetStoresCert();
-      for LIdx := 0 to System.High(LStores) do
-      begin
-        LTargets.AddRange(LStores[LIdx].EnumerateMatches(LSelector));
-      end;
-    except
-      on E: Exception do
-        raise EPkixCertPathBuilderCryptoLibException.CreateResFmt(@STargetCertSearchFailed, [E.Message]);
-    end;
+      // the target certificates: store matches, or one named directly on the selector
+      LTargets := TPkixCertPathValidatorUtilities.FindTargets(AParams);
 
-    if LTargets.Count < 1 then
-      raise EPkixCertPathBuilderCryptoLibException.CreateRes(@SNoTargetCertFound);
-
-    LPath := TList<IX509Certificate>.Create();
-    try
       // check all potential target certificates
-      for LCert in LTargets do
+      for LIdx := 0 to System.High(LTargets) do
       begin
-        Result := BuildPath(LCert, AParams, LPath);
+        Result := BuildPath(LTargets[LIdx], AParams, LPath);
         if Result <> nil then
           Break;
       end;
-    finally
-      LPath.Free;
+    except
+      on E: ENodeBudgetExceededCryptoLibException do
+        raise EPkixCertPathBuilderCryptoLibException.Create(E.Message);
     end;
   finally
-    LTargets.Free;
+    LPath.Free;
   end;
 
   if Result <> nil then

--- a/CryptoLib/src/Pkix/ClpPkixCertPathValidatorUtilities.pas
+++ b/CryptoLib/src/Pkix/ClpPkixCertPathValidatorUtilities.pas
@@ -63,6 +63,8 @@ resourcestring
   SDistributionPointIssuerFailed = 'could not get issuer information from distribution point: %s';
   SNoCrlsFound = 'no CRLs found for issuer "%s"';
   SIssuerCertSearchFailed = 'issuer certificate cannot be searched: %s';
+  STargetCertSearchFailed = 'error finding target certificate: %s';
+  SNoTargetCertFound = 'no certificate found matching the target constraints';
   SCrlUnsupportedCriticalExtensions = 'CRL has unsupported critical extensions';
   SCrlEntryUnsupportedCriticalExtensions = 'CRL entry has unsupported critical extensions';
 
@@ -209,6 +211,13 @@ type
     /// <summary>Candidate issuer certificates of ACert.</summary>
     class function FindIssuerCerts(const ACert: IX509Certificate;
       const APkixBuilderParameters: IPkixBuilderParameters): TCryptoLibGenericArray<IX509Certificate>; static;
+
+    /// <summary>
+    /// Candidate target certificates for a path build: the store matches of the target constraints,
+    /// or, when the stores hold none, the certificate named directly on the selector (ISpecificCertificate).
+    /// </summary>
+    class function FindTargets(const APkixBuilderParameters: IPkixBuilderParameters)
+      : TCryptoLibGenericArray<IX509Certificate>; static;
 
     /// <summary>Only the CRL extensions this library understands may be critical.</summary>
     class procedure CheckCrlCriticalExtensions(const ACrl: IX509Crl); static;
@@ -998,6 +1007,66 @@ begin
         System.Inc(LCount);
       end;
     end;
+  end;
+end;
+
+class function TPkixCertPathValidatorUtilities.FindTargets(
+  const APkixBuilderParameters: IPkixBuilderParameters): TCryptoLibGenericArray<IX509Certificate>;
+var
+  LSelector: ISelector<IX509Certificate>;
+  LStores: TCryptoLibGenericArray<IStore<IX509Certificate>>;
+  LMatches: TCryptoLibGenericArray<IX509Certificate>;
+  LOuter, LInner, LSeek, LCount: Int32;
+  LSeen: Boolean;
+  LSpecific: ISpecificCertificate;
+  LTarget: IX509Certificate;
+begin
+  LSelector := APkixBuilderParameters.GetTargetConstraintsCert();
+
+  Result := nil;
+  LCount := 0;
+
+  LStores := APkixBuilderParameters.GetStoresCert();
+  for LOuter := 0 to System.High(LStores) do
+  begin
+    try
+      LMatches := LStores[LOuter].EnumerateMatches(LSelector);
+    except
+      on E: Exception do
+        raise EPkixCertPathBuilderCryptoLibException.CreateResFmt(@STargetCertSearchFailed, [E.Message]);
+    end;
+
+    for LInner := 0 to System.High(LMatches) do
+    begin
+      LSeen := False;
+      for LSeek := 0 to LCount - 1 do
+      begin
+        if Result[LSeek].Equals(LMatches[LInner]) then
+        begin
+          LSeen := True;
+          Break;
+        end;
+      end;
+      if not LSeen then
+      begin
+        System.SetLength(Result, LCount + 1);
+        Result[LCount] := LMatches[LInner];
+        System.Inc(LCount);
+      end;
+    end;
+  end;
+
+  if LCount < 1 then
+  begin
+    // no store match: allow the target to be specified directly on the selector
+    LTarget := nil;
+    if Supports(LSelector, ISpecificCertificate, LSpecific) then
+      LTarget := LSpecific.Certificate;
+
+    if LTarget = nil then
+      raise EPkixCertPathBuilderCryptoLibException.CreateRes(@SNoTargetCertFound);
+
+    Result := TCryptoLibGenericArray<IX509Certificate>.Create(LTarget);
   end;
 end;
 

--- a/CryptoLib/src/X509/ClpX509Generators.pas
+++ b/CryptoLib/src/X509/ClpX509Generators.pas
@@ -26,6 +26,7 @@ uses
   ClpIAsn1Objects,
   ClpIX509Asn1Objects,
   ClpX509Asn1Objects,
+  ClpX509ObjectIdentifiers,
   ClpIAsn1Core,
   ClpIX509Certificate,
   ClpX509Certificate,
@@ -80,6 +81,7 @@ type
     procedure SetSubjectDN(const ASubject: IX509Name);
     procedure SetPublicKey(const APublicKey: IAsymmetricKeyParameter);
     function Generate(const ASignatureFactory: ISignatureFactory): IX509Certificate;
+    function GenerateUnsigned(): IX509Certificate;
     function GetSignatureAlgNames: TCryptoLibStringArray;
   end;
 
@@ -156,6 +158,7 @@ type
     function Generate(const ASignatureFactory: ISignatureFactory): IX509Certificate; overload;
     function Generate(const ASignatureFactory: ISignatureFactory; AIsCritical: Boolean;
       const AAltSignatureFactory: ISignatureFactory): IX509Certificate; overload;
+    function GenerateUnsigned(): IX509Certificate;
     function GetSignatureAlgNames: TCryptoLibStringArray;
   end;
 
@@ -316,6 +319,22 @@ begin
   FTbsGen.SetSignature(LSigAlgID);
   LTbs := FTbsGen.GenerateTbsCertificate;
   LSignature := TX509Utilities.GenerateSignature(ASignatureFactory, LTbs);
+  LStruct := TX509CertificateStructure.Create(LTbs, LSigAlgID, LSignature);
+  Result := TX509Certificate.Create(LStruct);
+end;
+
+function TX509V1CertificateGenerator.GenerateUnsigned(): IX509Certificate;
+var
+  LSigAlgID: IAlgorithmIdentifier;
+  LTbs: ITbsCertificateStructure;
+  LSignature: IDerBitString;
+  LStruct: IX509CertificateStructure;
+  LEmpty: TCryptoLibByteArray;
+begin
+  LSigAlgID := TAlgorithmIdentifier.Create(TX509ObjectIdentifiers.IdAlgUnsigned);
+  FTbsGen.SetSignature(LSigAlgID);
+  LTbs := FTbsGen.GenerateTbsCertificate;
+  LSignature := TDerBitString.Create(LEmpty);
   LStruct := TX509CertificateStructure.Create(LTbs, LSigAlgID, LSignature);
   Result := TX509Certificate.Create(LStruct);
 end;
@@ -550,6 +569,41 @@ begin
 
   LTbs := FTbsGen.GenerateTbsCertificate;
   LSignature := TX509Utilities.GenerateSignature(ASignatureFactory, LTbs);
+  LStruct := TX509CertificateStructure.Create(LTbs, LSigAlgID, LSignature);
+  Result := TX509Certificate.Create(LStruct);
+end;
+
+function TX509V3CertificateGenerator.GenerateUnsigned(): IX509Certificate;
+var
+  LSigAlgID: IAlgorithmIdentifier;
+  LDeltaExt: IX509Extension;
+  LDescriptor: IDeltaCertificateDescriptor;
+  LTbs: ITbsCertificateStructure;
+  LSignature: IDerBitString;
+  LStruct: IX509CertificateStructure;
+  LEmpty: TCryptoLibByteArray;
+begin
+  LSigAlgID := TAlgorithmIdentifier.Create(TX509ObjectIdentifiers.IdAlgUnsigned);
+  FTbsGen.SetSignature(LSigAlgID);
+
+  if not FExtGenerator.IsEmpty then
+  begin
+    LDeltaExt := FExtGenerator.GetExtension(TX509Extensions.DraftDeltaCertificateDescriptor);
+    if LDeltaExt <> nil then
+    begin
+      LDescriptor := TDeltaCertificateTool.TrimDeltaCertificateDescriptor(
+        TDeltaCertificateDescriptor.GetInstance(LDeltaExt.GetParsedValue),
+        FTbsGen.GenerateTbsCertificate,
+        FExtGenerator.Generate);
+      FExtGenerator.ReplaceExtension(TX509Extensions.DraftDeltaCertificateDescriptor,
+        LDeltaExt.IsCritical, LDescriptor);
+    end;
+
+    FTbsGen.SetExtensions(FExtGenerator.Generate);
+  end;
+
+  LTbs := FTbsGen.GenerateTbsCertificate;
+  LSignature := TDerBitString.Create(LEmpty);
   LStruct := TX509CertificateStructure.Create(LTbs, LSigAlgID, LSignature);
   Result := TX509Certificate.Create(LStruct);
 end;

--- a/CryptoLib/src/X509/Store/ClpX509StoreSelectors.pas
+++ b/CryptoLib/src/X509/Store/ClpX509StoreSelectors.pas
@@ -50,7 +50,8 @@ type
   /// <summary>
   /// Selects X.509 certificates from configurable criteria. An unset criterion matches anything.
   /// </summary>
-  TX509CertStoreSelector = class(TInterfacedObject, ISelector<IX509Certificate>, IX509CertStoreSelector)
+  TX509CertStoreSelector = class(TInterfacedObject, ISelector<IX509Certificate>, IX509CertStoreSelector,
+    ISpecificCertificate)
 
   strict private
   var
@@ -143,7 +144,8 @@ type
   /// <summary>
   /// Selects X.509 CRLs from configurable criteria. An unset criterion matches anything.
   /// </summary>
-  TX509CrlStoreSelector = class(TInterfacedObject, ISelector<IX509Crl>, IX509CrlStoreSelector)
+  TX509CrlStoreSelector = class(TInterfacedObject, ISelector<IX509Crl>, IX509CrlStoreSelector,
+    ICheckingCertificate, ICheckingAttrCert)
 
   strict private
   var
@@ -205,7 +207,7 @@ type
   /// Selects X.509 attribute certificates from configurable criteria (RFC 3281).
   /// </summary>
   TX509AttrCertStoreSelector = class(TInterfacedObject, ISelector<IX509V2AttributeCertificate>,
-    IX509AttrCertStoreSelector)
+    IX509AttrCertStoreSelector, ISpecificAttributeCert)
 
   strict private
   var


### PR DESCRIPTION
Streams / ASN.1
- Add TStreamUtilities.TryReadExactIncremental, which reads an exact number of bytes while growing the buffer incrementally rather than allocating the full claimed length up front. TDefiniteLengthInputStream.ToArray now reads through itself using it, so a stream claiming a large length cannot force an outsized allocation before delivering the data.

Key purpose IDs
- Add id-kp secureShellClient/secureShellServer (RFC 6187), cmcArchive, bundleSecurity (RFC 9174) and jwt/httpContentEncrypt/oauthAccessTokenSigning (RFC 9509) to TKeyPurposeId, and add kerberosv5 / id-pkinit to the IANA identifiers. Rename the Kerberos PKINIT purposes KeyPurposeClientAuth and KeyPurposeKdc to IdKpPkinitClientAuth and IdKpPkinitKdc (breaking), sourcing the id-pkinit arc from the IANA identifiers.

Store selectors
- Add ISpecificCertificate, ISpecificAttributeCert, ICheckingCertificate and ICheckingAttrCert marker interfaces exposing a selector's specific target, and have the certificate, attribute-certificate and CRL selectors implement them.

Unsigned certificates
- Add id-alg-noSignature, id-alg-unsigned and the Certificate Transparency arc (id-ct) to X509ObjectIdentifiers, and add GenerateUnsigned to the V1 and V3 certificate generators, producing an empty signature under id-alg-unsigned.

CertPath builder
- Extract target discovery into PkixCertPathValidatorUtilities.FindTargets, which now also accepts a target certificate named directly on the selector (ISpecificCertificate) when the stores hold no match.
- Bound the depth-first search by a per-build node budget, configurable through TCryptoLibConfig.X509.MaxCertPathBuildNodes (default 262144), so a store of like-named certificates that never chain to a trust anchor cannot be explored as an unbounded number of partial paths.

Tests
- Add CertPathBuilderTests covering unsigned V1/V3 generation, target selection via the store and via the selector, building under an unsigned trust anchor, and the node-budget guard; extend KeyPurposeIDTests with the new purposes.